### PR TITLE
Stop the tray panel flickering as you change tabs

### DIFF
--- a/Sources/Sarvkrit/UI/MenuBarView.swift
+++ b/Sources/Sarvkrit/UI/MenuBarView.swift
@@ -70,17 +70,27 @@ struct MenuBarView: View {
                 onHeight: { MenuBarWindowAnchor.shared.note(contentHeight: $0) }
             )
         )
-        // Grow and shrink the panel rather than snapping it — Keep Awake is two rows, System is a
-        // dozen.
+        // **Nothing here may animate this panel's height.** There used to be a `.standardMotion`
+        // per height-bearing value, on the theory that `MenuBarWindowAnchor` could follow the
+        // content through the animation. It does follow it, and SwiftUI overwrites the result:
+        // SwiftUI sizes this window from the content's *settled* height, so on a grow it jumps
+        // straight to the final height and re-asserts it on every content change, while the
+        // anchor drags it back to whatever height the animation is currently at. One instrumented
+        // Keyboard → Files switch, logged as `before -> after` window heights:
         //
-        // This used to be unsafe, and the comment here used to say so: a height change would leave
-        // the panel floating away from the menu bar, and animating walked it through many
-        // intermediate heights. The measured reason turned out to be that SwiftUI does not resize
-        // this window on a *shrink* at all — it keeps the tallest height of the presentation and
-        // centres the smaller content inside it. `MenuBarWindowAnchor` now does that resize, on
-        // every height change including each frame of an animated one.
-        .standardMotion(value: selection.wrappedValue)
-        .standardMotion(value: app.unmetRequirementsInOrder)
+        //     533 -> 338   533 -> 341   341 -> 341   533 -> 343   343 -> 343   533 -> 345  …
+        //
+        // Twenty-five of those inside 150ms and 195pt of travel on the bottom edge — two writers,
+        // alternating. That is the panel "moving and resetting" as you change tabs.
+        //
+        // With the animation gone the content settles in one pass, SwiftUI asserts the height at
+        // most once, and the anchor's correction is a single step. The strip still animates its
+        // own selection pill in `TrayPanelStrip`, on a view of fixed height, so nothing there can
+        // move the panel's bottom edge.
+        //
+        // **Animating the resize is not simply missing here; it was tried and it is unreachable
+        // from inside `MenuBarExtra`.** See `MenuBarWindowProbe` for the two measurements that
+        // close it off.
     }
 
     /// The whole strip. Features and General are built here rather than in `AppState` because they

--- a/Sources/Sarvkrit/UI/MenuBarWindowAnchor.swift
+++ b/Sources/Sarvkrit/UI/MenuBarWindowAnchor.swift
@@ -4,6 +4,30 @@ import SwiftUI
 
 /// Hands the enclosing `NSWindow` to a callback, and reports its own height as SwiftUI lays it out.
 ///
+/// **Why the panel snaps between sizes instead of animating, which is not for want of trying.**
+/// An animated window resize needs the window and its content to be different heights for the
+/// duration, and SwiftUI *centres* a root that does not fill its bounds — measured, a 350pt root
+/// sat 92pt down inside a 533pt host, exactly half the difference. So every frame of an animation
+/// would show a blank band above the content, or clip the header when the window is the shorter of
+/// the two.
+///
+/// The obvious fix is to make the root fill the window and pin the content to the top. It cannot
+/// be done from in here: `MenuBarExtra` sizes *and positions* its own window from what the root
+/// will accept, and a root that accepts anything breaks it two different ways, both measured:
+///
+///   - `.frame(minHeight: 0, maxHeight: .infinity, alignment: .top)` — the panel was created
+///     **10pt tall**, the system placed that, and it opened in the middle of the screen with the
+///     content hanging outside the material. Naming an explicit `idealHeight` does not help, so
+///     the size is taken from the *minimum*, not the ideal.
+///   - `.frame(maxHeight: .infinity, alignment: .top)` — created at the right size, but SwiftUI
+///     then settled on a height this probe disagreed with and re-asserted it indefinitely: the
+///     window held at 400pt around 363pt of content, corrected and undone every couple of seconds.
+///
+/// Neither shows up in a `fittingSize` test, because the *ideal* height is right in both cases.
+/// The panel's root is therefore left exactly as SwiftUI sizes it, and nothing may be layered
+/// outside it. Animating this properly means owning the window — an `NSStatusItem` and our own
+/// `NSPanel`, the way `ShelfPanel` and `ClipboardPickerPanel` already do it — not a modifier.
+///
 /// `MenuBarExtra` vends no window reference, so this is the only way to reach the panel's window.
 /// Installed as a `.background` of the dropdown's content: a background takes the size of what it
 /// backs without contributing any of its own, so the probe cannot perturb the layout it exists to
@@ -86,7 +110,16 @@ final class MenuBarWindowAnchor {
     /// SwiftUI's own idea of how tall the content is, straight from the probe's layout pass.
     private var contentHeight: CGFloat = 0
     /// Set while *we* are the ones resizing, so the `didResize` that follows can't recurse.
+    ///
+    /// Worth knowing that this guards less than it looks: the observers below are registered with
+    /// `queue: .main`, which delivers on the main *operation queue* and so a runloop turn later
+    /// than the `setFrame` that caused it — by which point a flag cleared synchronously is already
+    /// false. Harmless today, because the `didResize` that gets through finds the window already
+    /// where it belongs and does nothing. Anything that ever holds the window away from the
+    /// content height, an animation above all, would need a flag that spans the whole operation.
     private var isAdjusting = false
+    /// Set between a content report and the coalesced pass that acts on it.
+    private var pinScheduled = false
 
     private init() {}
 
@@ -131,10 +164,22 @@ final class MenuBarWindowAnchor {
 
     /// The content's height, reported by the probe as SwiftUI lays it out. **This is the trigger
     /// that matters:** it is the only signal a shrink produces.
+    ///
+    /// Records and defers rather than resizing on the spot, because this arrives from inside the
+    /// probe's `layout()`. Resizing a window there changes the hosting view's bounds mid-layout
+    /// and re-enters `layout()`; deferring means one correction per runloop turn however many
+    /// layout passes a change produces.
     func note(contentHeight height: CGFloat) {
         guard abs(height - contentHeight) > MenuBarPanelPlacement.moveTolerance else { return }
         contentHeight = height
-        pin()
+
+        guard !pinScheduled else { return }
+        pinScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.pinScheduled = false
+            self.pin()
+        }
     }
 
     private func observe(


### PR DESCRIPTION
## What changed

Changing tabs in the menu bar dropdown made the panel jump and snap back — up to **195pt** of travel on its bottom edge, ~25 times inside 150ms. Two writers were fighting over the window's height.

`MenuBarView` carried a `.standardMotion` per height-bearing value, which animated the *content* height. `MenuBarWindowProbe` reported each of its ~50 frames, and `MenuBarWindowAnchor` resized the window to match. Meanwhile SwiftUI sizes this window from the content's **settled** height, so on a grow it jumps to the final height immediately and re-asserts it on every content change.

Streaming the anchor's own `os_log` while switching tabs, as `before -> after` window heights across one Keyboard → Files switch:

```
533 -> 338   533 -> 341   341 -> 341   533 -> 343   343 -> 343   533 -> 345  …
```

The `533 -> N` lines are the anchor pulling the window down to the frame the animation is currently at; the `N -> N` lines are echoes that changed nothing. Shrinks were already fine — 27–30 corrections, monotonic, 8–14pt — because SwiftUI never resizes for a shrink and there was only ever one writer.

So the SwiftUI height animation goes, and the resize is one step in each direction. `note(contentHeight:)` also now defers to a coalesced main-queue pass rather than resizing from inside the probe's `layout()`, which is not a place to be changing the hosting view's bounds.

## Why the old comment made this look safe

`MenuBarWindowAnchor`'s comment asserted that growth "is handled correctly by SwiftUI", citing a log of smooth grow steps. That log came from a build with **neither** the anchor nor the animation in it — `7032210` added both in the same commit — so its three grow lines are three separate tab switches, each an instant resize. The arithmetic gives it away: `947−319=628`, `947−425=522`, `947−509=438`. SwiftUI has never animated this window.

## Why it snaps rather than animates

Animation was the goal and was tried at length. It is unreachable from inside `MenuBarExtra`, and `MenuBarWindowProbe` now records the measurements so the next person doesn't spend the same afternoon:

- An animated resize needs the window and its content to be different heights for the duration, and SwiftUI **centres** a root that doesn't fill its bounds — measured, a 350pt root sitting 92pt down inside a 533pt host, exactly half the difference. Every frame would show a blank band above the content, or clip the header.
- Making the root fill the window breaks how `MenuBarExtra` sizes *and positions* it, two different ways: `.frame(minHeight: 0, maxHeight: .infinity, alignment: .top)` had the panel created **10pt tall** and placed as such — opening mid-screen with content outside the material, and an explicit `idealHeight` does not rescue it, so the size comes from the *minimum*. Without a floor it was created correctly but SwiftUI then settled on a height the probe disagreed with and re-asserted it indefinitely: the window held at 400pt around 363pt of content, corrected and undone every couple of seconds.

Neither shows up in a `fittingSize` test, because the *ideal* height is right in both cases. Doing this properly means owning the window — an `NSStatusItem` and our own `NSPanel`, as `ShelfPanel` and `ClipboardPickerPanel` already do — which is its own piece of work.

## How I checked it

`/usr/bin/log stream --level debug --predicate 'subsystem == "ai.psylief.sarvkrit" AND category == "TrayPanel"'`, on a release build, switching tabs.

Before: 42–51 corrections per switch, the `before` column flipping back to the settled height ~25 times. After: **one** correction per switch, every one landing `y + h = 947` exactly, zero rejected anchors.

`make test` — 1466 tests. One failure, `MenuBarLabelRenderTests.testTheLabelLaysOutWithLiveReadings`, which fails identically on clean `origin/main` and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7SzrctuRiWyegmsivFfKg