### PR TITLE
Require pull requests on main, and say so in writing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Every change requests a review from the repository owner automatically.
+# Review is requested, not required: with `main` limiting merges to the owner,
+# a required approval would only deadlock the owner's own pull requests —
+# GitHub does not allow approving your own.
+*	@sadana-psylief

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What changed
+
+<!-- One or two sentences. What does this do that the code didn't do before? -->
+
+## Why
+
+<!-- The problem this solves. Link an issue if there is one. -->
+
+## How it was verified
+
+<!-- `make test` output, and what you did in the running app if the change is
+     visible there. The Accessibility grant follows the app's *location*, so
+     testing from build/ and from /Applications are two separate grants. -->
+
+- [ ] `make test` passes locally
+- [ ] New behaviour comes with tests, or there's a reason it can't

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # A runner has no "Apple Development" certificate, and project.yml pins one on purpose:
+  # a stable signature is what keeps the local Accessibility (TCC) grant alive across
+  # rebuilds. That reason doesn't apply here, so signing is turned off on the command
+  # line instead of being changed in project.yml.
+  SIGNING_OFF: >-
+    CODE_SIGNING_ALLOWED=NO
+    CODE_SIGNING_REQUIRED=NO
+    CODE_SIGN_IDENTITY=
+    DEVELOPMENT_TEAM=
+  # No arch= here, unlike the Makefile: it lets this run on either an Intel or an Apple
+  # silicon runner. Naming the platform is what stops xcodebuild enumerating simulator
+  # runtimes and failing over a Mac-only app.
+  DEST: -destination platform=macOS
+
+jobs:
+  build:
+    name: build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      # Sarvkrit.xcodeproj is generated from project.yml and is not checked in.
+      - name: Generate project
+        run: xcodegen generate
+
+      - name: Build
+        run: |
+          xcodebuild -project Sarvkrit.xcodeproj -scheme Sarvkrit \
+            -configuration Release $DEST -derivedDataPath build build $SIGNING_OFF
+
+  test:
+    # Not a required check, and expected to be flaky here. SarvkritTests is a unit-test
+    # bundle hosted *inside* Sarvkrit.app, and much of it (camera, microphone, Core Audio
+    # process taps, Accessibility) needs TCC grants a runner will not give. Left honest
+    # rather than forced green: nothing is gated on this job.
+    name: test (advisory)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate project
+        run: xcodegen generate
+
+      - name: Test
+        run: |
+          xcodebuild -project Sarvkrit.xcodeproj -scheme Sarvkrit \
+            -configuration Debug $DEST -derivedDataPath build test $SIGNING_OFF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to Sarvkrit
+
+Issues and pull requests are welcome. This page covers the process; the
+[Building](README.md#building) section of the README covers getting the project to compile.
+
+---
+
+## How a change lands
+
+**`main` is a landing zone, not a working branch.** Nobody pushes to it directly — not outside
+contributors, and not the owner either. Every change arrives as a pull request, and the repository
+owner merges it. Those two rules are enforced by GitHub rather than by convention, so a direct push
+to `main` is rejected by the server no matter who makes it.
+
+1. **Fork the repository**, or branch it if you have write access. Either works.
+2. **Branch from `main`.** Name it for what it does: `feature/…`, `fix/…`, `chore/…`.
+3. **Open a pull request** against `main`. The template asks what changed, why, and how you checked
+   it — filling it in honestly is the fastest route to a merge.
+4. **CI runs on every pull request.** The `build` job must pass before the PR can be merged. A second
+   `test (advisory)` job also runs; see below for why it doesn't gate anything.
+5. **The owner reviews and merges.** You'll be able to see an approved PR but not merge it yourself
+   — that's expected, not a permissions bug.
+
+You do not need an approval from anyone else, and you cannot approve your own pull request. Required
+approvals are deliberately set to zero: with merges limited to the owner, requiring one would only
+have deadlocked the owner's own PRs.
+
+---
+
+## Before you open a pull request
+
+- **`make test` must pass.** There are 334 tests; new behaviour should come with some. Quit any
+  running copy of Sarvkrit first — the `test` target does this for you, and the comment above it in
+  the `Makefile` explains why it has to.
+- **Prefer pure, testable logic** over code that can only be checked by running the app.
+  `CutPasteRewriter`, `RuleMatcher`, `ClipboardPrivacyFilter` and `KeepAwakeState` are the pattern:
+  decision logic in an `enum` or `struct` with no `CGEvent`, pasteboard or filesystem dependency, so
+  it can be tested exhaustively without a live event tap or a real folder.
+- **Don't commit `Sarvkrit.xcodeproj`.** It's generated from `project.yml` by XcodeGen. Run
+  `make generate` before opening the project in Xcode.
+- **Don't change the signing settings or the sandbox setting** in `project.yml` to make something
+  build. Both are load-bearing, and the README's
+  [Two things to know before changing the build](README.md#two-things-to-know-before-changing-the-build)
+  explains what breaks.
+
+## About the advisory `test` job
+
+CI builds reliably but cannot run the whole suite. `SarvkritTests` is a unit-test bundle hosted
+*inside* `Sarvkrit.app`, and a good part of it touches things macOS gates behind a TCC grant a
+GitHub runner will never give: the camera, the microphone, Core Audio process taps, Accessibility.
+So the `test` job runs and reports, but nothing is gated on it, and it is expected to be red at
+times. That is why `make test` passing **locally** is on you.
+
+## Licence
+
+Sarvkrit is under **[PolyForm Shield 1.0.0](LICENSE.md)** — source-available, not open-source. It's
+free to use for anything, including at work, but it cannot be used to build a competing product.
+Contributions are accepted under that same licence. The name and branding aren't covered by it: if
+you publish something built on this code, give it your own name.

--- a/README.md
+++ b/README.md
@@ -327,8 +327,9 @@ is no build setting to flip.
 
 ## Contributing
 
-Issues and pull requests are welcome.
+Issues and pull requests are welcome. **[CONTRIBUTING.md](CONTRIBUTING.md)** has the full process.
 
+- `main` takes no direct pushes. Every change goes through a pull request, which the owner merges.
 - `make test` must pass. There are 334 tests; new behaviour should come with some.
 - Prefer pure, testable logic over code that can only be checked by running the app.
 - Contributions are accepted under the same licence as the project.


### PR DESCRIPTION
## What changed

`main` is now enforced as a landing zone rather than a working branch, and the repo says so in
writing. Two repository rulesets plus the contributor-facing files that explain them.

| Ruleset | Rules | Bypass |
| --- | --- | --- |
| `main: PR required` | `pull_request` (0 approvals), `deletion`, `non_fast_forward` | **none** — the owner is subject to it too |
| `main: owner-only merges` | `update` | Repository admin |

New files: `.github/workflows/ci.yml`, `.github/CODEOWNERS`, `.github/PULL_REQUEST_TEMPLATE.md`,
`CONTRIBUTING.md`, plus a pointer to it from the README's Contributing section.

## Why

Direct pushes to `main` were possible for anyone with write access, and the repo is opening up to
outside contributors. Two rulesets rather than one because bypass permission is per-ruleset — a
single ruleset with admin bypass would have let the owner skip the pull request requirement along
with the merge restriction.

Required approvals are zero deliberately: GitHub forbids approving your own PR and the owner is the
only one who can merge, so any non-zero count would deadlock the owner's own PRs permanently.

## How it was verified

- `gh api /repos/.../rules/branches/main` reports `pull_request`, `deletion`, `non_fast_forward`,
  `update` in effect on `main`.
- `current_user_can_bypass` is `never` on the PR ruleset and `always` on the merge ruleset —
  confirming the admin role id resolves to the owner.
- The CI build command was run locally with signing disabled (`CODE_SIGNING_ALLOWED=NO …`) and
  reached `** BUILD SUCCEEDED **`, so the workflow isn't guessing at the signing override.
- This pull request existing at all is the first test of the PR requirement.

Still to do after merge: add the `build` check to the PR ruleset as a required status check, once it
has reported green here under its final name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)