### PR TITLE
Animate the tray panel growing

### DIFF
--- a/Sources/Sarvkrit/UI/DesignSystem/Tokens.swift
+++ b/Sources/Sarvkrit/UI/DesignSystem/Tokens.swift
@@ -103,7 +103,22 @@ enum Theme {
     /// One curve for the whole app. Motion exists to explain what changed — a system utility
     /// that animates for its own sake feels slow.
     enum Motion {
-        static let standard: Animation = .easeInOut(duration: 0.15)
+        /// The same curve as a scalar, for the one place motion is not a SwiftUI animation:
+        /// `MenuBarWindowAnchor` animates an `NSWindow` frame through `NSAnimationContext`, which
+        /// takes a duration and a `CAMediaTimingFunction`. `standard` is derived from it so the
+        /// AppKit and SwiftUI halves of "one curve for the whole app" cannot drift apart.
+        static let standardDuration: TimeInterval = 0.15
+
+        static let standard: Animation = .easeInOut(duration: standardDuration)
+
+        /// Longer than `standard`, and the one motion in the app that earns it.
+        ///
+        /// The tray panel's height changes by up to 195pt between panels. At 0.15s that is
+        /// ~1200pt/s, which does not read as movement — it reads as a jump that happens to be
+        /// blurry, and the handful of frames a display can fit into 150ms at that speed land far
+        /// enough apart to look like stepping. Everything else this token family covers moves a
+        /// row height or a colour, where 0.15s is right.
+        static let panelResizeDuration: TimeInterval = 0.25
 
         /// Pure, so the Reduce Motion contract is unit-testable rather than only observable by eye.
         static func resolved(reduceMotion: Bool) -> Animation? {

--- a/Sources/Sarvkrit/UI/MenuBarPanelResize.swift
+++ b/Sources/Sarvkrit/UI/MenuBarPanelResize.swift
@@ -1,0 +1,143 @@
+import CoreGraphics
+
+/// When the tray panel's resize is worth animating, and which two frames it runs between.
+///
+/// Split out from `MenuBarWindowAnchor` for the same reason `MenuBarPanelPlacement` was: the
+/// interesting cases are the ones a single-display machine with the panel open cannot be made to
+/// perform on demand. A resize arriving while another is still running, the first placement of a
+/// presentation, Reduce Motion, a content height that changes on its own every couple of seconds
+/// — each is one function call here and an afternoon of clicking otherwise.
+///
+/// `MenuBarPanelPlacement` answers *where* a panel of a given height goes. This answers *how it
+/// gets there*, and defers every question about position to that file.
+///
+/// A resize is animated when the content grew, and snapped otherwise — a shrink, Reduce
+/// Motion, the first placement of a presentation, and drift correction. That distinction is the
+/// whole point: animation is how this panel says "the content changed", and spending it on a
+/// stale origin would be motion that explains nothing.
+enum MenuBarPanelResize {
+
+    /// What the anchor should do about the height it was just told about.
+    enum Step: Equatable {
+        /// Nothing worth moving a window for.
+        case none
+        /// Go there now: Reduce Motion, the first placement of a presentation, or a correction
+        /// that isn't a content change and so isn't a resize the user should watch happen.
+        case set(CGRect)
+        /// Put the window at `from` — undoing SwiftUI's jump to the settled height — and animate
+        /// it to `to`.
+        ///
+        /// Both frames come from `MenuBarPanelPlacement.origin(...)` against the same anchor, so
+        /// `from.maxY == to.maxY` by construction. That is what keeps the top edge still while the
+        /// height changes: interpolating the whole rect moves the origin by `Δy = −Δh`, so
+        /// `y(t) + h(t)` is constant for every `t`. Animating height and origin as two properties
+        /// would not have that guarantee, and the top edge would wobble by rounding.
+        case animate(from: CGRect, to: CGRect)
+    }
+
+    /// The frame a panel of `height` should occupy, top edge on `top`.
+    static func frame(
+        forHeight height: CGFloat,
+        x: CGFloat,
+        top: CGFloat,
+        width: CGFloat,
+        in visible: CGRect
+    ) -> CGRect {
+        CGRect(
+            origin: MenuBarPanelPlacement.origin(
+                forHeight: height, x: x, top: top, width: width, in: visible),
+            size: CGSize(width: width, height: height)
+        )
+    }
+
+    /// - Parameters:
+    ///   - window: the frame the window has right now — which on a grow is already the settled
+    ///     height, because SwiftUI put it there before the content report arrived.
+    ///   - settledHeight: the height the last completed step left behind. `0` means this
+    ///     presentation has not placed the panel yet.
+    ///   - contentHeight: the probe's latest measurement of the content.
+    ///   - inFlightTo: the destination of an animation that is still running, if any.
+    static func step(
+        window: CGRect,
+        settledHeight: CGFloat,
+        contentHeight: CGFloat,
+        inFlightTo: CGRect?,
+        anchorTop: CGFloat,
+        visible: CGRect,
+        animates: Bool,
+        tolerance: CGFloat = MenuBarPanelPlacement.moveTolerance
+    ) -> Step {
+        // Nothing has been laid out yet. Sizing a window to zero is worse than leaving it alone.
+        guard contentHeight > 0 else { return .none }
+
+        let target = frame(
+            forHeight: contentHeight,
+            x: window.minX,
+            top: anchorTop,
+            width: window.width,
+            in: visible
+        )
+
+        // Reduce Motion is checked before anything else, including an animation already running:
+        // "never animate" has to mean never, and a setting switched on mid-flight should land the
+        // panel rather than finish the movement it asked not to see.
+        guard animates else {
+            return same(window, target, tolerance: tolerance) ? .none : .set(target)
+        }
+
+        // A resize arriving mid-animation. Two of these are common: a fast double tab switch, and
+        // the Volume Mixer's list of playing apps changing height on its own inside the 150ms.
+        if let inFlightTo {
+            // Already on its way to this height — a repeat report, not a new destination.
+            if abs(inFlightTo.height - contentHeight) <= tolerance { return .none }
+            // A genuinely new destination. Start from wherever the window has got to, not from
+            // the height this animation began at, or the panel jumps backwards before setting off.
+            return .animate(from: window, to: target)
+        }
+
+        // The first placement of a presentation. The panel must appear at its size: the system has
+        // its own opening animation, and growing into place on top of that reads as a stutter.
+        guard settledHeight > tolerance else {
+            return same(window, target, tolerance: tolerance) ? .none : .set(target)
+        }
+
+        // The content did not change height, so any difference is drift — a stale origin, a
+        // rounding residue, a display change. Correct it, but do not perform it: animation is how
+        // this panel says "the content changed", and spending it on a 1pt correction is noise.
+        if abs(settledHeight - contentHeight) <= tolerance {
+            return same(window, target, tolerance: tolerance) ? .none : .set(target)
+        }
+
+        // A **shrink** snaps. Measured, and it is a difference in what there is to look at
+        // rather than in the frames: an animated grow reveals the new content as the window opens
+        // over it, and an animated shrink has nothing to reveal — the content is already short and
+        // pinned to the top, so all that moves is the bottom edge travelling up through empty
+        // panel material. Instrumented, shrinks also came off worse than grows on their own terms:
+        // one lost 64% of its travel in a single step and ran in 118ms rather than 250, another
+        // stalled 50ms mid-run, where every grow stayed inside 15% and 17ms.
+        //
+        // Snapping it is not a consolation prize. The window and the content agree on height
+        // immediately, which is the state this whole file exists to produce.
+        guard contentHeight > settledHeight else {
+            return same(window, target, tolerance: tolerance) ? .none : .set(target)
+        }
+
+        // A grow: the direction with something to show. The window opens downward over content
+        // that `TopPinnedContentView` is already holding at full height against the top edge, so
+        // the new panel is revealed rather than stretched.
+        let from = frame(
+            forHeight: settledHeight,
+            x: window.minX,
+            top: anchorTop,
+            width: window.width,
+            in: visible
+        )
+        return .animate(from: from, to: target)
+    }
+
+    /// Whether two frames are the same to within the tolerance a window move is worth.
+    static func same(_ a: CGRect, _ b: CGRect, tolerance: CGFloat = MenuBarPanelPlacement.moveTolerance) -> Bool {
+        abs(a.height - b.height) <= tolerance
+            && !MenuBarPanelPlacement.needsMove(from: a.origin, to: b.origin, tolerance: tolerance)
+    }
+}

--- a/Sources/Sarvkrit/UI/MenuBarView.swift
+++ b/Sources/Sarvkrit/UI/MenuBarView.swift
@@ -70,27 +70,25 @@ struct MenuBarView: View {
                 onHeight: { MenuBarWindowAnchor.shared.note(contentHeight: $0) }
             )
         )
-        // **Nothing here may animate this panel's height.** There used to be a `.standardMotion`
-        // per height-bearing value, on the theory that `MenuBarWindowAnchor` could follow the
-        // content through the animation. It does follow it, and SwiftUI overwrites the result:
-        // SwiftUI sizes this window from the content's *settled* height, so on a grow it jumps
-        // straight to the final height and re-asserts it on every content change, while the
-        // anchor drags it back to whatever height the animation is currently at. One instrumented
-        // Keyboard → Files switch, logged as `before -> after` window heights:
+        // **Nothing here may animate this panel's height.** The window animates; the content
+        // does not. `MenuBarWindowAnchor` owns the one and `TopPinnedContentView` holds the other
+        // still while it moves.
+        //
+        // There used to be a `.standardMotion` per height-bearing value, on the theory that the
+        // anchor could follow the content through a SwiftUI animation. It does follow it, and
+        // SwiftUI overwrites the result: SwiftUI sizes this window from the content's *settled*
+        // height, so on a grow it jumps straight to the final height and re-asserts it on every
+        // content change, while the anchor drags it back to whatever height the animation is at.
+        // One instrumented Keyboard → Files switch, logged as `before -> after` window heights:
         //
         //     533 -> 338   533 -> 341   341 -> 341   533 -> 343   343 -> 343   533 -> 345  …
         //
         // Twenty-five of those inside 150ms and 195pt of travel on the bottom edge — two writers,
-        // alternating. That is the panel "moving and resetting" as you change tabs.
+        // alternating, which is the panel "moving and resetting" as you change tabs. With the
+        // animation moved to the window there is one writer and one animation.
         //
-        // With the animation gone the content settles in one pass, SwiftUI asserts the height at
-        // most once, and the anchor's correction is a single step. The strip still animates its
-        // own selection pill in `TrayPanelStrip`, on a view of fixed height, so nothing there can
-        // move the panel's bottom edge.
-        //
-        // **Animating the resize is not simply missing here; it was tried and it is unreachable
-        // from inside `MenuBarExtra`.** See `MenuBarWindowProbe` for the two measurements that
-        // close it off.
+        // The strip still animates its own selection pill in `TrayPanelStrip`, on a view of fixed
+        // height, so nothing there can move the panel's bottom edge.
     }
 
     /// The whole strip. Features and General are built here rather than in `AppState` because they

--- a/Sources/Sarvkrit/UI/MenuBarWindowAnchor.swift
+++ b/Sources/Sarvkrit/UI/MenuBarWindowAnchor.swift
@@ -100,6 +100,8 @@ final class MenuBarWindowAnchor {
 
     /// Weak: the panel's window belongs to SwiftUI, and outliving it is not this object's business.
     private weak var window: NSWindow?
+    /// Keeps the content still while the window resizes around it. Weak for the same reason.
+    private weak var pinned: TopPinnedContentView?
     private var observers: [NSObjectProtocol] = []
 
     /// The top edge the system chose for this presentation. Captured when the panel appears and
@@ -120,6 +122,22 @@ final class MenuBarWindowAnchor {
     private var isAdjusting = false
     /// Set between a content report and the coalesced pass that acts on it.
     private var pinScheduled = false
+    /// The height the last completed step left the window at. `0` means this presentation has not
+    /// placed the panel yet, which is what stops it animating open.
+    private var settledHeight: CGFloat = 0
+    /// Where a running animation is heading, if one is running.
+    private var inFlightTo: CGRect?
+    /// Bumped per animation, so a superseded one's completion handler knows it no longer owns the
+    /// state. A `MenuBarExtra` panel is reused for the life of the app, so state stuck here does
+    /// not clear itself.
+    private var generation = 0
+
+    private func reset() {
+        generation += 1
+        inFlightTo = nil
+        isAdjusting = false
+        settledHeight = 0
+    }
 
     private init() {}
 
@@ -131,8 +149,13 @@ final class MenuBarWindowAnchor {
         observers.removeAll()
         self.window = window
         anchorTop = nil
+        reset()
 
         guard let window else { return }
+
+        // Interposed once, before anything is measured or moved. Without it an animated resize
+        // shows half its own height difference as blank space above the content.
+        pinned = TopPinnedContentView.install(in: window)
 
         observe(NSWindow.didChangeOcclusionStateNotification, on: window) { [weak self] in
             guard let self, let window = self.window else { return }
@@ -141,6 +164,7 @@ final class MenuBarWindowAnchor {
                 self.pin()
             } else {
                 self.anchorTop = nil
+                self.reset()
             }
         }
         // A second chance to capture, for the presentation where the occlusion notification lands
@@ -153,10 +177,16 @@ final class MenuBarWindowAnchor {
         // would throw away the one number worth keeping.
         observe(NSWindow.willCloseNotification, on: window) { [weak self] in
             self?.anchorTop = nil
+            self?.reset()
         }
         // Growth still arrives this way. Cheap to honour, and it keeps the two paths in agreement.
         observe(NSWindow.didResizeNotification, on: window) { [weak self] in
-            self?.pin()
+            // Ignored while we are the ones resizing: an animated resize posts one of these per
+            // frame, and every one would otherwise re-enter and re-decide. To see those frames —
+            // the only way to tell whether the window actually moved smoothly, since no test can
+            // watch a window animate — log `window.frame` here.
+            guard let self, !self.isAdjusting else { return }
+            self.pin()
         }
 
         captureAnchor()
@@ -172,14 +202,23 @@ final class MenuBarWindowAnchor {
     func note(contentHeight height: CGFloat) {
         guard abs(height - contentHeight) > MenuBarPanelPlacement.moveTolerance else { return }
         contentHeight = height
+        // The container lays the content out at this height, not at the window's — during a
+        // resize those differ on purpose.
+        pinned?.contentHeight = height
 
+        // Acted on **now**, inside the probe's layout pass, and not deferred to the next runloop
+        // turn. On a grow SwiftUI has already resized the window to the settled height by the time
+        // this arrives, and a turn's delay is long enough for that frame to be drawn: the panel
+        // visibly snaps to full size and then animates from the top again.
+        //
+        // Resizing from inside `layout()` is only safe because of `TopPinnedContentView`. The
+        // content's height no longer depends on the window's, so the re-entrant layout this
+        // provokes measures the same height and returns at the tolerance check above. `pinScheduled`
+        // is the guard that makes that terminate rather than a promise to run later.
         guard !pinScheduled else { return }
         pinScheduled = true
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.pinScheduled = false
-            self.pin()
-        }
+        pin()
+        pinScheduled = false
     }
 
     private func observe(
@@ -204,36 +243,103 @@ final class MenuBarWindowAnchor {
         anchorTop = top
     }
 
+    /// Decide, then do. Every judgement lives in `MenuBarPanelResize`; this half owns only the
+    /// AppKit calls and the bookkeeping an animation needs.
     private func pin() {
-        guard !isAdjusting, contentHeight > 0, let window, window.isVisible,
+        guard let window, window.isVisible,
               let visible = screen(for: window)?.visibleFrame else { return }
 
-        let current = window.frame
-        let size = CGSize(width: current.width, height: contentHeight)
-        let origin = MenuBarPanelPlacement.origin(
-            forHeight: contentHeight,
-            x: current.minX,
-            top: anchorTop ?? visible.maxY,
-            width: size.width,
-            in: visible
+        apply(
+            MenuBarPanelResize.step(
+                window: window.frame,
+                settledHeight: settledHeight,
+                contentHeight: contentHeight,
+                inFlightTo: inFlightTo,
+                anchorTop: anchorTop ?? visible.maxY,
+                visible: visible,
+                // Read here, once, at the moment of deciding. Not the thing `Tokens.swift` warns
+                // against: that warning is about reading it in a `View` body, where the value is
+                // captured in a render and never updates again.
+                animates: !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+            ),
+            to: window
         )
+    }
 
-        guard abs(current.height - size.height) > MenuBarPanelPlacement.moveTolerance
-                || MenuBarPanelPlacement.needsMove(from: current.origin, to: origin) else { return }
+    private func apply(_ step: MenuBarPanelResize.Step, to window: NSWindow) {
+        switch step {
+        case .none:
+            return
 
-        // One `setFrame`, not `setContentSize` followed by `setFrameTopLeftPoint` the way
-        // `ClipboardPickerController.resize(to:)` does it. That panel opens at the cursor and is
-        // never visibly wrong in between; here the in-between state — the new short height still
-        // sitting on the old bottom-left origin — is precisely the bug, and it would flash.
-        isAdjusting = true
-        window.setFrame(NSRect(origin: origin, size: size), display: true)
-        isAdjusting = false
+        case .set(let frame):
+            // One `setFrame`, not `setContentSize` followed by `setFrameTopLeftPoint` the way
+            // `ClipboardPickerController.resize(to:)` does it. That panel opens at the cursor and
+            // is never visibly wrong in between; here the in-between state — the new short height
+            // still sitting on the old bottom-left origin — is precisely the bug, and it would
+            // flash.
+            let before = window.frame
+            isAdjusting = true
+            window.setFrame(frame, display: true)
+            isAdjusting = false
+            settledHeight = frame.height
+            inFlightTo = nil
+            log.debug("""
+                set \(NSStringFromRect(before), privacy: .public) -> \
+                \(NSStringFromRect(window.frame), privacy: .public) \
+                anchorTop=\(self.anchorTop ?? -1, privacy: .public)
+                """)
 
-        log.debug("""
-            pinned \(NSStringFromRect(current), privacy: .public) -> \
-            \(NSStringFromRect(window.frame), privacy: .public) \
-            anchorTop=\(self.anchorTop ?? -1, privacy: .public)
-            """)
+        case .animate(let from, let to):
+            generation += 1
+            let generation = self.generation
+            isAdjusting = true
+            inFlightTo = to
+            // Recorded now rather than in the completion handler. A superseded animation's
+            // completion bails at the generation check, and if the baseline were only written
+            // there it would be left describing a height the panel has not been at for two
+            // switches — enough for the next correction to animate to a place it already is.
+            // Logged once as `350 350 363 363` followed by a second `animate 363 -> 350`.
+            settledHeight = to.height
+
+            // The rewind. On a grow SwiftUI has already jumped the window to the settled height by
+            // the time the content report arrives, so without this the animation starts at its own
+            // destination and there is nothing to see. `display: false` because this is not a
+            // frame anyone should be shown — it is where the animation begins, and the animation
+            // begins in the same call stack.
+            if !MenuBarPanelResize.same(window.frame, from) {
+                // `display: false` is not enough on its own — the frame still reaches the window
+                // server, and on a 195pt grow that is a visible flash of the panel at its old
+                // height. This holds the screen until the animation's first frame is in.
+                window.disableScreenUpdatesUntilFlush()
+                window.setFrame(from, display: false)
+            }
+
+            NSAnimationContext.runAnimationGroup({ context in
+                context.duration = Theme.Motion.panelResizeDuration
+                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                // The whole rect in one call, which is what holds the top edge still: the origin
+                // moves by Δy = −Δh, so y + h is constant at every step. Animating height and
+                // origin as separate properties would let rounding wobble the top edge.
+                window.animator().setFrame(to, display: true)
+            }, completionHandler: { [weak self] in
+                MainActor.assumeIsolated {
+                    // A newer switch may have started meanwhile; it owns the state now, and
+                    // clearing `isAdjusting` here would unguard its animation.
+                    guard let self, generation == self.generation else { return }
+                    self.isAdjusting = false
+                    self.inFlightTo = nil
+                    // One settling pass: absorbs sub-pixel residue and anything SwiftUI did to the
+                    // window while we were not listening.
+                    self.pin()
+                }
+            })
+
+            log.debug("""
+                animate \(from.height, privacy: .public) -> \(to.height, privacy: .public) \
+                top=\(to.maxY, privacy: .public) \
+                anchorTop=\(self.anchorTop ?? -1, privacy: .public)
+                """)
+        }
     }
 
     /// The screen holding the status item, which is the one the window is on — not

--- a/Sources/Sarvkrit/UI/TopPinnedContentView.swift
+++ b/Sources/Sarvkrit/UI/TopPinnedContentView.swift
@@ -1,0 +1,77 @@
+import AppKit
+
+/// Holds a window's real content view at its own natural height, against the top edge.
+///
+/// Exists for one reason: **`NSHostingView` centres its root when the view is taller than the
+/// root wants to be.** Measured, a 350pt SwiftUI root sat 92pt down inside a 533pt host — exactly
+/// half the difference. That is harmless while a window is always exactly as tall as its content,
+/// and it is the whole problem the moment one is animated, because an animated resize means the
+/// window and its content are different heights for every frame of it. Half the difference appears
+/// as a blank band above the content, or eats the header when the window is the shorter of the two.
+///
+/// The tempting fix is on the SwiftUI side — make the root fill its bounds and align it to the top.
+/// It cannot be done for a `MenuBarExtra` panel, which sizes *and positions* its own window from
+/// what the root will accept; see `MenuBarWindowProbe` for the two ways that fails. So the root is
+/// left exactly as SwiftUI wants it and this sits between it and the window instead: the window
+/// resizes, this view resizes with it, and the content inside simply does not move.
+///
+/// Sizing is forwarded rather than invented, so inserting this changes nothing about how big
+/// anyone thinks the window should be — only where the content sits inside it.
+final class TopPinnedContentView: NSView {
+
+    /// The view this was interposed in front of — the window's original content view.
+    private(set) var content: NSView?
+
+    /// The height `content` is laid out at, independent of how tall this view currently is.
+    ///
+    /// Set from the same measurement that drives the window's height, rather than read back from
+    /// the content: during a resize the two disagree on purpose, and asking the content how tall
+    /// it is mid-animation is how the disagreement leaks back in.
+    var contentHeight: CGFloat = 0 {
+        didSet {
+            guard abs(contentHeight - oldValue) > 0.5 else { return }
+            needsLayout = true
+        }
+    }
+
+    /// Interposes a new instance between `window` and its current content view, once.
+    ///
+    /// Returns the existing one if it is already installed, so this is safe to call on every pass
+    /// through the probe's `viewDidMoveToWindow`.
+    @discardableResult
+    static func install(in window: NSWindow) -> TopPinnedContentView? {
+        if let existing = window.contentView as? TopPinnedContentView { return existing }
+        guard let content = window.contentView else { return nil }
+
+        let container = TopPinnedContentView(frame: content.frame)
+        container.autoresizingMask = [.width, .height]
+        // Order matters: taking the content view off the window first would let AppKit install a
+        // fresh empty one and resize the old view on the way out.
+        window.contentView = container
+        container.addSubview(content)
+        container.content = content
+        container.contentHeight = content.fittingSize.height
+        return container
+    }
+
+    override func layout() {
+        super.layout()
+        guard let content else { return }
+
+        // Never taller than the window, or a grow would draw content above the title area; never
+        // shorter than what it was measured at, or the content squeezes as the window animates.
+        let height = contentHeight > 0 ? contentHeight : bounds.height
+        content.frame = NSRect(
+            x: 0,
+            // AppKit's origin is bottom-left, so "pinned to the top" is an origin that moves.
+            y: isFlipped ? 0 : bounds.height - height,
+            width: bounds.width,
+            height: height
+        )
+    }
+
+    /// Forwarded, so interposing this cannot change anyone's idea of how big the window should be.
+    override var fittingSize: NSSize { content?.fittingSize ?? super.fittingSize }
+    override var intrinsicContentSize: NSSize { content?.intrinsicContentSize ?? super.intrinsicContentSize }
+    override func hitTest(_ point: NSPoint) -> NSView? { content?.hitTest(point) }
+}

--- a/Tests/SarvkritTests/MenuBarPanelResizeTests.swift
+++ b/Tests/SarvkritTests/MenuBarPanelResizeTests.swift
@@ -1,0 +1,198 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// When the tray panel animates its height, and between which frames.
+///
+/// Pure, for the reason `MenuBarPanelPlacementTests` gives about position and this file needs
+/// about timing: a resize landing mid-animation, the first placement of a presentation, and
+/// Reduce Motion are states you cannot hold a panel in long enough to look at.
+final class MenuBarPanelResizeTests: XCTestCase {
+    private let visible = CGRect(x: 0, y: 0, width: 1600, height: 1000)
+    private let width: CGFloat = 420
+    private let anchorTop: CGFloat = 947
+    private let x: CGFloat = 731
+
+    /// The frame the window has when it is `height` tall and correctly anchored.
+    private func anchored(_ height: CGFloat) -> CGRect {
+        MenuBarPanelResize.frame(
+            forHeight: height, x: x, top: anchorTop, width: width, in: visible)
+    }
+
+    private func step(
+        window: CGRect,
+        settled: CGFloat,
+        content: CGFloat,
+        inFlightTo: CGRect? = nil,
+        animates: Bool = true
+    ) -> MenuBarPanelResize.Step {
+        MenuBarPanelResize.step(
+            window: window, settledHeight: settled, contentHeight: content,
+            inFlightTo: inFlightTo, anchorTop: anchorTop, visible: visible, animates: animates)
+    }
+
+    // MARK: - The bug
+
+    func testAGrowAnimatesFromTheHeightItHadNotFromTheOneSwiftUIJumpedTo() throws {
+        // The reported bug, in numbers. Measured on a Keyboard → Files switch: the content went
+        // 338 → 533, and SwiftUI had already set the window to 533 before the first content report
+        // arrived. Animating from *there* is a zero-length animation, and the old code's answer —
+        // dragging the window down to whatever height the content animation was currently at, ~25
+        // times in 150ms — is the 195pt flicker the user was reporting.
+        let step = step(window: anchored(533), settled: 338, content: 533)
+
+        guard case .animate(let from, let to) = step else {
+            return XCTFail("a content-height change is the one thing worth animating, got \(step)")
+        }
+        XCTAssertEqual(from.height, 338, "the animation started where SwiftUI jumped to, not where the panel was")
+        XCTAssertEqual(to.height, 533)
+    }
+
+    func testEveryMeasuredGrowKeepsTheTopEdgeStillForTheWholeAnimation() throws {
+        // `from.maxY == to.maxY` is what makes the top edge stay put: interpolating the whole rect
+        // moves the origin by Δy = −Δh, so y(t) + h(t) is constant. If these ever disagreed the
+        // panel would slide during the resize however smooth the resize itself was.
+        for pair in [(286, 338), (338, 533), (351, 533)] as [(CGFloat, CGFloat)] {
+            let step = step(window: anchored(pair.0), settled: pair.0, content: pair.1)
+            guard case .animate(let from, let to) = step else {
+                return XCTFail("\(pair.0) -> \(pair.1) did not animate, got \(step)")
+            }
+            XCTAssertEqual(from.height, pair.0, "\(pair)")
+            XCTAssertEqual(to.height, pair.1, "\(pair)")
+            XCTAssertEqual(from.maxY, anchorTop, "\(pair) starts off the anchor")
+            XCTAssertEqual(to.maxY, anchorTop, "\(pair) ends off the anchor")
+        }
+    }
+
+    func testEveryMeasuredShrinkSnaps() {
+        // A shrink has nothing to reveal — the content is already short and against the top edge,
+        // so an animation only drags the bottom edge up through empty material. Snapping puts the
+        // window and its content in agreement immediately.
+        for pair in [(533, 351), (400, 300), (338, 286)] as [(CGFloat, CGFloat)] {
+            XCTAssertEqual(
+                step(window: anchored(pair.0), settled: pair.0, content: pair.1),
+                .set(anchored(pair.1)), "\(pair)")
+        }
+    }
+
+    func testAGrowRewindsPastTheHeightSwiftUIAlreadyJumpedTo() throws {
+        // The asymmetry the whole design turns on: SwiftUI resizes this window on a grow and does
+        // nothing at all on a shrink. So on a grow the window is *already* at the destination when
+        // this runs, and the animation has to be given somewhere to start from.
+        let step = step(window: anchored(533), settled: 338, content: 533)
+
+        guard case .animate(let from, let to) = step else { return XCTFail("expected an animation") }
+        XCTAssertEqual(from.height, 338, "the rewind is what makes a grow visible at all")
+        XCTAssertEqual(to.height, 533)
+    }
+
+    // MARK: - Not animating
+
+    func testReduceMotionSnapsAndNeverAnimates() {
+        // A shrink, because that is where Reduce Motion has work to do: SwiftUI does not resize on
+        // a shrink, so the window is still 533 tall around 351pt of content and something has to
+        // move it. On a grow SwiftUI has already jumped the window to the settled height, so the
+        // honest answer there is `.none` — the panel is the right size, just not because of us.
+        XCTAssertEqual(
+            step(window: anchored(533), settled: 533, content: 351, animates: false),
+            .set(anchored(351)))
+        XCTAssertEqual(
+            step(window: anchored(533), settled: 338, content: 533, animates: false),
+            .none)
+
+        // Whatever the direction, it must never be an animation.
+        for pair in [(286, 338), (338, 533), (533, 351), (400, 300)] as [(CGFloat, CGFloat)] {
+            let step = step(window: anchored(pair.0), settled: pair.0, content: pair.1, animates: false)
+            if case .animate = step { XCTFail("\(pair) animated with Reduce Motion on") }
+        }
+    }
+
+    func testReduceMotionSwitchedOnMidAnimationLandsThePanelRatherThanFinishingTheMove() {
+        // Checked before the in-flight case on purpose: "never animate" has to mean never, and
+        // finishing a movement the user has just asked not to see is the wrong reading.
+        XCTAssertEqual(
+            step(window: anchored(400), settled: 338, content: 533,
+                 inFlightTo: anchored(533), animates: false),
+            .set(anchored(533)))
+    }
+
+    func testTheFirstPlacementOfAPresentationDoesNotAnimate() {
+        // The panel must appear at its size. `MenuBarExtra` has its own opening animation, and
+        // growing into place on top of it reads as a stutter rather than as motion.
+        XCTAssertEqual(
+            step(window: CGRect(x: x, y: 0, width: width, height: 100), settled: 0, content: 533),
+            .set(anchored(533)))
+    }
+
+    func testDriftIsCorrectedButNotPerformed() {
+        // The content height did not change, so whatever moved the window was not the user doing
+        // anything. Animation is how this panel says "the content changed"; spending it on a
+        // stale origin would be motion that explains nothing.
+        let drifted = CGRect(x: x, y: anchorTop - 533 - 40, width: width, height: 533)
+        XCTAssertEqual(step(window: drifted, settled: 533, content: 533), .set(anchored(533)))
+    }
+
+    func testAPanelAlreadyWhereItBelongsIsLeftAlone() {
+        XCTAssertEqual(step(window: anchored(533), settled: 533, content: 533), .none)
+    }
+
+    func testNothingHappensBeforeTheContentHasBeenLaidOut() {
+        // Sizing a window to zero is worse than leaving it at whatever the system chose.
+        XCTAssertEqual(step(window: anchored(533), settled: 533, content: 0), .none)
+    }
+
+    func testASubPixelContentChangeIsNotWorthAnAnimation() {
+        XCTAssertEqual(step(window: anchored(533), settled: 533, content: 533.3), .none)
+    }
+
+    // MARK: - A resize arriving mid-animation
+
+    func testARepeatedReportOfTheHeightAlreadyBeingAnimatedToIsIgnored() {
+        // The animation generates ~50 resize notifications of its own and the probe lays out
+        // repeatedly; without this the panel would restart its animation on every frame and never
+        // arrive.
+        XCTAssertEqual(
+            step(window: anchored(400), settled: 338, content: 533, inFlightTo: anchored(533)),
+            .none)
+    }
+
+    func testANewDestinationMidAnimationRestartsFromWhereTheWindowHasGotTo() throws {
+        // A fast double tab switch, or the Volume Mixer's app list changing height inside the
+        // 150ms. Starting again from the height the first animation began at would jump the panel
+        // backwards before setting off.
+        let midFlight = anchored(400)
+        let step = step(window: midFlight, settled: 338, content: 620, inFlightTo: anchored(533))
+
+        guard case .animate(let from, let to) = step else { return XCTFail("expected an animation") }
+        XCTAssertTrue(MenuBarPanelResize.same(from, midFlight),
+                      "the new animation should start from the window's current frame")
+        XCTAssertEqual(to.height, 620)
+        XCTAssertEqual(from.maxY, anchorTop)
+        XCTAssertEqual(to.maxY, anchorTop)
+    }
+
+    func testTheVolumeMixerGainingARowAnimatesLikeAnyOtherGrow() throws {
+        // `VolumeMixerTrayView` is one row per app making sound, so the panel changes height while
+        // it is open and nobody has touched it. An app starting to play grows the panel and
+        // animates; one stopping snaps, like every other shrink.
+        let row = Theme.Metrics.panelRowHeight
+        guard case .animate(let from, let to) = step(window: anchored(533), settled: 533, content: 533 + row)
+        else { return XCTFail("expected an animation") }
+        XCTAssertEqual(from.height, 533)
+        XCTAssertEqual(to.height, 533 + row)
+
+        XCTAssertEqual(step(window: anchored(533), settled: 533, content: 533 - row),
+                       .set(anchored(533 - row)), "an app stopping is a shrink, and shrinks snap")
+    }
+
+    // MARK: - Position is still `MenuBarPanelPlacement`'s answer
+
+    func testATallPanelStillOverflowsTheBottomRatherThanLiftingOffItsIcon() {
+        // Deferred entirely to `MenuBarPanelPlacement`, and asserted here so that adding a resize
+        // animation cannot quietly introduce a lower clamp of its own.
+        let frame = MenuBarPanelResize.frame(
+            forHeight: 1200, x: x, top: anchorTop, width: width, in: visible)
+        XCTAssertEqual(frame.maxY, anchorTop)
+        XCTAssertLessThan(frame.minY, visible.minY)
+    }
+}

--- a/Tests/SarvkritTests/TopPinnedContentViewTests.swift
+++ b/Tests/SarvkritTests/TopPinnedContentViewTests.swift
@@ -1,0 +1,117 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Sarvkrit
+
+/// The one thing standing between an animated panel resize and the bug it used to be.
+///
+/// These use a real `NSPanel` with a real `NSHostingView`, parked far off any screen the way
+/// `TrayPanelRenderTests` does, because the behaviour under test is `NSHostingView`'s own layout
+/// and a windowless view does not perform it.
+@MainActor
+final class TopPinnedContentViewTests: XCTestCase {
+
+    private let contentHeight: CGFloat = 350
+    private let width: CGFloat = 420
+
+    /// A `MenuBarWindowProbe` stands in for the content, because it is a real `NSView` whose
+    /// position can be read. A SwiftUI `Color` leaves no backing view to measure.
+    private func panel(height: CGFloat) -> NSPanel {
+        let panel = NSPanel(
+            contentRect: NSRect(x: -30000, y: -30000, width: width, height: height),
+            styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
+        panel.contentView = NSHostingView(
+            rootView: VStack(spacing: 0) { Color.clear.frame(height: contentHeight) }
+                .frame(width: width)
+                .background(MenuBarWindowProbe(onWindow: { _ in }, onHeight: { _ in })))
+        return panel
+    }
+
+    private func marker(in view: NSView) -> NSView? {
+        if view is MenuBarWindowProbe.ProbeView { return view }
+        for sub in view.subviews { if let found = marker(in: sub) { return found } }
+        return nil
+    }
+
+    private func topInset(of view: NSView, in container: NSView) -> CGFloat {
+        let f = view.convert(view.bounds, to: container)
+        return container.isFlipped ? f.minY - container.bounds.minY : container.bounds.maxY - f.maxY
+    }
+
+    // MARK: - The behaviour that makes an animated resize impossible without this
+
+    func testWithoutTheContainerAHostingViewCentresItsRoot() throws {
+        // Not a test of our code — a test of the premise, so that if a future macOS stops centring,
+        // this fails and tells you the container can go.
+        let panel = self.panel(height: 533)
+        defer { panel.close() }
+        let host = try XCTUnwrap(panel.contentView)
+        host.layoutSubtreeIfNeeded()
+
+        let root = try XCTUnwrap(marker(in: host))
+        XCTAssertEqual(topInset(of: root, in: host), (533 - contentHeight) / 2, accuracy: 1,
+                       "expected the root centred, which is what the container exists to prevent")
+    }
+
+    // MARK: - What the container promises
+
+    func testTheContentStaysAgainstTheTopEdgeWhateverTheWindowDoes() throws {
+        let panel = self.panel(height: 533)
+        defer { panel.close() }
+        let container = try XCTUnwrap(TopPinnedContentView.install(in: panel))
+        container.contentHeight = contentHeight
+
+        // Every height an animated 533 -> 350 shrink passes through, and the grow back up.
+        for height in [533, 500, 450, 400, 350, 300, 400, 533] as [CGFloat] {
+            panel.setFrame(NSRect(x: -30000, y: -30000, width: width, height: height), display: false)
+            panel.layoutIfNeeded()
+            container.layoutSubtreeIfNeeded()
+
+            let content = try XCTUnwrap(container.content)
+            XCTAssertEqual(topInset(of: content, in: container), 0, accuracy: 0.5,
+                           "content moved off the top edge at window height \(height)")
+            XCTAssertEqual(content.frame.height, contentHeight, accuracy: 0.5,
+                           "content was resized by the window at height \(height)")
+        }
+    }
+
+    func testInstallingItChangesNobodysIdeaOfHowBigTheWindowShouldBe() throws {
+        // `MenuBarExtra` sizes and positions its own window from the content view. If interposing
+        // this changed `fittingSize`, it would break the panel exactly as the SwiftUI-side
+        // attempts did.
+        let panel = self.panel(height: 533)
+        defer { panel.close() }
+        let before = try XCTUnwrap(panel.contentView).fittingSize
+
+        let container = try XCTUnwrap(TopPinnedContentView.install(in: panel))
+        XCTAssertEqual(container.fittingSize.height, before.height, accuracy: 0.5)
+        XCTAssertEqual(container.fittingSize.width, before.width, accuracy: 0.5)
+    }
+
+    func testInstallingIsIdempotent() throws {
+        // The probe reports its window on every pass through `viewDidMoveToWindow`, so this is
+        // called repeatedly; nesting a container inside a container would add an untracked view
+        // per presentation.
+        let panel = self.panel(height: 533)
+        defer { panel.close() }
+        let first = try XCTUnwrap(TopPinnedContentView.install(in: panel))
+        let second = try XCTUnwrap(TopPinnedContentView.install(in: panel))
+
+        XCTAssertTrue(first === second)
+        XCTAssertEqual(first.subviews.count, 1)
+    }
+
+    func testTheContentKeepsTakingClicks() throws {
+        // The panel is full of live switches. A container that swallowed a click would be worse
+        // than the drift it removes.
+        let panel = self.panel(height: 533)
+        defer { panel.close() }
+        let container = try XCTUnwrap(TopPinnedContentView.install(in: panel))
+        container.contentHeight = contentHeight
+        container.layoutSubtreeIfNeeded()
+
+        let hit = container.hitTest(NSPoint(x: width / 2, y: container.bounds.midY))
+        XCTAssertNotNil(hit, "clicks stopped reaching the content")
+        XCTAssertFalse(hit === container, "the container took the click itself")
+    }
+}


### PR DESCRIPTION
Follows #17, which removed the fight over the panel's height but left the resize as a snap. This animates the growing direction: switching to a panel that needs more room now opens the window over the new content instead of jumping to it.

## The blocker was never the animation

`NSHostingView` **centres** its root when the view is taller than the root wants to be — measured, a 350pt root sitting 92pt down inside a 533pt host, exactly half the difference. An animated resize means the window and its content are different heights for every frame of it, so half the difference showed up as a blank band above the content, or ate the header when the window was the shorter of the two.

That can't be fixed from the SwiftUI side here, because `MenuBarExtra` sizes **and positions** its own window from what the root will accept:

| Attempt | Result |
|---|---|
| `.frame(minHeight: 0, maxHeight: .infinity, alignment: .top)` | Panel created **10pt tall** and placed as such — opened mid-screen with content hanging outside the material. An explicit `idealHeight` didn't help, so the size comes from the *minimum*. |
| `.frame(maxHeight: .infinity, alignment: .top)` | Created at the right size, but SwiftUI then settled on a height the probe disagreed with and re-asserted it indefinitely — the window held at 400pt around 363pt of content, corrected and undone every couple of seconds. |

Neither shows up in a `fittingSize` test, because the *ideal* height is right in both.

## So the root is left alone and the fix moves to AppKit

`TopPinnedContentView` is interposed between the window and its content view. The window resizes, the container resizes with it, and the content inside keeps its own height against the top edge. Sizing is forwarded, so interposing it changes nobody's idea of how big the window should be — the exact property both SwiftUI-side attempts broke.

Its tests use a real `NSPanel` and a real `NSHostingView`, including one that asserts the centring itself, so if a future macOS stops doing it the container can go.

## Only grows animate

A shrink has nothing to reveal — the content is already short and against the top edge, so all that moves is the bottom edge travelling up through empty material. Instrumented, shrinks were also worse on their own terms: one lost **64%** of its travel in a single step and ran in 118ms rather than 250, another stalled 50ms mid-run, where every grow stayed inside 15% and 17ms. A shrink now snaps, which puts the window and its content in agreement immediately.

## Three things the instrumentation caught

- `note(contentHeight:)` acts inside the probe's layout pass rather than deferring a runloop turn. On a grow SwiftUI has already resized the window by the time it arrives, and a turn's delay was long enough for that frame to be *drawn* — the panel snapped to full size, then animated from the top again. Resizing from `layout()` is only safe because the container means the measured height no longer depends on the window's.
- The settled height is recorded when an animation **starts**, not when it finishes. A superseded animation's completion bails at the generation check, and the baseline was being left two switches stale — logged as `350 350 363 363` followed by a second `animate 363 -> 350`.
- `Theme.Motion.panelResizeDuration` is 0.25s. The app-wide 0.15s over 195pt is ~1200pt/s, which reads as a blurry jump rather than movement.

`isAdjusting` now spans the whole animation rather than a single `setFrame`; the observers deliver on the main operation queue, a runloop turn later, so a synchronously-cleared flag guarded nothing.

## How I checked it

`/usr/bin/log stream --level debug --predicate 'subsystem == "ai.psylief.sarvkrit" AND category == "TrayPanel"'` on a release build, logging `window.frame` on every `didResize` during an animation — the only way to see whether a window actually moved smoothly. Frames ramp monotonically (`338 → 368 → 376 → … → 533`, deltas 8→11→2) with `y + h == 947` throughout, and one decision per switch.

`make test` — 1486 tests. One failure, `MenuBarLabelRenderTests.testTheLabelLaysOutWithLiveReadings`, which fails identically on clean `main` and passes on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7SzrctuRiWyegmsivFfKg