### PR TITLE
Stop main going red, and correct what the last commit guessed at

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,9 @@
-# Every change requests a review from the repository owner automatically.
-# Review is requested, not required: with `main` limiting merges to the owner,
-# a required approval would only deadlock the owner's own pull requests —
-# GitHub does not allow approving your own.
+# Records who owns what. Review here is never *required*: with `main` limiting
+# merges to the owner, a required approval would only deadlock the owner's own
+# pull requests — GitHub does not allow approving your own.
+#
+# Note that GitHub does not act on this file on a personal repository: pull
+# requests from other accounts get no automatic review request from it, which
+# was measured, not assumed. It is kept because it still records ownership, and
+# it would start working if this repo ever moved into an organisation.
 *	@sadana-psylief

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,16 @@ jobs:
             -configuration Release $DEST -derivedDataPath build build $SIGNING_OFF
 
   test:
-    # Not a required check, and expected to be flaky here. SarvkritTests is a unit-test
-    # bundle hosted *inside* Sarvkrit.app, and much of it (camera, microphone, Core Audio
-    # process taps, Accessibility) needs TCC grants a runner will not give. Left honest
-    # rather than forced green: nothing is gated on this job.
+    # Not a required check. The suite very nearly passes on a runner — 845 of 846 — and the
+    # one failure is CameraMonitorSmokeTests.testTheMachineReportsAtLeastOneCamera, which
+    # asserts the machine has a camera. A runner has none, and that test cannot tell "no
+    # camera" from "enumeration is broken", which is the bug it exists to catch. So it is
+    # only meaningful on real hardware: this job reports, and nothing is gated on it.
+    #
+    # Pull requests only. On `push: main` it would fail on that same test every time and
+    # leave a permanent red X against the default branch, which reads as "broken" to anyone
+    # arriving at the repo.
+    if: github.event_name == 'pull_request'
     name: test (advisory)
     runs-on: macos-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ have deadlocked the owner's own PRs.
 
 ## Before you open a pull request
 
-- **`make test` must pass.** There are 334 tests; new behaviour should come with some. Quit any
+- **`make test` must pass.** There are 846 tests; new behaviour should come with some. Quit any
   running copy of Sarvkrit first — the `test` target does this for you, and the comment above it in
   the `Makefile` explains why it has to.
 - **Prefer pure, testable logic** over code that can only be checked by running the app.
@@ -45,11 +45,15 @@ have deadlocked the owner's own PRs.
 
 ## About the advisory `test` job
 
-CI builds reliably but cannot run the whole suite. `SarvkritTests` is a unit-test bundle hosted
-*inside* `Sarvkrit.app`, and a good part of it touches things macOS gates behind a TCC grant a
-GitHub runner will never give: the camera, the microphone, Core Audio process taps, Accessibility.
-So the `test` job runs and reports, but nothing is gated on it, and it is expected to be red at
-times. That is why `make test` passing **locally** is on you.
+CI runs the whole suite on pull requests and gets 845 of 846 — including the parts that reach real
+hardware, which was the surprise. The one test that cannot pass on a runner is
+`CameraMonitorSmokeTests.testTheMachineReportsAtLeastOneCamera`: it asserts that the machine has a
+camera, a runner has none, and the test cannot tell that apart from the enumeration being broken —
+which is the bug it exists to catch. It is only meaningful on real hardware.
+
+So the `test` job reports but gates nothing, and it is expected to be red. Read it for *which*
+tests failed rather than for its overall colour. `make test` passing on your own Mac is still on
+you, and that run is the one that counts.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ is no build setting to flip.
 Issues and pull requests are welcome. **[CONTRIBUTING.md](CONTRIBUTING.md)** has the full process.
 
 - `main` takes no direct pushes. Every change goes through a pull request, which the owner merges.
-- `make test` must pass. There are 334 tests; new behaviour should come with some.
+- `make test` must pass. There are 846 tests; new behaviour should come with some.
 - Prefer pure, testable logic over code that can only be checked by running the app.
 - Contributions are accepted under the same licence as the project.
 


### PR DESCRIPTION
## What changed

Follow-ups from the first CI run, which answered three things differently than the previous commit assumed.

- **The advisory `test` job now runs on pull requests only.** It was also running on `push: main`, where it fails on the same test every time — a permanent red ❌ against the default branch, which reads as "broken" to anyone arriving at a public repo.
- **CONTRIBUTING.md's explanation of that job was wrong.** 845 of 846 tests pass on a runner, *including* everything that reaches real hardware. Only `CameraMonitorSmokeTests.testTheMachineReportsAtLeastOneCamera` fails — a runner has no camera, and that test cannot tell that apart from broken enumeration, which is the bug it exists to catch. Hardware-only, so still advisory, but for the real reason rather than a sweeping TCC claim.
- **CODEOWNERS doesn't do what its comment promised.** GitHub validates the file — `codeowners/errors` returns none — but sends no review request on a personal repository: two PRs from a second account produced none. Measured, not assumed. The file stays (it records ownership, and would start working in an org) with the claim removed.
- `334 tests` was stale in README and CONTRIBUTING. It's 846.

## Why

The previous PR shipped documentation written before CI had ever run. Two of its statements turned out to be false and one of its triggers had a visible cost, so this corrects the record rather than leaving contributors with confident and wrong explanations.

## How it was verified

- YAML parses, and `jobs.test.if` reads `github.event_name == 'pull_request'`.
- The `build` job passing on this PR is the check; `test (advisory)` should appear here and *not* on the merge commit to `main` — that's the point of the change, and worth a look at `main` afterwards to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)