### PR TITLE
Moor the tray panel: SwiftUI never shrinks that window

### DIFF
--- a/Sources/Sarvkrit/UI/MenuBarPanelPlacement.swift
+++ b/Sources/Sarvkrit/UI/MenuBarPanelPlacement.swift
@@ -1,0 +1,79 @@
+import CoreGraphics
+
+/// Where the menu bar dropdown belongs when its content changes height.
+///
+/// A `MenuBarExtra` window is positioned by the system once, at presentation, and is not
+/// re-anchored when its content changes size — so switching to a shorter tab drags the panel away
+/// from the menu bar. Correcting that means recomputing an origin, and an origin computed against
+/// a live display is a thing you can only check by eye on the display you happen to own. Pure, for
+/// the same reason `ScreenPlacement` is: the multi-display and short-screen cases are the ones most
+/// likely to be wrong and least likely to be noticed.
+enum MenuBarPanelPlacement {
+
+    /// How far from the menu bar's bottom edge a window's top may sit and still be believed to be
+    /// the system's own placement.
+    ///
+    /// Only there to reject a frame that was never positioned at all; it can afford to be generous
+    /// because a top edge is only ever captured at presentation, never after a resize. Measured on
+    /// a 15" display the system leaves a **2pt** gap below `visibleFrame.maxY`, and with
+    /// "Automatically hide and show the menu bar" on, `visibleFrame` stops describing the menu bar
+    /// and the same placement reads ~33pt down — so anything tighter than that would reject a
+    /// perfectly good anchor in a setting nobody thinks to test.
+    static let anchorTolerance: CGFloat = 48
+
+    /// Sub-pixel differences are not worth moving a window for, as
+    /// `ClipboardPickerController.resize(to:)` also decided.
+    static let moveTolerance: CGFloat = 0.5
+
+    /// Whether `top` is close enough to `menuBarBottom` to be the system's placement.
+    ///
+    /// `menuBarBottom` is a parameter rather than derived here, and not only for purity: the
+    /// obvious candidates disagree. `NSScreen.visibleFrame.maxY` matched the system's own placement
+    /// to 2pt when measured, while `NSStatusBar.system.thickness` reported 22pt against a menu bar
+    /// actually 33pt tall — 11pt of error, and a panel visibly hanging off the bar. The caller
+    /// says which one it means.
+    static func isPlausibleAnchor(
+        top: CGFloat,
+        menuBarBottom: CGFloat,
+        tolerance: CGFloat = anchorTolerance
+    ) -> Bool {
+        abs(menuBarBottom - top) <= tolerance
+    }
+
+    /// The frame origin — AppKit's bottom-left — for a panel of `height` whose top edge belongs
+    /// at `top`.
+    ///
+    /// `x` is passed through and only clamped: the horizontal position is the system's, it is
+    /// already correct (it does not move when the panel resizes), and deriving it would mean
+    /// guessing at the status item's position — the one number that would unmoor the panel
+    /// sideways if guessed wrong.
+    static func origin(
+        forHeight height: CGFloat,
+        x: CGFloat,
+        top: CGFloat,
+        width: CGFloat,
+        in visible: CGRect
+    ) -> CGPoint {
+        var left = x
+        if left + width > visible.maxX { left = visible.maxX - width }
+        if left < visible.minX { left = visible.minX }
+
+        // Never up under the menu bar, whatever it was asked for.
+        let clampedTop = min(top, visible.maxY)
+
+        // The top is the anchored edge, and there is deliberately no lower clamp: a panel too tall
+        // for the space beneath the menu bar overflows the bottom rather than being pushed up. The
+        // alternative is worse in exactly the way this whole file exists to prevent — lifting it to
+        // fit would slide it off the icon it belongs to, and far enough would tuck its header under
+        // the menu bar. Content that tall is a content problem, answered by scrolling.
+        return CGPoint(x: left, y: clampedTop - height)
+    }
+
+    static func needsMove(
+        from current: CGPoint,
+        to desired: CGPoint,
+        tolerance: CGFloat = moveTolerance
+    ) -> Bool {
+        abs(current.x - desired.x) > tolerance || abs(current.y - desired.y) > tolerance
+    }
+}

--- a/Sources/Sarvkrit/UI/MenuBarView.swift
+++ b/Sources/Sarvkrit/UI/MenuBarView.swift
@@ -39,14 +39,23 @@ struct MenuBarView: View {
         }
         .padding(Theme.Space.md)
         .frame(width: Theme.Size.dropdownWidth)
-        // The panel's own height is deliberately NOT animated, though it does change between tabs
-        // — Keyboard is one row, Files is three.
+        // Reaches the panel's own NSWindow, which `MenuBarExtra` does not hand out. A background,
+        // so it takes the panel's size without contributing any of its own.
+        .background(
+            MenuBarWindowProbe(
+                onWindow: { MenuBarWindowAnchor.shared.attach(to: $0) },
+                onHeight: { MenuBarWindowAnchor.shared.note(contentHeight: $0) }
+            )
+        )
+        // Grow and shrink the panel rather than snapping it — Keyboard is one row, Files is three.
         //
-        // A MenuBarExtra window is positioned by the system, once, anchored under the menu bar
-        // icon. An NSWindow's origin is its bottom-left, so when the content shrinks and the panel
-        // is resized without its origin being adjusted, the top edge falls away from the menu bar.
-        // Animating the resize walks it through many intermediate heights and makes that far more
-        // likely. A panel that snaps to its new size is much better than one that comes unmoored.
+        // This used to be unsafe, and the comment here used to say so: a height change would leave
+        // the panel floating away from the menu bar, and animating walked it through many
+        // intermediate heights. The measured reason turned out to be that SwiftUI does not resize
+        // this window on a *shrink* at all — it keeps the tallest height of the presentation and
+        // centres the smaller content inside it. `MenuBarWindowAnchor` now does that resize, on
+        // every height change including each frame of an animated one.
+        .standardMotion(value: selection)
         .standardMotion(value: app.needsAccessibility)
         .onAppear {
             selection = TrayTab.resolve(storedID: app.selectedTrayTabID, available: app.trayTabs)

--- a/Sources/Sarvkrit/UI/MenuBarWindowAnchor.swift
+++ b/Sources/Sarvkrit/UI/MenuBarWindowAnchor.swift
@@ -1,0 +1,202 @@
+import AppKit
+import OSLog
+import SwiftUI
+
+/// Hands the enclosing `NSWindow` to a callback, and reports its own height as SwiftUI lays it out.
+///
+/// `MenuBarExtra` vends no window reference, so this is the only way to reach the panel's window.
+/// Installed as a `.background` of the dropdown's content: a background takes the size of what it
+/// backs without contributing any of its own, so the probe cannot perturb the layout it exists to
+/// stabilise. `hitTest` returns nil for the same reason `ShelfDragSource` does the opposite — that
+/// view wants clicks, this one must never take one out of the padding.
+struct MenuBarWindowProbe: NSViewRepresentable {
+    let onWindow: (NSWindow?) -> Void
+    let onHeight: (CGFloat) -> Void
+
+    func makeNSView(context: Context) -> ProbeView {
+        let view = ProbeView()
+        view.onWindow = onWindow
+        view.onHeight = onHeight
+        return view
+    }
+
+    func updateNSView(_ view: ProbeView, context: Context) {
+        view.onWindow = onWindow
+        view.onHeight = onHeight
+    }
+
+    final class ProbeView: NSView {
+        var onWindow: ((NSWindow?) -> Void)?
+        var onHeight: ((CGFloat) -> Void)?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            onWindow?(window)
+        }
+
+        /// The content's height, straight from SwiftUI's own layout pass — which is not necessarily
+        /// the window's height, and the difference is the thing worth knowing.
+        override func layout() {
+            super.layout()
+            onHeight?(bounds.height)
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    }
+}
+
+/// Keeps the tray panel the size of its content, with its top edge under the menu bar icon.
+///
+/// **What actually goes wrong, measured rather than assumed.** A `MenuBarExtra` window is
+/// positioned by the system once, at presentation. When the content *grows* SwiftUI handles it
+/// correctly — it drops the origin and holds the top edge exactly where the system put it. When the
+/// content *shrinks* SwiftUI does nothing at all: no `NSWindowDidResizeNotification` is posted, the
+/// window keeps the tallest height it reached during that presentation, and the smaller content is
+/// centred inside it. One instrumented tab switch, Sound → Keyboard:
+///
+///     grow    frame={{731, 628}, {420, 319}}  top=947  content=319
+///     grow    frame={{731, 522}, {420, 425}}  top=947  content=425
+///     grow    frame={{731, 438}, {420, 509}}  top=947  content=509
+///     shrink  frame={{731, 438}, {420, 509}}  top=947  content=266   ← no resize
+///     shrink  frame={{731, 438}, {420, 509}}  top=947  content=319   ← no resize
+///
+/// So the panel never came unmoored: the window's top edge was under the icon the whole time. What
+/// the user sees floating in the middle of the screen is the material drawn around 266pt of content
+/// centred in a 509pt window — which is why an earlier attempt to fix this by adjusting the origin
+/// could not have worked, and why the height has to be driven from the *content*, not from a resize
+/// notification that never arrives.
+@MainActor
+final class MenuBarWindowAnchor {
+    static let shared = MenuBarWindowAnchor()
+
+    /// Kept because this corrects a window SwiftUI owns, on undocumented behaviour that has changed
+    /// between macOS releases before. When it stops working, this line is the difference between
+    /// "the panel is broken again" and knowing which half.
+    private let log = Logger(subsystem: AppIdentity.logSubsystem, category: "TrayPanel")
+
+    /// Weak: the panel's window belongs to SwiftUI, and outliving it is not this object's business.
+    private weak var window: NSWindow?
+    private var observers: [NSObjectProtocol] = []
+
+    /// The top edge the system chose for this presentation. Captured when the panel appears and
+    /// held until it goes away — never re-read from a frame that has already been resized, because
+    /// an anchor latched from a drifted frame pins the panel to the wrong place for as long as it
+    /// stays open.
+    private var anchorTop: CGFloat?
+    /// SwiftUI's own idea of how tall the content is, straight from the probe's layout pass.
+    private var contentHeight: CGFloat = 0
+    /// Set while *we* are the ones resizing, so the `didResize` that follows can't recurse.
+    private var isAdjusting = false
+
+    private init() {}
+
+    /// Idempotent: the probe reports its window on every pass through `viewDidMoveToWindow`.
+    func attach(to window: NSWindow?) {
+        guard window !== self.window else { return }
+
+        observers.forEach(NotificationCenter.default.removeObserver)
+        observers.removeAll()
+        self.window = window
+        anchorTop = nil
+
+        guard let window else { return }
+
+        observe(NSWindow.didChangeOcclusionStateNotification, on: window) { [weak self] in
+            guard let self, let window = self.window else { return }
+            if window.occlusionState.contains(.visible) {
+                self.captureAnchor()
+                self.pin()
+            } else {
+                self.anchorTop = nil
+            }
+        }
+        // A second chance to capture, for the presentation where the occlusion notification lands
+        // before the system has finished positioning the window.
+        observe(NSWindow.didBecomeKeyNotification, on: window) { [weak self] in
+            self?.captureAnchor()
+        }
+        // Deliberately *not* a presentation-end signal: this fires while the panel is open and
+        // still on screen — toggling a switch inside it is enough — and clearing the anchor there
+        // would throw away the one number worth keeping.
+        observe(NSWindow.willCloseNotification, on: window) { [weak self] in
+            self?.anchorTop = nil
+        }
+        // Growth still arrives this way. Cheap to honour, and it keeps the two paths in agreement.
+        observe(NSWindow.didResizeNotification, on: window) { [weak self] in
+            self?.pin()
+        }
+
+        captureAnchor()
+    }
+
+    /// The content's height, reported by the probe as SwiftUI lays it out. **This is the trigger
+    /// that matters:** it is the only signal a shrink produces.
+    func note(contentHeight height: CGFloat) {
+        guard abs(height - contentHeight) > MenuBarPanelPlacement.moveTolerance else { return }
+        contentHeight = height
+        pin()
+    }
+
+    private func observe(
+        _ name: Notification.Name, on window: NSWindow, _ handler: @escaping () -> Void
+    ) {
+        observers.append(
+            NotificationCenter.default.addObserver(forName: name, object: window, queue: .main) { _ in
+                MainActor.assumeIsolated(handler)
+            }
+        )
+    }
+
+    private func captureAnchor() {
+        guard anchorTop == nil, let window, window.isVisible,
+              let visible = screen(for: window)?.visibleFrame else { return }
+
+        let top = window.frame.maxY
+        guard MenuBarPanelPlacement.isPlausibleAnchor(top: top, menuBarBottom: visible.maxY) else {
+            log.debug("anchor rejected: top=\(top, privacy: .public) visibleMaxY=\(visible.maxY, privacy: .public)")
+            return
+        }
+        anchorTop = top
+    }
+
+    private func pin() {
+        guard !isAdjusting, contentHeight > 0, let window, window.isVisible,
+              let visible = screen(for: window)?.visibleFrame else { return }
+
+        let current = window.frame
+        let size = CGSize(width: current.width, height: contentHeight)
+        let origin = MenuBarPanelPlacement.origin(
+            forHeight: contentHeight,
+            x: current.minX,
+            top: anchorTop ?? visible.maxY,
+            width: size.width,
+            in: visible
+        )
+
+        guard abs(current.height - size.height) > MenuBarPanelPlacement.moveTolerance
+                || MenuBarPanelPlacement.needsMove(from: current.origin, to: origin) else { return }
+
+        // One `setFrame`, not `setContentSize` followed by `setFrameTopLeftPoint` the way
+        // `ClipboardPickerController.resize(to:)` does it. That panel opens at the cursor and is
+        // never visibly wrong in between; here the in-between state — the new short height still
+        // sitting on the old bottom-left origin — is precisely the bug, and it would flash.
+        isAdjusting = true
+        window.setFrame(NSRect(origin: origin, size: size), display: true)
+        isAdjusting = false
+
+        log.debug("""
+            pinned \(NSStringFromRect(current), privacy: .public) -> \
+            \(NSStringFromRect(window.frame), privacy: .public) \
+            anchorTop=\(self.anchorTop ?? -1, privacy: .public)
+            """)
+    }
+
+    /// The screen holding the status item, which is the one the window is on — not
+    /// `ScreenPlacement.screenUnderPointer`, whose answer is about the pointer and would be the
+    /// wrong display the moment someone opens this panel and moves the mouse away.
+    private func screen(for window: NSWindow) -> NSScreen? {
+        window.screen
+            ?? NSScreen.screens.first { $0.frame.contains(CGPoint(x: window.frame.midX, y: window.frame.maxY)) }
+            ?? NSScreen.main
+    }
+}

--- a/Sources/Sarvkrit/UI/Sound/VolumeMixerTrayView.swift
+++ b/Sources/Sarvkrit/UI/Sound/VolumeMixerTrayView.swift
@@ -7,13 +7,6 @@ import SwiftUI
 struct VolumeMixerTrayView: View {
     @ObservedObject var feature: VolumeMixerFeature
 
-    /// Capped and scrollable rather than growing with the app count.
-    ///
-    /// A MenuBarExtra panel is positioned by the system once, anchored under the icon; content that
-    /// changes height while it's open drags the top edge away from the menu bar. The list of
-    /// playing apps changes on its own every couple of seconds, which is exactly that case.
-    private static let maxHeight: CGFloat = 132
-
     var body: some View {
         VStack(spacing: 0) {
             ModuleSeparator()
@@ -29,7 +22,13 @@ struct VolumeMixerTrayView: View {
                         }
                     }
                 }
-                .frame(height: min(Self.maxHeight, CGFloat(feature.processes.count) * 34))
+                // Grows with the app count. It used to be capped at 132pt because a panel whose
+                // content changed height while open drifted away from the menu bar — and this list
+                // changes on its own every couple of seconds. `MenuBarWindowAnchor` holds the
+                // panel's top edge now, so the cap was buying nothing. The `ScrollView` stays: it
+                // costs nothing and is the only thing standing between an implausible number of
+                // apps playing at once and a panel taller than the screen.
+                .frame(height: CGFloat(feature.processes.count) * 34)
             }
         }
     }

--- a/Tests/SarvkritTests/MenuBarPanelPlacementTests.swift
+++ b/Tests/SarvkritTests/MenuBarPanelPlacementTests.swift
@@ -1,0 +1,128 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// The tray panel's anchoring. Pure, because the cases that matter — a second display, a screen
+/// too short for the panel, an auto-hidden menu bar — cannot be reproduced on the machine running
+/// the tests.
+final class MenuBarPanelPlacementTests: XCTestCase {
+    private let visible = CGRect(x: 0, y: 0, width: 1600, height: 1000)
+    private let width: CGFloat = 420
+    /// Flush under a 25pt menu bar on a 1000-tall screen.
+    private let menuBarBottom: CGFloat = 975
+
+    // MARK: - The bug
+
+    func testShrinkingThePanelLeavesItsTopEdgeWhereItWas() {
+        // The reported bug, in numbers: switching Sound (1018pt) → Keyboard (693pt) moved the top
+        // edge 178px down the screen. Both heights must put the top in the same place.
+        let tall = MenuBarPanelPlacement.origin(
+            forHeight: 700, x: 900, top: 975, width: width, in: visible)
+        let short = MenuBarPanelPlacement.origin(
+            forHeight: 400, x: 900, top: 975, width: width, in: visible)
+
+        XCTAssertEqual(tall.y + 700, 975, "the top edge is the anchored edge")
+        XCTAssertEqual(short.y + 400, 975, "and it does not move when the panel shrinks")
+    }
+
+    func testGrowingThePanelAlsoLeavesItsTopEdgeWhereItWas() {
+        // Growing drifts the other way — Keyboard → Files — and is the same failure.
+        for height in [200, 400, 600, 800] as [CGFloat] {
+            let origin = MenuBarPanelPlacement.origin(
+                forHeight: height, x: 900, top: 975, width: width, in: visible)
+            XCTAssertEqual(origin.y + height, 975, "height \(height) moved the top edge")
+        }
+    }
+
+    // MARK: - Clamping
+
+    func testThePanelIsNeverPlacedUpUnderTheMenuBar() {
+        // A stale anchor from a taller screen would ask for exactly this.
+        let origin = MenuBarPanelPlacement.origin(
+            forHeight: 400, x: 900, top: 1200, width: width, in: visible)
+        XCTAssertEqual(origin.y + 400, visible.maxY)
+    }
+
+    func testATallPanelKeepsItsTopAndOverflowsTheBottom() {
+        // Deliberate, and the reason there is no lower clamp: lifting a panel to fit would slide it
+        // off the icon it belongs to, and far enough would tuck its header under the menu bar —
+        // both worse than an overhang. Content this tall should scroll instead.
+        for height in [990, 1200] as [CGFloat] {
+            let origin = MenuBarPanelPlacement.origin(
+                forHeight: height, x: 900, top: 975, width: width, in: visible)
+            XCTAssertEqual(origin.y + height, 975, "height \(height) moved the top edge")
+        }
+    }
+
+    func testTheHorizontalPositionIsPassedThroughUntouched() {
+        // Regression guard: the horizontal position is the system's and was measured correct.
+        // Deriving it is what would unmoor the panel sideways.
+        for height in [200, 700, 1200] as [CGFloat] {
+            let origin = MenuBarPanelPlacement.origin(
+                forHeight: height, x: 900, top: 975, width: width, in: visible)
+            XCTAssertEqual(origin.x, 900, "height \(height) moved the panel sideways")
+        }
+    }
+
+    func testAPanelNearTheRightEdgeIsPulledBackOnScreen() {
+        // A status item at the far right of the menu bar.
+        let origin = MenuBarPanelPlacement.origin(
+            forHeight: 400, x: 1500, top: 975, width: width, in: visible)
+        XCTAssertEqual(origin.x + width, visible.maxX)
+    }
+
+    func testAnchoringWorksOnADisplayThatDoesNotStartAtZero() {
+        // The case a single-display machine can never exercise: "the top of the screen" is not
+        // 1000 and "the left edge" is not 0.
+        let second = CGRect(x: 1600, y: -200, width: 1600, height: 1000)
+        let origin = MenuBarPanelPlacement.origin(
+            forHeight: 400, x: 2500, top: 775, width: width, in: second)
+        XCTAssertEqual(origin.y + 400, 775)
+        XCTAssertEqual(origin.x, 2500)
+        XCTAssertGreaterThanOrEqual(origin.y, second.minY)
+    }
+
+    // MARK: - Trusting a captured anchor
+
+    func testAFrameNowhereNearTheMenuBarIsNotAnAnchor() {
+        // The frame the window carries before the system positions it. Capturing that would pin
+        // the panel to the middle of the screen for the rest of the presentation.
+        XCTAssertFalse(
+            MenuBarPanelPlacement.isPlausibleAnchor(top: 500, menuBarBottom: menuBarBottom))
+    }
+
+    func testAFrameFlushUnderTheMenuBarIsAnAnchor() {
+        XCTAssertTrue(
+            MenuBarPanelPlacement.isPlausibleAnchor(top: 975, menuBarBottom: menuBarBottom))
+        XCTAssertTrue(
+            MenuBarPanelPlacement.isPlausibleAnchor(top: 973, menuBarBottom: menuBarBottom),
+            "a couple of points of gap is what the system itself leaves")
+    }
+
+    func testATopHalfTheScreenAwayIsRejected() {
+        // Generous is not credulous: a window parked in the middle of the screen is not an anchor.
+        XCTAssertFalse(
+            MenuBarPanelPlacement.isPlausibleAnchor(top: 500, menuBarBottom: menuBarBottom))
+        XCTAssertFalse(
+            MenuBarPanelPlacement.isPlausibleAnchor(top: 825, menuBarBottom: menuBarBottom))
+    }
+
+    func testAnAutoHiddenMenuBarStillHasAPlausibleAnchor() {
+        // With auto-hide on, `visibleFrame.maxY` becomes the top of the screen while the system
+        // still places the panel below the bar it is showing — measured ~33pt, where the normal
+        // gap is 2pt. The tolerance has to cover that, or the anchor is thrown away in a setting
+        // nobody thinks to test.
+        XCTAssertTrue(
+            MenuBarPanelPlacement.isPlausibleAnchor(top: visible.maxY - 33, menuBarBottom: visible.maxY))
+    }
+
+    // MARK: - Not moving
+
+    func testSubPixelDifferencesAreNotWorthAMove() {
+        let here = CGPoint(x: 900, y: 575)
+        XCTAssertFalse(
+            MenuBarPanelPlacement.needsMove(from: here, to: CGPoint(x: 900.4, y: 575)))
+        XCTAssertTrue(
+            MenuBarPanelPlacement.needsMove(from: here, to: CGPoint(x: 900, y: 575.6)))
+    }
+}


### PR DESCRIPTION
## The bug

Switching to a shorter tab left the dropdown floating mid-screen, detached from the icon it belongs to.

| Sound (5 rows) | Keyboard (2 rows) |
|---|---|
| top edge flush under the menu bar | top edge 178px down the screen |

## Why the last attempt didn't work

`47691dd` diagnosed this as an origin that needed adjusting — *"an NSWindow's origin is its bottom-left, so a shrink without an origin adjustment drops the top edge"* — and mitigated it by refusing to animate the height. That diagnosis was wrong, and an origin-only correction would have fixed nothing. An instrumented build recorded what actually happens:

```
grow    frame={{731, 628}, {420, 319}}  top=947  content=319
grow    frame={{731, 522}, {420, 425}}  top=947  content=425
grow    frame={{731, 438}, {420, 509}}  top=947  content=509
shrink  frame={{731, 438}, {420, 509}}  top=947  content=266   <- no resize
shrink  frame={{731, 438}, {420, 509}}  top=947  content=319   <- no resize
```

Growth is handled correctly by SwiftUI: it drops the origin and holds the top edge where the system put it. **A shrink posts no `didResize` at all.** The window keeps the tallest height of the presentation and the smaller content is centred inside it — so the top edge was never adrift. What floats is material drawn around 266pt of content in a 509pt window.

## The fix

The correction is driven by the **content height**, the one signal a shrink produces, rather than by a resize notification that never arrives.

- **`MenuBarWindowProbe`** — an `NSViewRepresentable` in `.background`, so it takes the panel's size without contributing any of its own; `hitTest` returns nil so it never eats a click in the padding. It exists because `MenuBarExtra` vends no window reference — nothing in the app could reach this window before.
- **`MenuBarWindowAnchor`** — resizes to the content height and pins the top in **one** `setFrame`. Not `setContentSize` then `setFrameTopLeftPoint` the way `ClipboardPickerController` does it: that panel is never visibly wrong in between, whereas here the in-between state (new short height on the old bottom-left origin) *is* the bug, and would flash.
- The anchor top is captured at presentation and never re-read from a resized frame. `didResignKey` is explicitly **not** a dismissal signal — the log shows it firing while the panel is open, so clearing the anchor there would throw it away mid-use.
- **`MenuBarPanelPlacement`** is pure, so the cases this machine can't reproduce stay checkable: a second display whose origin isn't zero, and an auto-hidden menu bar, where `visibleFrame.maxY` stops describing the menu bar and reads ~33pt off. `NSStatusBar.thickness` isn't the reference to derive from either — it reported 22pt against a bar measured 33pt tall.

There is no lower clamp, and a test says why: lifting a nearly screen-tall panel "back on screen" would slide it off its icon and tuck its header under the menu bar. The top edge is pinned; a panel too tall for the space below overhangs.

## Both workarounds come out

Both were built on the old diagnosis:

- the tab switch is **animated again** (`.standardMotion(value: selection)`);
- the Volume Mixer's **132pt cap is gone** — the playing-apps list shows in full, changing height every couple of seconds as it always did.

## Verification

- 729 tests passing, including 12 new pure placement tests.
- Verified by hand on the installed build: Sound → Keyboard → Sound → Files, the permission banner animating in and out, tray views appearing as features are toggled.
- **362 corrections logged** across a session of animated tab switches; every single one landed the top edge on 947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)