### PR TITLE
Let people install Sarvkrit with Homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DIST_DIR   := dist
 DEST       := -destination 'platform=macOS,arch=arm64'
 RELEASE_APP := $(BUILD_DIR)/Build/Products/Release/$(APP).app
 
-.PHONY: all generate build debug test preview run dmg notarize release install uninstall clean
+.PHONY: all generate build debug test preview run dmg notarize release tap install uninstall clean
 
 all: build
 
@@ -59,7 +59,16 @@ dmg: build
 notarize:
 	./scripts/notarize.sh $(DIST_DIR)/$(APP).dmg
 
-## Cuts a GitHub release from a commit already on main: build, notarize, tag, publish.
+## Points the Homebrew cask at a release that is already published, hashing the DMG GitHub is
+## serving rather than the one in dist/. `make release` runs this itself; it is a separate target
+## because a release cannot be un-published, so when the tap push is the thing that failed, this
+## is the whole recovery.
+##   make tap VERSION=1.1.1
+tap:
+	./scripts/update-tap.sh $(VERSION)
+
+## Cuts a GitHub release from a commit already on main: build, notarize, tag, publish, and point
+## the Homebrew cask at it.
 ## Notarization is the gate — nothing is tagged or uploaded if Gatekeeper would still block it.
 ##   make release VERSION=1.1.1
 ##

--- a/README.md
+++ b/README.md
@@ -43,6 +43,31 @@ before you run it: <https://sarvkrit.com/install> is the script, served as plain
 already have the DMG, `xattr -dr com.apple.quarantine /Applications/Sarvkrit.app` is the same idea
 by hand.
 
+### Homebrew
+
+```sh
+brew install --cask sadana-psylief/tap/sarvkrit
+```
+
+Already have Sarvkrit in `/Applications`? Homebrew refuses to write over an app it did not install,
+so adopt the existing copy instead — `brew install --cask --adopt sadana-psylief/tap/sarvkrit` —
+and `brew upgrade --cask sarvkrit` from then on.
+
+<!-- TODO(notarize): drop the paragraph below, and the postflight_steps block in the tap's
+     Casks/sarvkrit.rb that it describes, once `make notarize` has run for real. -->
+
+Homebrew quarantines everything it downloads and removed the `--no-quarantine` escape hatch in 5.1,
+so an un-notarized cask installed the ordinary way walks straight back into step 2 above. The cask
+therefore strips the attribute itself after installing, and leans on its pinned `sha256` to
+guarantee it installed the bytes that were published — the same trade the install script makes when
+it checks the signature by hand. It is not equivalent to notarization: it swaps Apple's trust root
+for a hash published by the same repo as the DMG. The DMG route above is the one that keeps
+Gatekeeper's own check.
+
+The cask lives in [sadana-psylief/homebrew-tap](https://github.com/sadana-psylief/homebrew-tap),
+not `homebrew/cask` — the official tap audits with `gktool scan` and no longer accepts un-notarized
+apps. `scripts/update-tap.sh` keeps it in step with each release; see **Releasing** below.
+
 Sarvkrit lives in the menu bar and has no Dock icon until you open its window.
 
 ---
@@ -556,6 +581,17 @@ make release VERSION=1.1.1 RELEASE_ARGS=--allow-unnotarized
 
 which also insists the notes tell people about the **Open Anyway** detour they will hit.
 
+`release.sh` finishes by running `scripts/update-tap.sh`, which downloads the DMG GitHub is now
+serving, hashes it, and rewrites `version` and `sha256` in
+[sadana-psylief/homebrew-tap](https://github.com/sadana-psylief/homebrew-tap). It hashes the
+published asset rather than `dist/Sarvkrit.dmg` so the cask can only ever promise what users
+actually receive. A release cannot be un-published, so a failure there is reported rather than
+fatal — the release stands and Homebrew users sit one version behind until you re-run:
+
+```bash
+make tap VERSION=1.1.1
+```
+
 Because `sarvkrit.com/download` and GitHub's own "latest" link both resolve through
 `releases/latest/download/Sarvkrit.dmg`, a new release is picked up with no change on the site.
 The site's own copy — the version it prints, the feature list — is a separate change in
@@ -605,11 +641,15 @@ why the install section above has a step 2 at all.
    passing on both the app and the DMG. Cut a new version rather than replacing the v1.0 asset:
    the v1.0 notes publish that DMG's sha256 under *Verifying the download*, so clobbering the
    asset in place would make the published hash a lie.
-6. Grep both repos for the marker `TODO` + `(notarize)` and delete what it finds: the install
-   step 2 above, step 2 of `INSTALL_STEPS`, the `OpenAnywayMock` illustration and its `.ctx-*`
-   rules in `index.css`. This runbook is a hit too and stays — it is the instruction, not the
-   thing being removed. Then fix step 2 of the v1.0 release notes, which still describes the
-   Gatekeeper detour.
+6. Grep **all three** repos for the marker `TODO` + `(notarize)` and delete what it finds: the
+   install step 2 above, step 2 of `INSTALL_STEPS`, the `OpenAnywayMock` illustration and its
+   `.ctx-*` rules in `index.css`, and — in
+   [sadana-psylief/homebrew-tap](https://github.com/sadana-psylief/homebrew-tap) — the
+   `postflight_steps` block in `Casks/sarvkrit.rb`, which is only stripping the quarantine
+   attribute because the DMG is not notarized. Once it is, Homebrew's own quarantine is exactly
+   what should be left in place, and the cask becomes an ordinary one. This runbook is a hit too
+   and stays — it is the instruction, not the thing being removed. Then fix step 2 of the v1.0
+   release notes, which still describes the Gatekeeper detour.
 
 **The Team ID will almost certainly change.** `77A36893HP` is a *free personal team* — Xcode's own
 record says `isFreeProvisioningTeam = true`, `teamType = Personal Team`, named "Tushar Sadana
@@ -661,7 +701,8 @@ that marketing a product as a practical substitute definitely competes.
 This is a **source-available** licence, not an open-source one. That distinction is deliberate: the
 OSI definition requires permitting competing derivative works, which is the one thing this licence
 withholds. Practically, that means GitHub won't show an open-source licence badge, Sarvkrit can't go
-into Homebrew core, and some people won't contribute to non-OSI projects. That's the cost of the
+into Homebrew core (formulae need an OSI licence; the cask above is unaffected), and some people
+won't contribute to non-OSI projects. That's the cost of the
 term, not an oversight.
 
 ### The name

--- a/README.md
+++ b/README.md
@@ -49,9 +49,23 @@ by hand.
 brew install --cask sadana-psylief/tap/sarvkrit
 ```
 
+The first install from this tap prints a tap-trust warning and asks you to confirm. That is
+Homebrew's default for anything outside its own repositories, not something specific to Sarvkrit.
+
 Already have Sarvkrit in `/Applications`? Homebrew refuses to write over an app it did not install,
-so adopt the existing copy instead — `brew install --cask --adopt sadana-psylief/tap/sarvkrit` —
-and `brew upgrade --cask sarvkrit` from then on.
+so hand the existing copy over with one of:
+
+```sh
+brew install --cask --force sadana-psylief/tap/sarvkrit    # any existing copy
+brew install --cask --adopt sadana-psylief/tap/sarvkrit    # only if it is already this version
+```
+
+`--adopt` keeps the bundle exactly where it is and just puts Homebrew in charge of it, but it
+compares `CFBundleShortVersionString` and `CFBundleVersion` first and refuses with *"the existing App
+is different"* if they don't match — so it works only when your copy is already the version the cask
+installs. `--force` replaces whatever is there and always works; settings live in `~/Library` and the
+Accessibility grant is keyed to the bundle ID, signature and path, none of which change. Either way
+it is `brew upgrade --cask sarvkrit` from then on.
 
 <!-- TODO(notarize): drop the paragraph below, and the postflight_steps block in the tap's
      Casks/sarvkrit.rb that it describes, once `make notarize` has run for real. -->

--- a/Sources/Sarvkrit/Core/InstallSource.swift
+++ b/Sources/Sarvkrit/Core/InstallSource.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// How the running copy of Sarvkrit got onto this Mac.
+///
+/// This exists for exactly one reason: the update notice hands the user a command, and handing a
+/// Homebrew user the `curl` command is actively harmful. The install script replaces
+/// `/Applications/Sarvkrit.app` wholesale, which leaves Homebrew's receipt pointing at a version
+/// that is no longer there — `brew upgrade` then has nothing to do, `brew uninstall` removes an
+/// app it no longer recognises, and the two installers quietly fight over the same bundle.
+enum InstallSource: Equatable {
+    case homebrew
+    case direct
+
+    /// Homebrew Cask *moves* the real bundle to the applications directory and leaves a symlink
+    /// behind in the Caskroom pointing back at it — the reverse of what you might expect, and the
+    /// reason a brew-installed Sarvkrit keeps its Accessibility grant like any other copy.
+    ///
+    /// That symlink is the signal. Its path carries the version Homebrew believes is installed, so
+    /// matching on the running bundle's own version is what stops a leftover Caskroom directory
+    /// from an older release reading as "brew manages this". Both prefixes are checked because
+    /// Homebrew lives at `/opt/homebrew` on Apple Silicon and `/usr/local` on Intel, and Sarvkrit
+    /// ships universal.
+    static func detect(
+        bundleURL: URL = Bundle.main.bundleURL,
+        version: String = Bundle.main.shortVersionString,
+        prefixes: [String] = ["/opt/homebrew", "/usr/local"],
+        fileManager: FileManager = .default
+    ) -> InstallSource {
+        let target = bundleURL.resolvingSymlinksInPath().standardizedFileURL
+        for prefix in prefixes {
+            let link = URL(fileURLWithPath: prefix)
+                .appendingPathComponent("Caskroom/sarvkrit")
+                .appendingPathComponent(version)
+                .appendingPathComponent("Sarvkrit.app")
+            guard fileManager.fileExists(atPath: link.path) else { continue }
+            if link.resolvingSymlinksInPath().standardizedFileURL == target { return .homebrew }
+        }
+        return .direct
+    }
+
+    /// What to tell the user to run to get the new version.
+    ///
+    /// The curl line is the default rather than the fallback: until the DMG is notarized it is the
+    /// only route that does not send people through System Settings → Privacy & Security on every
+    /// single update. The cask avoids that wall too, by stripping the quarantine attribute itself.
+    var updateCommand: String {
+        switch self {
+        case .homebrew: "brew upgrade --cask sarvkrit"
+        case .direct: "curl -fsSL https://sarvkrit.com/install | sh"
+        }
+    }
+}

--- a/Sources/Sarvkrit/UI/Shared/UpdateNoticeView.swift
+++ b/Sources/Sarvkrit/UI/Shared/UpdateNoticeView.swift
@@ -9,11 +9,19 @@ import SwiftUI
 /// Open Anyway" on *every* update. `curl` sets no quarantine attribute, so the install script
 /// never meets that wall — and it already checks the signature and the team itself, quits the
 /// running copy, and replaces the app in place.
+///
+/// Which command depends on how this copy was installed. Giving the curl line to someone who
+/// installed through Homebrew would have the script overwrite the bundle out from under the
+/// cask, so `InstallSource` decides; see the reasoning there.
 struct UpdateNoticeView: View {
     var release: LatestRelease
     var onSkip: () -> Void
 
-    static let installCommand = "curl -fsSL https://sarvkrit.com/install | sh"
+    /// Resolved once, at init, rather than on every render: it touches the filesystem, and the
+    /// answer cannot change while the app is running.
+    var source: InstallSource = .detect()
+
+    var installCommand: String { source.updateCommand }
 
     @State private var copied = false
 
@@ -44,7 +52,7 @@ struct UpdateNoticeView: View {
                 .foregroundStyle(.secondary)
 
             HStack(spacing: Theme.Space.sm) {
-                Text(Self.installCommand)
+                Text(installCommand)
                     .font(.system(.caption, design: .monospaced))
                     .textSelection(.enabled)
                     .lineLimit(1)
@@ -82,7 +90,7 @@ struct UpdateNoticeView: View {
         // A deliberate user action, so no nspasteboard.org "transient" marker: they asked for
         // this to be on the clipboard and it should behave like anything else they copied.
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(Self.installCommand, forType: .string)
+        NSPasteboard.general.setString(installCommand, forType: .string)
         copied = true
         ToastPresenter.shared.show("Copied", symbolName: "doc.on.doc")
     }

--- a/Tests/SarvkritTests/UpdateUIRenderTests.swift
+++ b/Tests/SarvkritTests/UpdateUIRenderTests.swift
@@ -104,6 +104,50 @@ final class UpdateUIRenderTests: XCTestCase {
     /// The command the notice hands over has to be exactly the one the README and the site
     /// document, character for character — it is the entire update path.
     func testInstallCommandIsTheDocumentedOne() {
-        XCTAssertEqual(UpdateNoticeView.installCommand, "curl -fsSL https://sarvkrit.com/install | sh")
+        XCTAssertEqual(InstallSource.direct.updateCommand, "curl -fsSL https://sarvkrit.com/install | sh")
+        XCTAssertEqual(InstallSource.homebrew.updateCommand, "brew upgrade --cask sarvkrit")
+    }
+
+    /// Detection has to key on the running bundle, not merely on Homebrew being present: plenty of
+    /// people have brew installed and Sarvkrit from the DMG, and telling them to `brew upgrade`
+    /// something brew has never heard of is a dead end.
+    func testHomebrewIsDetectedOnlyForTheBundleTheCaskroomPointsAt() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("InstallSourceTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let apps = root.appendingPathComponent("Applications")
+        let ours = apps.appendingPathComponent("Sarvkrit.app")
+        let someoneElses = apps.appendingPathComponent("Elsewhere/Sarvkrit.app")
+        try FileManager.default.createDirectory(at: ours, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: someoneElses, withIntermediateDirectories: true)
+
+        // Exactly the layout `brew install --cask` leaves behind: the real bundle in the
+        // applications directory, and a symlink to it under Caskroom/<token>/<version>.
+        let prefix = root.appendingPathComponent("opt/homebrew")
+        let caskroom = prefix.appendingPathComponent("Caskroom/sarvkrit/1.1.0")
+        try FileManager.default.createDirectory(at: caskroom, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: caskroom.appendingPathComponent("Sarvkrit.app"), withDestinationURL: ours)
+
+        XCTAssertEqual(
+            InstallSource.detect(bundleURL: ours, version: "1.1.0", prefixes: [prefix.path]),
+            .homebrew)
+
+        // A different bundle at the same version — brew manages a copy, but not this one.
+        XCTAssertEqual(
+            InstallSource.detect(bundleURL: someoneElses, version: "1.1.0", prefixes: [prefix.path]),
+            .direct)
+
+        // The right bundle, but the Caskroom entry is a leftover from an older release, so brew's
+        // record is stale and `brew upgrade` would be the wrong advice.
+        XCTAssertEqual(
+            InstallSource.detect(bundleURL: ours, version: "1.2.0", prefixes: [prefix.path]),
+            .direct)
+
+        // No Homebrew at all.
+        XCTAssertEqual(
+            InstallSource.detect(bundleURL: ours, version: "1.1.0", prefixes: []),
+            .direct)
     }
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -116,6 +116,16 @@ git push origin "$TAG"
 gh release create "$TAG" "$DMG" --title "Sarvkrit $VERSION" --notes-file "$NOTES"
 rm -f "$NOTES"
 
+## Past this point the release is public and cannot be taken back, so a failing tap push must not
+## read as a failing release. It is reported and left for `make tap` rather than aborting: the
+## worst case is Homebrew users sitting one version behind for as long as it takes to re-run.
+./scripts/update-tap.sh "$VERSION" || {
+  echo >&2
+  echo "warning: $TAG is published, but the Homebrew cask was not updated." >&2
+  echo "         Homebrew users stay on the previous version until you re-run:" >&2
+  echo "           make tap VERSION=$VERSION" >&2
+}
+
 ## sarvkrit.com/download and the GitHub "latest" link both resolve through
 ## releases/latest/download/Sarvkrit.dmg, so they pick this up with no change on the site side.
 echo

--- a/scripts/update-tap.sh
+++ b/scripts/update-tap.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Points the Homebrew cask at an already-published release.
+#
+#   ./scripts/update-tap.sh 1.1.0
+#
+# Separate from release.sh, and runnable on its own, for two reasons. It hashes the DMG that
+# GitHub is actually serving rather than the one in dist/, so what the cask promises is what
+# users receive even if the two ever diverge. And when release.sh publishes a release but the
+# tap push fails — a network blip, an expired key — the release is already live and irreversible;
+# re-running this is the whole recovery, and it has to work without cutting anything again.
+set -euo pipefail
+
+VERSION="${1:?usage: update-tap.sh <version>, e.g. update-tap.sh 1.1.0}"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]] || { echo "error: '$VERSION' is not a version" >&2; exit 1; }
+
+TAG="v$VERSION"
+TAP_REMOTE="git@github.com-2:sadana-psylief/homebrew-tap.git"
+CASK="Casks/sarvkrit.rb"
+
+## Everything checkable, before anything that costs time or leaves a trace.
+command -v gh >/dev/null || { echo "error: gh is not installed" >&2; exit 1; }
+gh release view "$TAG" >/dev/null 2>&1 || {
+  echo "error: no release $TAG — this bumps the cask to a release that already exists" >&2; exit 1; }
+
+TMP="$(mktemp -d -t sarvkrit-tap)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+## The published asset, not dist/Sarvkrit.dmg. Notarization stapling rewrites the file, and a
+## hash taken from a local build is only ever a claim about a local build.
+gh release download "$TAG" --pattern Sarvkrit.dmg --dir "$TMP"
+SHA="$(shasum -a 256 "$TMP/Sarvkrit.dmg" | awk '{print $1}')"
+echo "$TAG  sha256 $SHA"
+
+## A fresh clone rather than $(brew --repository)/Library/Taps/sadana-psylief/homebrew-tap. That
+## checkout belongs to whoever is running this: its origin is the HTTPS URL brew taps with, it may
+## be mid-rebase, and `brew update` will happily reset it under us.
+git clone --quiet --depth 1 "$TAP_REMOTE" "$TMP/tap"
+cd "$TMP/tap"
+[[ -f "$CASK" ]] || { echo "error: $CASK is missing from the tap" >&2; exit 1; }
+
+/usr/bin/sed -i '' \
+  -e "s/^\( *version \).*/\1\"$VERSION\"/" \
+  -e "s/^\( *sha256 \).*/\1\"$SHA\"/" \
+  "$CASK"
+## Confirm the rewrite landed rather than trusting sed's exit status, which is 0 whether or not
+## the pattern matched. Same reason release.sh re-greps project.yml after bumping it.
+grep -q "^  version \"$VERSION\"$" "$CASK" || { echo "error: version rewrite did not apply" >&2; exit 1; }
+grep -q "^  sha256 \"$SHA\"$" "$CASK"      || { echo "error: sha256 rewrite did not apply" >&2; exit 1; }
+
+if [[ -z "$(git status --porcelain)" ]]; then
+  echo "Cask is already at $VERSION with this hash — nothing to push."
+  exit 0
+fi
+
+git add "$CASK"
+git commit --quiet -m "Sarvkrit $VERSION"
+git push --quiet origin HEAD
+
+echo
+echo "Tap updated. Verify with:"
+echo "  brew update && brew upgrade --cask sarvkrit"
+echo "  brew install --cask sadana-psylief/tap/sarvkrit    # or --adopt over an existing copy"


### PR DESCRIPTION
## What changed

`brew install --cask sadana-psylief/tap/sarvkrit` now installs Sarvkrit. The cask lives in the new
[sadana-psylief/homebrew-tap](https://github.com/sadana-psylief/homebrew-tap); this PR adds the
script that keeps it in step with each release, wires it into `make release`, and teaches the
in-app update notice which command to hand over.

- `scripts/update-tap.sh` — bumps `version` and `sha256` in the tap for an already-published release
- `scripts/release.sh`, `Makefile` — call it last; new `make tap VERSION=…` target
- `Sources/Sarvkrit/Core/InstallSource.swift` — detects a Homebrew-managed bundle
- `UpdateNoticeView` — shows `brew upgrade --cask sarvkrit` to those users instead of the curl line
- `README.md` — Homebrew section, the tap step under *Cutting a release*, and the cask added to the
  `TODO(notarize)` cleanup list

## Why

**Not `homebrew/cask`.** Its audit runs `gktool scan` and no longer accepts un-notarized apps —
un-notarized casks are being removed from the official tap this month. A personal tap has no such
gate.

**The quarantine problem.** Homebrew marks everything it downloads, and removed the
`--no-quarantine` escape hatch in 5.1. So an un-notarized cask installed the ordinary way walks
straight back into install step 2 — the wall `sarvkrit.com/install` exists to avoid. The cask
strips the attribute itself in `postflight_steps` and leans on its pinned `sha256` to guarantee it
installed the bytes that were published: the same trade `install.sh` makes when it verifies the
signature by hand. It is marked `TODO(notarize)` and the README says plainly that a pinned hash is
a *different* trust root, not the same one.

**Why the app needs to know.** The curl script replaces `/Applications/Sarvkrit.app` wholesale. Run
by someone who installed through Homebrew, it leaves brew's receipt pointing at a version that is no
longer there — `brew upgrade` then has nothing to do and the two installers quietly fight over the
same bundle.

**Why `update-tap.sh` is separate from `release.sh`.** It hashes the DMG GitHub is actually serving
rather than `dist/Sarvkrit.dmg`, so the cask can only ever promise what users receive. And a release
cannot be un-published: when the tap push is the thing that fails, re-running it is the whole
recovery, so `release.sh` reports that failure rather than aborting on it.

## How it was verified

Against Homebrew 6.0.22, installing into a throwaway `--appdir` so the real `/Applications` copy and
its Accessibility grant were never touched:

- `xattr -lr <app> | grep -c com.apple.quarantine` → **0**, on both the plain and the `--adopt` path
- `codesign --verify --deep --strict` still passes after the `xattr` pass; TeamIdentifier `77A36893HP`
- The Caskroom symlink is created on both paths, which is what `InstallSource` keys on
- A plain install over an existing app errors with *"It seems there is already an App at…"* — which
  is why both commands are documented; everyone who already has Sarvkrit needs `--adopt`
- Confirmed brew really does apply the attribute: the cached DMG carries `com.apple.quarantine`, and
  a control cask installed without a postflight has it on the installed app
- `./scripts/update-tap.sh 1.1.0` downloads the published asset, hashes it to
  `11fa22be…`, matches the release notes, and no-ops cleanly; `9.9.9` is refused

- [x] `make test` passes locally — 1586 tests, 3 skipped, 0 failures
- [x] New behaviour comes with tests — `InstallSource.detect` is covered for the brew-managed
      bundle, a different bundle at the same version, a stale Caskroom entry, and no Homebrew at all