### PR TITLE
Make the Shelf panel movable

### DIFF
--- a/Sources/Sarvkrit/UI/Shelf/ShelfPanel.swift
+++ b/Sources/Sarvkrit/UI/Shelf/ShelfPanel.swift
@@ -51,11 +51,21 @@ final class ShelfController: NSObject {
             }
         )
 
-        let anchor = point ?? NSEvent.mouseLocation
-        if let screen = ScreenPlacement.screenUnderPointer() {
-            panel.setFrameTopLeftPoint(ScreenPlacement.topLeft(
-                forSize: Self.size, at: anchor, in: screen.visibleFrame
-            ))
+        // Placed only when it is actually being opened. `show()` is reached from five places — the
+        // menu bar, ⌃⌥S, drag-start auto-open, the edge strip's `draggingEntered` and `toggle()` —
+        // and the edge strip can fire repeatedly as one drag re-crosses it. Unguarded, a panel the
+        // user had dragged somewhere useful teleported back under the pointer on the next drag,
+        // which made moving it pointless even once it became possible.
+        //
+        // A fresh open still returns to the default position; only an already-visible panel is left
+        // where it was put.
+        if !panel.isVisible {
+            let anchor = point ?? NSEvent.mouseLocation
+            if let screen = ScreenPlacement.screenUnderPointer() {
+                panel.setFrameTopLeftPoint(ScreenPlacement.topLeft(
+                    forSize: Self.size, at: anchor, in: screen.visibleFrame
+                ))
+            }
         }
         panel.makeKeyAndOrderFront(nil)
     }

--- a/Sources/Sarvkrit/UI/Shelf/ShelfView.swift
+++ b/Sources/Sarvkrit/UI/Shelf/ShelfView.swift
@@ -49,11 +49,17 @@ struct ShelfView: View {
 
     private var header: some View {
         HStack(spacing: Theme.Space.sm) {
+            // The icon and title are decoration, and are explicitly not hit-testable: left
+            // interactive they would swallow the mouse-down before it reached the drag handle
+            // behind the row, so the two most obvious places to grab the window — its icon and its
+            // name — would be the two that didn't move it.
             Image(systemName: "tray.full")
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(Color.accentColor)
+                .allowsHitTesting(false)
             Text("Shelf")
                 .font(.system(size: 13, weight: .semibold))
+                .allowsHitTesting(false)
             Spacer()
             if !store.items.isEmpty {
                 Button("Clear") { store.clear() }
@@ -73,6 +79,11 @@ struct ShelfView: View {
         }
         .padding(.horizontal, Theme.Space.md)
         .frame(height: 34)
+        // The header is the panel's title bar, and now behaves like one. `WindowDragHandle` sits
+        // *behind* the row, so the Clear and close buttons keep taking their own clicks while the
+        // icon, the title and the gap between them drag the whole window. The panel is borderless,
+        // so without this there is no way to move it at all.
+        .background(WindowDragHandle())
     }
 
     @ViewBuilder

--- a/Sources/Sarvkrit/UI/Shelf/WindowDragHandle.swift
+++ b/Sources/Sarvkrit/UI/Shelf/WindowDragHandle.swift
@@ -1,0 +1,59 @@
+import AppKit
+import SwiftUI
+
+/// Makes the region it backs drag the whole window, the way a title bar does.
+///
+/// The shelf panel is `.borderless`, so it has no title bar — and a title bar is the only surface
+/// AppKit moves a window by on its own. Without this the panel cannot be moved at all: it lands
+/// wherever the pointer was when a drag opened it, and if that covers the folder you were aiming
+/// for, there is nothing you can do about it.
+///
+/// **Why not `isMovableByWindowBackground`, which is one line?** Two reasons, both specific to this
+/// panel rather than general caution:
+///
+/// 1. **It would steal drags from the tiles.** `ShelfDragSource` covers only each tile's preview
+///    image, so filenames, subtitles and the padding between tiles are *not* drag sources. Making
+///    the whole background movable means grabbing a filename moves the window instead of dragging
+///    the file out — trading this bug for a worse one.
+/// 2. **It is unpredictable here.** That flag defers to the hit-tested view's
+///    `mouseDownCanMoveWindow`, whose default varies with view opacity, and the shelf's content is
+///    an `NSHostingView` over `.regularMaterial`. Whether any given point moved the window would be
+///    a property of SwiftUI's internal view tree.
+///
+/// `performDrag(with:)` is the AppKit primitive built for exactly this — borderless windows that
+/// need a custom grab region — and it makes the draggable area something we state rather than
+/// something we hope for. That matters in this file's neighbourhood: an `ignoresMouseEvents = true`
+/// once silently killed the shelf's drop callbacks, and a `DisclosureGroup` once rendered a toggle
+/// that could not be clicked. Both looked correct.
+///
+/// Put it *behind* the content it should drag — `.background(WindowDragHandle())`. SwiftUI's own
+/// controls then sit above it and take their own clicks, while the gaps between them fall through
+/// to here. That is precisely how a real title bar behaves, and it needs no hit-testing arithmetic.
+struct WindowDragHandle: NSViewRepresentable {
+
+    func makeNSView(context: Context) -> DragHandleView {
+        DragHandleView()
+    }
+
+    func updateNSView(_ view: DragHandleView, context: Context) {}
+
+    /// Transparent, and does nothing but hand the mouse-down to the window.
+    final class DragHandleView: NSView {
+
+        /// Unlike `ShelfDragSource.DragSourceView`, which swallows `mouseDown` so that
+        /// `mouseDragged` will arrive, this hands the event straight over. `performDrag` runs its
+        /// own event-tracking loop until the mouse comes up, so there is no drag threshold to
+        /// implement and no second event to wait for.
+        override func mouseDown(with event: NSEvent) {
+            window?.performDrag(with: event)
+        }
+
+        /// Keeps `mouseDown` above as the *only* way this view moves the window.
+        ///
+        /// The inherited value is true for a non-opaque view, which would let AppKit's own
+        /// background-drag machinery claim the event and never call `mouseDown` — so if anyone
+        /// later switches `isMovableByWindowBackground` on, the behaviour here would silently
+        /// change hands. Pinning it to false means one code path, always.
+        override var mouseDownCanMoveWindow: Bool { false }
+    }
+}


### PR DESCRIPTION
The shelf lands wherever the pointer was when a drag opened it, and could not be moved afterwards. If it covered the folder you were aiming for, there was nothing you could do.

Nothing was broken so much as never asked for. The panel is `.borderless`, so it has no title bar — the only surface AppKit moves a window by on its own — and `isMovableByWindowBackground` was never set. No `performDrag`, no `mouseDownCanMoveWindow` override existed anywhere in Sources.

**The header is now the title bar**, which is where anyone would grab it anyway: `WindowDragHandle` sits behind the row and hands its mouse-down to `performDrag(with:)`. Ordering does the hard part — SwiftUI's Clear and close buttons sit above the handle and keep their own clicks, while the gaps between them drag the window, exactly as a real title bar behaves and with no hit-testing arithmetic. The icon and title are marked `allowsHitTesting(false)`, or the two most obvious places to grab the window would have been the two that didn't work.

**Deliberately not `isMovableByWindowBackground`**, the one-line version. `ShelfDragSource` covers only each tile's preview image, so filenames, subtitles and the padding between tiles are not drag sources — making the whole background movable would mean grabbing a filename moves the window instead of dragging the file out, which is a worse bug than this one. It is also unpredictable: that flag defers to the hit-tested view's `mouseDownCanMoveWindow`, whose default varies with opacity, and the content here is an `NSHostingView` over `.regularMaterial`. Whether a given point moved the window would be a property of SwiftUI's internal view tree. This corner of the app has been bitten three times by an affordance that looked correct and silently did nothing — `ignoresMouseEvents = true` killing the shelf's own drop callbacks, a 17pt hit region, a `DisclosureGroup` whose toggle could not be clicked.

**And `show()` no longer yanks a moved panel back.** It recomputed the origin under the pointer on every call, unguarded, while five call sites reach it — the menu bar, ⌃⌥S, drag-start auto-open, the edge strip's `draggingEntered` and `toggle()` — and the edge strip fires again each time one drag re-crosses it. So a shelf you had moved somewhere useful teleported back to the cursor on the next drag, which would have made moving it pointless even once it became possible. Placement now happens only when the panel is actually being opened: a fresh open still returns to the default, an already-visible one stays where it was put.

717 tests passing. The behaviour itself is AppKit wiring rather than logic, so it is confirmed by hand — the failure mode here is silent, which is the whole reason for choosing the explicit handle.


Claude-Session: https://claude.ai/code/session_01CLzTNijWouSnSu3gC6wdE7