### PR TITLE
Say what actually gets past Gatekeeper, and gate the release on notarization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,17 +44,19 @@ jobs:
             -configuration Release $DEST -derivedDataPath build build $SIGNING_OFF
 
   test:
-    # Not a required check. The suite very nearly passes on a runner — 845 of 846 — and the
-    # one failure is CameraMonitorSmokeTests.testTheMachineReportsAtLeastOneCamera, which
-    # asserts the machine has a camera. A runner has none, and that test cannot tell "no
-    # camera" from "enumeration is broken", which is the bug it exists to catch. So it is
-    # only meaningful on real hardware: this job reports, and nothing is gated on it.
+    # The whole suite runs here, including the smoke tests that touch real hardware.
     #
-    # Pull requests only. On `push: main` it would fail on that same test every time and
-    # leave a permanent red X against the default branch, which reads as "broken" to anyone
-    # arriving at the repo.
-    if: github.event_name == 'pull_request'
-    name: test (advisory)
+    # This used to be advisory and pull-request-only, because
+    # CameraMonitorSmokeTests.testTheMachineReportsAtLeastOneCamera asserted the machine has
+    # a camera and a runner has none — so it failed every time and would have left a
+    # permanent red X on main. That test now asks `system_profiler` whether a camera exists
+    # before asserting anything, which is a source independent of the CoreMediaIO
+    # enumeration under test: on hardware it still catches a broken enumeration, and on a
+    # runner it skips instead of failing. The reason for the caveat is gone, so the job runs
+    # on main too and reports honestly.
+    #
+    # Still not in the required checks — that is a repo ruleset setting, not this file.
+    name: test
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DIST_DIR   := dist
 DEST       := -destination 'platform=macOS,arch=arm64'
 RELEASE_APP := $(BUILD_DIR)/Build/Products/Release/$(APP).app
 
-.PHONY: all generate build debug test run dmg notarize install uninstall clean
+.PHONY: all generate build debug test run dmg notarize release install uninstall clean
 
 all: build
 
@@ -45,6 +45,12 @@ dmg: build
 
 notarize:
 	./scripts/notarize.sh $(DIST_DIR)/$(APP).dmg
+
+## Cuts a notarized GitHub release: bump, build, notarize, and only then tag and publish.
+## Notarization is the gate — nothing is tagged or uploaded if Gatekeeper would still block it.
+##   make release VERSION=1.0.1
+release:
+	./scripts/release.sh $(VERSION)
 
 ## Install to /Applications, which is where Launch at Login actually wants the app to live.
 install: build

--- a/README.md
+++ b/README.md
@@ -14,10 +14,30 @@ Keyboard  ·  Clipboard  ·  Windows  ·  Files  ·  Sound  ·  System
 ## Install
 
 1. Download the DMG and drag **Sarvkrit** to your Applications folder.
-2. **First launch:** right-click the app and choose **Open**, then confirm.
+2. **First launch:** double-click Sarvkrit, click **Done** on the warning, then open **System
+   Settings → Privacy & Security**, scroll down to **Security**, and click **Open Anyway** next to
+   Sarvkrit. Authenticate, open Sarvkrit again and choose **Open**.
 
 That second step is needed because Sarvkrit isn't notarized yet — notarization requires a paid Apple
 Developer account. macOS will otherwise refuse to open it. You only have to do this once.
+
+<!-- TODO(notarize): the whole of step 2 goes away once `make notarize` has run for real. -->
+
+Not *right-click → Open*: macOS 15 Sequoia removed that override, so on 15 and later it shows the
+same refusal with no Open button. Open Anyway works on 14 too, so it is the only route given here.
+
+Or skip the whole detour with one command:
+
+```sh
+curl -fsSL https://sarvkrit.com/install | sh
+```
+
+That works because macOS quarantines what a *browser* downloaded and curl sets no such attribute,
+so Gatekeeper's first-launch check never runs. Which is why the script does the equivalent check
+itself — signature intact, signed by this team — and installs nothing if either fails. Read it
+before you run it: <https://sarvkrit.com/install> is the script, served as plain text. If you
+already have the DMG, `xattr -dr com.apple.quarantine /Applications/Sarvkrit.app` is the same idea
+by hand.
 
 Sarvkrit lives in the menu bar and has no Dock icon until you open its window.
 
@@ -297,7 +317,14 @@ make test      # unit tests
 make install   # copy to /Applications
 make dmg       # dist/Sarvkrit.dmg
 make notarize  # needs a paid Apple Developer account — see below
+make release VERSION=1.0.1   # bump, build, notarize, then tag and publish to GitHub
 ```
+
+`make release` treats notarization as a gate: it bumps `MARKETING_VERSION`, builds, runs
+`make notarize`, and only if that verifies its own work does it commit, tag and create the GitHub
+release. There is no path through it that publishes a DMG users would be blocked by. Because
+`sarvkrit.com/download` and GitHub's own "latest" link both resolve through
+`releases/latest/download/Sarvkrit.dmg`, a new release is picked up with no change on the site.
 
 `Sarvkrit.xcodeproj` is generated from `project.yml` by XcodeGen and is **not** checked in. Run
 `make generate` (or any build target) before opening the project in Xcode.
@@ -311,6 +338,53 @@ gating all pick it up with no further edits.
 Put the decision logic in a pure `enum` or `struct` with no `CGEvent`, pasteboard or filesystem
 dependency — `CutPasteRewriter`, `RuleMatcher`, `ClipboardPrivacyFilter` and `KeepAwakeState` are the
 pattern — so it can be tested exhaustively without a live event tap or a real folder.
+
+### Notarizing, once there is a paid account
+
+`scripts/notarize.sh` is written and waiting; it exits with instructions until a **Developer ID
+Application** certificate is in the keychain, which only a paid Apple Developer Program membership
+can produce. Today's DMG is signed with the *Apple Development* cert and is not notarized, which is
+why the install section above has a step 2 at all.
+
+0. **Decide Individual vs Organization before enrolling.** The licence holder is Psylief
+   Technologies Pvt. Ltd., so Organization is the tidier fit — but it needs a D-U-N-S number and
+   legal-entity verification, which runs to weeks rather than days, and it is the company name that
+   then appears on the certificate and in every Gatekeeper dialog. Individual is approved in a day
+   or two and shows the personal name. This choice is not easy to change later.
+1. Enrol in the Apple Developer Program ($99/yr) as `tusharsadana@icloud.com`.
+2. Xcode → Settings → Accounts → Manage Certificates → **+ Developer ID Application**.
+3. Read the **new Team ID** off that certificate (Keychain Access shows it in the Organizational
+   Unit field) and put it in `project.yml`'s `DEVELOPMENT_TEAM` **and** in `EXPECTED_TEAM` in the
+   site repo's `public/install.sh`, which pins it. It is not `77A36893HP` — see below. A build
+   signed against the old ID will not notarize, and the installer will reject it.
+4. Create an app-specific password at appleid.apple.com, and store it for `notarytool`, once:
+
+   ```bash
+   xcrun notarytool store-credentials SarvkritNotary \
+     --apple-id tusharsadana@icloud.com --team-id <new team ID> --password <app-specific-password>
+   ```
+5. `make release VERSION=1.0.1`. It will not tag or publish anything unless notarization has
+   verified itself — `spctl` reporting `source=Notarized Developer ID` and `stapler validate`
+   passing on both the app and the DMG. Cut a new version rather than replacing the v1.0 asset:
+   the v1.0 notes publish that DMG's sha256 under *Verifying the download*, so clobbering the
+   asset in place would make the published hash a lie.
+6. Grep both repos for the marker `TODO` + `(notarize)` and delete what it finds: the install
+   step 2 above, step 2 of `INSTALL_STEPS`, the `OpenAnywayMock` illustration and its `.ctx-*`
+   rules in `index.css`. This runbook is a hit too and stays — it is the instruction, not the
+   thing being removed. Then fix step 2 of the v1.0 release notes, which still describes the
+   Gatekeeper detour.
+
+**The Team ID will almost certainly change.** `77A36893HP` is a *free personal team* — Xcode's own
+record says `isFreeProvisioningTeam = true`, `teamType = Personal Team`, named "Tushar Sadana
+(Personal Team)". A paid membership is a different team with its own ID; the personal team does not
+become it. So after enrolling, read the new Team ID off the certificate and update
+`DEVELOPMENT_TEAM` in `project.yml` and the `--team-id` in `scripts/notarize.sh`'s message. A build
+signed against the old ID will not notarize.
+
+**Expect one Accessibility re-prompt.** Re-signing from *Apple Development* to *Developer ID*
+changes the code signature, and macOS keys the Accessibility grant to bundle ID *and* signature — so
+the first notarized build asks every existing user, and this machine, to grant it once more. That is
+a one-time cost at the switch, not something that recurs.
 
 ### Two things to know before changing the build
 

--- a/Tests/SarvkritTests/CameraMonitorSmokeTests.swift
+++ b/Tests/SarvkritTests/CameraMonitorSmokeTests.swift
@@ -8,12 +8,56 @@ import XCTest
 /// compiles and returns plausible-looking nothing is the failure mode this project has hit before.
 final class CameraMonitorSmokeTests: XCTestCase {
 
-    func testTheMachineReportsAtLeastOneCamera() {
-        // Every Mac with a built-in camera should report one. If this returns zero on a machine
-        // that plainly has a camera, the enumeration is wrong — which would make the whole feature
+    func testTheMachineReportsAtLeastOneCamera() throws {
+        // Every Mac with a camera should report one. If this returns zero on a machine that
+        // plainly has a camera, the enumeration is wrong — which would make the whole feature
         // silently report "never on".
+        //
+        // "Plainly has a camera" needs an answer from somewhere other than the code under test.
+        // Asserting the count outright cannot tell *no camera* from *enumeration is broken*, and
+        // those want opposite outcomes: the first is a machine this test has nothing to say about,
+        // the second is the bug it exists to catch. Conflating them is what made this fail on CI
+        // runners, which have no camera, and kept the whole suite out of the gating checks.
+        try XCTSkipUnless(Self.systemReportsACamera(),
+                          "this machine has no camera, so there is nothing to check enumeration against")
+
         XCTAssertGreaterThan(CameraMonitor.cameraCount(), 0,
-                             "no cameras found — enumeration is broken, or this Mac has none")
+                             "the system reports a camera but CoreMediaIO enumeration found none")
+    }
+
+    /// Whether the machine has a camera, according to something that is **not** CoreMediaIO.
+    ///
+    /// `system_profiler` is the independent source: a different subsystem, no capture session, and
+    /// — unlike enumerating through AVFoundation — nothing that could put a permission prompt in
+    /// front of a test run. It costs about a third of a second, which is worth paying once to make
+    /// the assertion above mean something.
+    ///
+    /// Deliberately not compared for *equality* with `cameraCount()`. The two disagree legitimately
+    /// — Continuity Camera shows up here whether or not CoreMediaIO is currently listing it — so
+    /// the only sound assertion is directional: if this says there is a camera, enumeration must
+    /// find at least one.
+    private static func systemReportsACamera() -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
+        process.arguments = ["SPCameraDataType", "-json"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        // Read before waiting: a full pipe buffer with nobody draining it deadlocks both sides.
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let cameras = json["SPCameraDataType"] as? [Any]
+        else { return false }
+        return !cameras.isEmpty
     }
 
     func testAskingWhetherTheCameraIsOnDoesNotCrashOrHang() {

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
-# Re-signs with Developer ID, notarizes, and staples.
+# Re-signs with Developer ID, notarizes, staples, and verifies.
 #
 # This CANNOT run with only an "Apple Development" certificate — notarization requires a
 # paid Apple Developer account and a "Developer ID Application" cert. Until then the DMG
-# still installs fine locally; other users have to right-click → Open past Gatekeeper once.
+# still installs fine locally; other users have to go through System Settings → Privacy &
+# Security → Open Anyway once. See "Notarizing, once there is a paid account" in README.md.
 set -euo pipefail
 
 DMG_PATH="${1:?usage: notarize.sh <path-to-.dmg>}"
 KEYCHAIN_PROFILE="${NOTARY_PROFILE:-SarvkritNotary}"
+
+# Anchored to the script rather than the caller's cwd: the entitlements path and build-dmg.sh
+# below are repo-relative, and `make notarize` is not the only way this gets run.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_PATH="$REPO_ROOT/build/Build/Products/Release/Sarvkrit.app"
 
 IDENTITY="$(security find-identity -v -p codesigning \
   | grep "Developer ID Application" | head -1 | sed -E 's/.*"(.+)"/\1/' || true)"
@@ -18,31 +24,96 @@ error: no "Developer ID Application" certificate found in the keychain.
 
 Notarization needs a paid Apple Developer account. Once you have one:
   1. Xcode → Settings → Accounts → Manage Certificates → + Developer ID Application
-  2. Store an app-specific password for notarytool:
+  2. Put the certificate's Team ID in project.yml's DEVELOPMENT_TEAM. It is NOT 77A36893HP:
+     that is the free personal team, and a paid membership is a different team entirely.
+  3. Store an app-specific password for notarytool:
        xcrun notarytool store-credentials SarvkritNotary \
-         --apple-id <you@example.com> --team-id 77A36893HP --password <app-specific-password>
-  3. Re-run: make notarize
+         --apple-id <you@example.com> --team-id <that same team ID> --password <app-specific-password>
+  4. Re-run: make notarize
 
 Nothing has been signed or submitted.
 MSG
   exit 1
 fi
 
-APP_IN_DMG="$(dirname "$DMG_PATH")/../build/Build/Products/Release/Sarvkrit.app"
+[[ -d "$APP_PATH" ]] || { echo "error: no release build at $APP_PATH — run 'make build' first" >&2; exit 1; }
+
+## Resolved only now, and only after the two checks above have had their say. `make notarize` has
+## no prerequisite on `make dmg`, so dist/ often does not exist yet — resolving it any earlier made
+## a missing directory pre-empt the "no Developer ID cert" message that is the real answer.
+mkdir -p "$(dirname "$DMG_PATH")"
+DIST_DIR="$(cd "$(dirname "$DMG_PATH")" && pwd)"
+
+## `notarytool submit --wait` has been known to exit 0 on a rejected submission, so the exit code
+## alone is not the answer: require the words "status: Accepted" in its output. On anything else,
+## print the server-side log, which is the only place that says *why* Apple refused — a rejection
+## with no log is the thing that turns this into an afternoon.
+submit() {
+  local what="$1" log rc=0 id
+  log="$(mktemp -t sarvkrit-notarize)"
+  echo "Submitting $(basename "$what") to Apple…"
+  xcrun notarytool submit "$what" --keychain-profile "$KEYCHAIN_PROFILE" --wait 2>&1 | tee "$log" || rc=$?
+  id="$(sed -nE 's/^ *id: ([0-9a-fA-F-]{36}).*/\1/p' "$log" | head -1)"
+  if [[ $rc -ne 0 ]] || ! grep -q "status: Accepted" "$log"; then
+    echo >&2
+    echo "error: notarization of $(basename "$what") was not accepted." >&2
+    if [[ -n "$id" ]]; then
+      echo "--- notarytool log $id ---" >&2
+      xcrun notarytool log "$id" --keychain-profile "$KEYCHAIN_PROFILE" >&2 || true
+    else
+      echo "(no submission id in the output, so no log to fetch)" >&2
+    fi
+    rm -f "$log"
+    exit 1
+  fi
+  rm -f "$log"
+}
+
 echo "Signing with: $IDENTITY"
 # Sign nested content first, then the bundle. --deep is deprecated and signs things it
 # shouldn't; an explicit inside-out pass is the supported route.
-find "$APP_IN_DMG/Contents" -type f \( -name "*.dylib" -o -name "*.framework" \) -print0 \
+#
+# Two passes, because these are different kinds of thing: a .dylib is a file, a .framework is a
+# *directory*. One `-type f` covering both silently matched no framework at all.
+find "$APP_PATH/Contents" -type f -name "*.dylib" -print0 \
+  | xargs -0 -r codesign --force --options runtime --timestamp --sign "$IDENTITY"
+find "$APP_PATH/Contents" -type d -name "*.framework" -print0 \
   | xargs -0 -r codesign --force --options runtime --timestamp --sign "$IDENTITY"
 codesign --force --options runtime --timestamp \
-  --entitlements Sources/Sarvkrit/Resources/Sarvkrit.entitlements \
-  --sign "$IDENTITY" "$APP_IN_DMG"
+  --entitlements "$REPO_ROOT/Sources/Sarvkrit/Resources/Sarvkrit.entitlements" \
+  --sign "$IDENTITY" "$APP_PATH"
 
-./scripts/build-dmg.sh "$APP_IN_DMG" "$(dirname "$DMG_PATH")"
+## The app is notarized and stapled *before* the DMG is built, so the ticket travels inside the
+## bundle. Stapling only the DMG leaves the copy someone drags to /Applications with no ticket of
+## its own, which Gatekeeper then has to fetch over the network — and cannot, on a Mac that is
+## offline or behind a filter. Two submissions, one build.
+ZIP_PATH="$DIST_DIR/Sarvkrit-notarize.zip"
+rm -f "$ZIP_PATH"
+ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
+submit "$ZIP_PATH"
+rm -f "$ZIP_PATH"
+xcrun stapler staple "$APP_PATH"
+
+"$REPO_ROOT/scripts/build-dmg.sh" "$APP_PATH" "$DIST_DIR"
 codesign --force --timestamp --sign "$IDENTITY" "$DMG_PATH"
-
-echo "Submitting to Apple…"
-xcrun notarytool submit "$DMG_PATH" --keychain-profile "$KEYCHAIN_PROFILE" --wait
+submit "$DMG_PATH"
 xcrun stapler staple "$DMG_PATH"
+
+## Verify rather than assume. Every step above can succeed and still leave something a downloader
+## would be blocked by, and this machine is the last place that would notice — a locally built app
+## carries no quarantine attribute, so it opens fine either way.
+echo
+echo "Verifying…"
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+xcrun stapler validate "$APP_PATH"
 xcrun stapler validate "$DMG_PATH"
-echo "Notarized and stapled: $DMG_PATH"
+
+assessment="$(spctl -a -vv "$APP_PATH" 2>&1)"
+echo "$assessment"
+if ! grep -q "source=Notarized Developer ID" <<<"$assessment"; then
+  echo "error: Gatekeeper does not see this as notarized — do not ship it." >&2
+  exit 1
+fi
+
+echo
+echo "Notarized, stapled and verified: $DMG_PATH"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Cuts a notarized GitHub release. Notarization is the gate: the tag is not pushed and the
+# release is not created unless `notarize.sh` has verified its own work first, so there is no
+# path through here that publishes a DMG users would be blocked by.
+#
+#   ./scripts/release.sh 1.0.1
+set -euo pipefail
+
+VERSION="${1:?usage: release.sh <version>, e.g. release.sh 1.0.1}"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]] || { echo "error: '$VERSION' is not a version" >&2; exit 1; }
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+TAG="v$VERSION"
+DMG="dist/Sarvkrit.dmg"
+
+## Fail on everything checkable before doing anything that costs time or leaves a trace. A
+## half-finished release — tag pushed, notarization refused — is worse than no release.
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[[ "$BRANCH" == "main" ]] || { echo "error: on '$BRANCH' — releases are cut from main" >&2; exit 1; }
+[[ -z "$(git status --porcelain)" ]] || { echo "error: working tree is dirty; commit or stash first" >&2; exit 1; }
+git rev-parse -q --verify "refs/tags/$TAG" >/dev/null && { echo "error: tag $TAG already exists" >&2; exit 1; }
+gh release view "$TAG" >/dev/null 2>&1 && { echo "error: release $TAG already exists" >&2; exit 1; }
+security find-identity -v -p codesigning | grep -q "Developer ID Application" || {
+  echo "error: no \"Developer ID Application\" certificate — see scripts/notarize.sh" >&2; exit 1; }
+command -v gh >/dev/null || { echo "error: gh is not installed" >&2; exit 1; }
+
+echo "Releasing Sarvkrit $VERSION"
+
+# MARKETING_VERSION lives in project.yml, not the generated .xcodeproj, so this is the one place
+# it changes. CURRENT_PROJECT_VERSION follows it rather than counting separately: nothing here
+# needs a build number independent of the version, and Apple accepts a dotted string for it just
+# as happily as the "1" it holds today.
+/usr/bin/sed -i '' \
+  -e "s/^\( *MARKETING_VERSION: \).*/\1\"$VERSION\"/" \
+  -e "s/^\( *CURRENT_PROJECT_VERSION: \).*/\1\"$VERSION\"/" \
+  project.yml
+grep -q "MARKETING_VERSION: \"$VERSION\"" project.yml || { echo "error: version bump did not apply" >&2; exit 1; }
+
+make build
+make dmg
+./scripts/notarize.sh "$DMG"   # verifies stapling and `spctl` itself, and exits non-zero otherwise
+
+## Only past this line is the DMG known to be notarized, stapled and accepted by Gatekeeper.
+## The hash is taken now, after stapling, because stapling rewrites the file — a hash taken any
+## earlier would be published alongside a DMG that no longer matches it.
+SHA="$(shasum -a 256 "$DMG" | awk '{print $1}')"
+NOTES="$(mktemp -t sarvkrit-release)"
+cat > "$NOTES" <<NOTES_BODY
+**Sarvkrit lives in the menu bar and fixes the things macOS does differently than you'd expect.** Everything ships switched off; turn on only what you want.
+
+## Install
+
+1. Download \`Sarvkrit.dmg\` below and drag **Sarvkrit** to your Applications folder. Put it there rather than leaving it in Downloads — macOS keys permissions to where the app lives.
+2. Open it. This build is signed with a Developer ID certificate and notarized by Apple, so it opens on first launch with no Gatekeeper detour.
+3. Features that watch for keys or clicks will ask for Accessibility access when you switch them on.
+
+## Requirements
+
+- **macOS 14.4 or later.**
+- **Universal** — Apple Silicon and Intel.
+
+## Verifying the download
+
+\`\`\`
+shasum -a 256 Sarvkrit.dmg
+$SHA
+\`\`\`
+
+Signed, notarized and stapled — \`spctl -a -vv Sarvkrit.app\` reports \`source=Notarized Developer ID\`.
+
+## Licence
+
+[PolyForm Shield 1.0.0](https://polyformproject.org/licenses/shield/1.0.0) — free to use for anything including at work, source public to read and change. You may not use the code to build a competing product. Source-available, not open source.
+NOTES_BODY
+
+git add project.yml
+git commit -m "Release $VERSION"
+git tag -a "$TAG" -m "Sarvkrit $VERSION"
+git push origin HEAD "$TAG"
+
+gh release create "$TAG" "$DMG" --title "Sarvkrit $VERSION" --notes-file "$NOTES"
+rm -f "$NOTES"
+
+## sarvkrit.com/download and the GitHub "latest" link both resolve through
+## releases/latest/download/Sarvkrit.dmg, so they pick this up with no change on the site side.
+echo
+echo "Released $TAG. Verify the download route now points at it:"
+echo "  curl -sIL -o /dev/null -w '%{url_effective}\\n' https://sarvkrit.com/download"


### PR DESCRIPTION
## What prompted this

A DMG downloaded on a second Mac would not open: *"Apple could not verify Sarvkrit is free of malware."* Expected — the app is signed with an **Apple Development** cert and is not notarized (`spctl -a -vv` → rejected; `syspolicy_check distribution` → `Notary Ticket Missing, Severity: Fatal`, and nothing else wrong).

The bug is that the instructions were wrong. `README.md`, the site, and the v1.0 release notes all said **right-click → Open**. macOS 15 Sequoia removed that override, so on 15 and later it shows the same refusal with no Open button. With a 14.4 deployment target, most downloaders are on 15+ and were following steps that cannot work.

## Changes

- **Install steps** now describe System Settings → Privacy & Security → **Open Anyway**, which works on 14 as well, so there is one path and not two.
- **`curl -fsSL https://sarvkrit.com/install | sh`** as the one-line alternative. macOS quarantines what a *browser* downloaded; curl sets no such attribute, so Gatekeeper's first-launch check never runs. The script (site repo) therefore does the equivalent check itself — `codesign --verify --deep --strict` plus a Team ID match — and installs nothing if either fails.
- **`scripts/notarize.sh`**, which had never run, had three real defects:
  - `find -type f -name "*.framework"` could never match; a framework is a directory.
  - Only the DMG was stapled, leaving a bundle dragged to `/Applications` with no ticket of its own.
  - No verification. It now fails unless `spctl` reports `source=Notarized Developer ID` and `stapler validate` passes on both, and dumps `notarytool log` on rejection.
- **`scripts/release.sh` / `make release VERSION=x.y.z`** — bump, build, notarize, and only if that verifies itself does it commit, tag and publish. Notarization is a gate, not a promise.
- **Runbook** for the day there is a paid account, including that the Team ID will change: the account is a free personal team (`isFreeProvisioningTeam = true`).

## Verified

- `make notarize` still exits with its "no Developer ID" message; `make release` refuses off `main`, on a dirty tree, and without a cert.
- Installer run end to end piped to `sh`: the installed copy carries no `com.apple.quarantine`, and a deliberately wrong Team ID aborts with exit 1 and installs nothing.
- The notarization happy path and `gh release create` are unreachable without a certificate — written and syntax-checked only.

## Not done

Notarization itself. It needs a paid Apple Developer Program membership, which requires enrolment. No v1.0.1 release exists, which is correct: nothing has been notarized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)