### PR TITLE
Screen recording, and making it survive contact

### DIFF
--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -14,6 +14,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         wireShelf()
         wireCutPasteToasts()
         wireScreenshots()
+        wireRecording()
         wirePinToScreen()
         // Installed unconditionally, before anything can put a window on screen. This is the one
         // shortcut that must never be missing when it is needed.
@@ -216,6 +217,112 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The capture itself is async because ScreenCaptureKit is; the hotkey fires on the main
     /// thread and hands off to a Task rather than blocking it, since a capture of a large display
     /// takes long enough to be felt as a stutter if it ran inline.
+    /// The recorder reaches its HUD through these closures. Nothing under `Features/` imports
+    /// the UI layer, which is why they exist at all.
+    private func wireRecording() {
+        guard let feature = AppState.shared.features
+            .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
+
+        feature.startStop = { MainActor.assumeIsolated { Self.toggleRecording(feature) } }
+        feature.recordArea = { MainActor.assumeIsolated { Self.toggleRecording(feature) } }
+        feature.pauseResume = {
+            MainActor.assumeIsolated {
+                guard feature.recorder.isRecording else { return }
+                RecordingHUDController.shared.onPauseResume?()
+            }
+        }
+        feature.markMoment = {
+            MainActor.assumeIsolated {
+                guard feature.recorder.isRecording else { return }
+                feature.recorder.flag()
+                ToastPresenter.shared.show("Marked", symbolName: "flag")
+            }
+        }
+
+        RecordingHUDController.shared.onStop = {
+            MainActor.assumeIsolated { Self.stopRecording(feature) }
+        }
+        RecordingHUDController.shared.onPauseResume = {
+            MainActor.assumeIsolated {
+                let recorder = feature.recorder
+                guard recorder.isRecording else { return }
+                if recorder.isPaused { recorder.resume() } else { recorder.pause() }
+            }
+        }
+        RecordingHUDController.shared.onDiscard = {
+            Task { @MainActor in
+                await feature.recorder.discard()
+                RecordingHUDController.shared.dismiss()
+                feature.noteRecording(false)
+                ToastPresenter.shared.show("Discarded", symbolName: "trash")
+            }
+        }
+    }
+
+    /// **A second press stops rather than starting a second recording** — the same rule the
+    /// screenshot path applies to a scrolling capture already in progress.
+    @MainActor
+    private static func toggleRecording(_ feature: ScreenRecordingFeature) {
+        guard !feature.recorder.isRecording else { return stopRecording(feature) }
+
+        var request = RecordingRequest(
+            source: .display,
+            destination: RecordingBundle.defaultDirectory()
+                .appendingPathComponent("\(Self.recordingName()).\(RecordingBundle.fileExtension)"))
+        request.fps = feature.framesPerSecond
+        request.capturesSystemAudio = feature.capturesSystemAudio
+        request.hidesDesktopIcons = feature.hidesDesktopIcons
+
+        Task { @MainActor in
+            do {
+                try FileManager.default.createDirectory(
+                    at: RecordingBundle.defaultDirectory(), withIntermediateDirectories: true)
+                try await feature.recorder.start(request)
+                feature.noteRecording(true)
+                RecordingHUDController.shared.show(
+                    elapsed: { feature.recorder.elapsed },
+                    dropped: { feature.recorder.droppedFrames })
+            } catch RecordingError.noDisplays {
+                // Denial has no error to catch; ScreenCaptureKit just reports nothing. macOS does
+                // not hand a running process a new grant either, so the answer is a relaunch.
+                if ScreenRecordingRelaunch.looksLikeStaleGrant(
+                    preflightGranted: AppState.shared.permissions.canCaptureScreen,
+                    capturedDisplayCount: 0) {
+                    ScreenRecordingRelaunch.relaunch()
+                } else {
+                    AppState.shared.permissions.request(.screenRecording)
+                }
+            } catch RecordingError.outOfSpace(let free) {
+                let gigabytes = Double(free) / 1_000_000_000
+                ToastPresenter.shared.show(String(format: "Only %.1f GB free", gigabytes),
+                                           symbolName: "externaldrive.badge.exclamationmark")
+            } catch {
+                ToastPresenter.shared.show("Couldn't start recording",
+                                           symbolName: "exclamationmark.triangle")
+            }
+        }
+    }
+
+    @MainActor
+    private static func stopRecording(_ feature: ScreenRecordingFeature) {
+        Task { @MainActor in
+            let dropped = feature.recorder.droppedFrames
+            let bundle = try? await feature.recorder.finish()
+            RecordingHUDController.shared.dismiss()
+            feature.noteRecording(false)
+            guard let bundle else { return }
+            NSWorkspace.shared.activateFileViewerSelecting([bundle.root])
+            ToastPresenter.shared.show(
+                dropped > 0 ? "Saved — \(dropped) frames dropped" : "Recording saved",
+                symbolName: "record.circle")
+        }
+    }
+
+    private static func recordingName() -> String {
+        CaptureFilename.make(pattern: "Recording {date} at {time}", mode: .fullscreen,
+                             date: Date(), counter: 0)
+    }
+
     private func wireScreenshots() {
         guard let screenshots = AppState.shared.features
             .compactMap({ $0 as? ScreenshotFeature }).first else { return }

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -407,6 +407,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 RecordingHUDController.shared.show(
                     elapsed: { feature.recorder.elapsed },
                     dropped: { feature.recorder.droppedFrames })
+                // Nil when this take has no camera, so no window appears for a screen-only
+                // recording rather than an empty circle.
+                if let preview = feature.recorder.cameraPreviewLayer() {
+                    CameraPreviewWindowController.shared.show(preview)
+                }
             } catch RecordingError.noDisplays {
                 // Denial has no error to catch; ScreenCaptureKit just reports nothing. macOS does
                 // not hand a running process a new grant either, so the answer is a relaunch.
@@ -481,6 +486,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let dropped = feature.recorder.droppedFrames
             let bundle = try? await feature.recorder.finish()
             RecordingHUDController.shared.dismiss()
+            CameraPreviewWindowController.shared.dismiss()
             feature.noteRecording(false)
             guard let bundle else { return }
             if dropped > 0 {

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -72,6 +72,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let recording = AppState.shared.features
                     .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
                 Task { @MainActor in await Self.record(source, windowID: windowID, with: recording) }
+            case .editorCommand(let command):
+                if !StudioEditorController.shared.perform(command) {
+                    Self.urlLog.error("editor command with no editor open")
+                }
             case .exportEditor(let destination):
                 if !StudioEditorController.shared.export(to: destination) {
                     Self.urlLog.error("export with no editor open")

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -224,7 +224,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
 
         feature.startStop = { MainActor.assumeIsolated { Self.toggleRecording(feature) } }
-        feature.recordArea = { MainActor.assumeIsolated { Self.toggleRecording(feature) } }
+        // The dedicated shortcut skips straight to the area picker rather than making somebody
+        // change the segmented control every time.
+        feature.recordArea = {
+            MainActor.assumeIsolated { Self.toggleRecording(feature, forcing: .area) }
+        }
         feature.pauseResume = {
             MainActor.assumeIsolated {
                 guard feature.recorder.isRecording else { return }
@@ -262,22 +266,99 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// **A second press stops rather than starting a second recording** — the same rule the
     /// screenshot path applies to a scrolling capture already in progress.
     @MainActor
-    private static func toggleRecording(_ feature: ScreenRecordingFeature) {
+    private static func toggleRecording(_ feature: ScreenRecordingFeature,
+                                        forcing source: RecordingSource? = nil) {
         guard !feature.recorder.isRecording else { return stopRecording(feature) }
+        if PreRecordBarController.shared.isShowing {
+            return PreRecordBarController.shared.dismiss()
+        }
 
-        var request = RecordingRequest(
-            source: .display,
-            destination: RecordingBundle.defaultDirectory()
-                .appendingPathComponent("\(Self.recordingName()).\(RecordingBundle.fileExtension)"))
-        request.fps = feature.framesPerSecond
-        request.capturesSystemAudio = feature.capturesSystemAudio
-        request.hidesDesktopIcons = feature.hidesDesktopIcons
+        if let source { feature.setup.source = source }
+        PreRecordBarController.shared.onRecord = { setup in
+            MainActor.assumeIsolated { aim(feature, setup: setup) }
+        }
+        PreRecordBarController.shared.show(setup: feature.setup)
+    }
+
+    /// Works out *what* to record, then counts down, then starts.
+    ///
+    /// Area and window both need something chosen on screen first. Area reuses the frozen-screen
+    /// overlay the screenshot path already has — the screen is captured once and the selection is
+    /// drawn over a still, which is why an open menu stays put while you aim at it.
+    @MainActor
+    private static func aim(_ feature: ScreenRecordingFeature, setup: RecordingSetup) {
+        let capturer = AppState.shared.features
+            .compactMap { $0 as? ScreenshotFeature }.first?.capturer ?? SCKScreenCaptureService()
+
+        switch setup.source {
+        case .display:
+            begin(feature, setup: setup, areaRect: nil, display: nil, window: nil)
+
+        case .area:
+            Task { @MainActor in
+                guard let frames = try? await capturer.snapshotAllDisplays(
+                    options: CaptureOptions()) else { return }
+                CaptureOverlayController.shared.present(
+                    frames: frames,
+                    chrome: .init(showsCrosshair: true, showsMagnifier: true,
+                                  showsDimensions: true,
+                                  hint: "Drag the area to record")
+                ) { _, display, rect in
+                    MainActor.assumeIsolated {
+                        guard let display, let rect else { return }
+                        begin(feature, setup: setup, areaRect: rect, display: display, window: nil)
+                    }
+                }
+            }
+
+        case .window:
+            Task { @MainActor in
+                guard let windows = try? await capturer.shareableWindows() else { return }
+                WindowPickerListController.shared.present(
+                    windows: windows,
+                    thumbnail: { _ in nil }
+                ) { window in
+                    MainActor.assumeIsolated {
+                        guard let window else { return }
+                        begin(feature, setup: setup, areaRect: nil, display: nil, window: window)
+                    }
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private static func begin(_ feature: ScreenRecordingFeature, setup: RecordingSetup,
+                              areaRect: CGRect?, display: DisplaySnapshotGeometry?,
+                              window: CapturableWindow?) {
+        // The countdown is the screenshot path's, unchanged: it already knows how to place itself
+        // and how to be cancelled by ⌃⇧⎋.
+        CountdownPresenter.shared.run(seconds: setup.countdownSeconds) { proceed in
+            MainActor.assumeIsolated {
+                guard proceed else { return }
+                start(feature, setup: setup, areaRect: areaRect, display: display, window: window)
+            }
+        }
+    }
+
+    @MainActor
+    private static func start(_ feature: ScreenRecordingFeature, setup: RecordingSetup,
+                              areaRect: CGRect?, display: DisplaySnapshotGeometry?,
+                              window: CapturableWindow?) {
+        let destination = RecordingBundle.defaultDirectory()
+            .appendingPathComponent("\(recordingName()).\(RecordingBundle.fileExtension)")
+        var request = setup.request(fps: feature.framesPerSecond,
+                                    hidesDesktopIcons: feature.hidesDesktopIcons,
+                                    destination: destination)
+        request.areaRect = areaRect
+        request.display = display
+        request.window = window
 
         Task { @MainActor in
             do {
                 try FileManager.default.createDirectory(
                     at: RecordingBundle.defaultDirectory(), withIntermediateDirectories: true)
-                try await feature.recorder.start(request)
+                try await feature.recorder.start(request, setup: setup)
                 feature.noteRecording(true)
                 RecordingHUDController.shared.show(
                     elapsed: { feature.recorder.elapsed },
@@ -296,6 +377,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 let gigabytes = Double(free) / 1_000_000_000
                 ToastPresenter.shared.show(String(format: "Only %.1f GB free", gigabytes),
                                            symbolName: "externaldrive.badge.exclamationmark")
+            } catch RecordingError.windowGone {
+                ToastPresenter.shared.show("That window has gone", symbolName: "macwindow.badge.plus")
             } catch {
                 ToastPresenter.shared.show("Couldn't start recording",
                                            symbolName: "exclamationmark.triangle")
@@ -315,6 +398,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 ToastPresenter.shared.show("\(dropped) frames dropped",
                                            symbolName: "exclamationmark.triangle")
             }
+            // **The moment the feature turns on.** What you want after a recording is to watch it;
+            // what you want after a screenshot is to send it. So this opens the editor rather than
+            // revealing a file in Finder.
             StudioEditorController.shared.open(bundle)
         }
     }

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -117,8 +117,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 if !StudioEditorController.shared.perform(command) {
                     Self.urlLog.error("editor command with no editor open")
                 }
-            case .exportEditor(let destination):
-                if !StudioEditorController.shared.export(to: destination) {
+            case .exportEditor(let destination, let preset):
+                if !StudioEditorController.shared.export(to: destination, preset: preset) {
                     Self.urlLog.error("export with no editor open")
                 }
             case .playPause:

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -72,6 +72,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let recording = AppState.shared.features
                     .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
                 Task { @MainActor in await Self.record(source, windowID: windowID, with: recording) }
+            case .addPicture(let file):
+                if !StudioEditorController.shared.addPicture(from: file) {
+                    Self.urlLog.error("could not add that picture")
+                }
             case .editorCommand(let command):
                 if !StudioEditorController.shared.perform(command) {
                     Self.urlLog.error("editor command with no editor open")

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -311,10 +311,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             RecordingHUDController.shared.dismiss()
             feature.noteRecording(false)
             guard let bundle else { return }
-            NSWorkspace.shared.activateFileViewerSelecting([bundle.root])
-            ToastPresenter.shared.show(
-                dropped > 0 ? "Saved — \(dropped) frames dropped" : "Recording saved",
-                symbolName: "record.circle")
+            if dropped > 0 {
+                ToastPresenter.shared.show("\(dropped) frames dropped",
+                                           symbolName: "exclamationmark.triangle")
+            }
+            StudioEditorController.shared.open(bundle)
         }
     }
 

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -83,7 +83,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 openEditor(with: file)
             case .openFromClipboard:
                 openEditorFromClipboard()
-            case .openSettings:
+            case .openSettings(let pane):
+                if let pane { AppState.shared.pendingSidebarSelection = pane }
                 MainWindowController.shared.show()
             case .action(let action):
                 guard let screenshots = AppState.shared.features
@@ -95,6 +96,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 Task { @MainActor in
                     await Self.captureRect(rect, displayIndex: displayIndex, with: screenshots)
                 }
+            case .showRecordBar:
+                guard let recording = AppState.shared.features
+                    .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
+                Self.toggleRecording(recording)
+            case .aimRecording:
+                guard let recording = AppState.shared.features
+                    .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
+                PreRecordBarController.shared.dismiss()
+                Self.aim(recording, setup: recording.setup)
             case .record(let source, let windowID):
                 guard let recording = AppState.shared.features
                     .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -72,6 +72,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let recording = AppState.shared.features
                     .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
                 Task { @MainActor in await Self.record(source, windowID: windowID, with: recording) }
+            case .exportEditor(let destination):
+                if !StudioEditorController.shared.export(to: destination) {
+                    Self.urlLog.error("export with no editor open")
+                }
             case .playPause:
                 if !StudioEditorController.shared.togglePlayback() {
                     Self.urlLog.error("play with no editor open")

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -103,6 +103,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private static let urlLog = Logger(subsystem: AppIdentity.logSubsystem, category: "URLScheme")
     private static let captureLog = Logger(subsystem: AppIdentity.logSubsystem, category: "Capture")
+    private static let recordingLog = Logger(subsystem: AppIdentity.logSubsystem,
+                                             category: "Recording")
 
     /// Registers the background update check, and repairs it when it has gone missing.
     ///
@@ -224,6 +226,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
 
         feature.startStop = { MainActor.assumeIsolated { Self.toggleRecording(feature) } }
+        // ⌃⇧⎋ takes everything down, and a running recording is part of everything. It stops and
+        // keeps the take rather than discarding it: an escape hatch should not destroy work.
+        CaptureOverlayGuard.shared.stopRecording = {
+            MainActor.assumeIsolated {
+                guard feature.recorder.isRecording else { return }
+                Self.stopRecording(feature)
+            }
+        }
         // The dedicated shortcut skips straight to the area picker rather than making somebody
         // change the segmented control every time.
         feature.recordArea = {
@@ -269,6 +279,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private static func toggleRecording(_ feature: ScreenRecordingFeature,
                                         forcing source: RecordingSource? = nil) {
         guard !feature.recorder.isRecording else { return stopRecording(feature) }
+        // A start already in flight is neither a stop nor a reason to put the bar back up.
+        // `isRecording` is only set once the stream is live, two `await`s later.
+        guard !feature.recorder.isStarting else { return }
         if PreRecordBarController.shared.isShowing {
             return PreRecordBarController.shared.dismiss()
         }
@@ -296,8 +309,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         case .area:
             Task { @MainActor in
-                guard let frames = try? await capturer.snapshotAllDisplays(
-                    options: CaptureOptions()) else { return }
+                let frames: [DisplayFrame]
+                do {
+                    frames = try await capturer.snapshotAllDisplays(options: CaptureOptions())
+                } catch {
+                    // Swallowed with `try?` until now, so a refused screen grant put nothing at
+                    // all on screen — which is exactly the "I do not see the area" report.
+                    let described = String(describing: error)
+                    recordingLog.error("couldn't freeze the screen to aim: \(described, privacy: .public)")
+                    let failure = RecordingFailureMessage.describe(error)
+                    ToastPresenter.shared.show(failure.text, symbolName: failure.symbolName)
+                    return
+                }
                 CaptureOverlayController.shared.present(
                     frames: frames,
                     chrome: .init(showsCrosshair: true, showsMagnifier: true,
@@ -313,7 +336,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         case .window:
             Task { @MainActor in
-                guard let windows = try? await capturer.shareableWindows() else { return }
+                let windows: [CapturableWindow]
+                do {
+                    windows = try await capturer.shareableWindows()
+                } catch {
+                    let described = String(describing: error)
+                    recordingLog.error("couldn't list windows to aim: \(described, privacy: .public)")
+                    let failure = RecordingFailureMessage.describe(error)
+                    ToastPresenter.shared.show(failure.text, symbolName: failure.symbolName)
+                    return
+                }
                 WindowPickerListController.shared.present(
                     windows: windows,
                     thumbnail: { _ in nil }
@@ -369,19 +401,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 if ScreenRecordingRelaunch.looksLikeStaleGrant(
                     preflightGranted: AppState.shared.permissions.canCaptureScreen,
                     capturedDisplayCount: 0) {
+                    // Said out loud first. `relaunch()` terminates us, and an app that quits and
+                    // reappears with no explanation is indistinguishable from one that crashed.
+                    recordingLog.error("screen grant looks stale — relaunching")
+                    ToastPresenter.shared.show("Restarting to pick up screen access",
+                                               symbolName: "arrow.clockwise")
                     ScreenRecordingRelaunch.relaunch()
                 } else {
                     AppState.shared.permissions.request(.screenRecording)
                 }
-            } catch RecordingError.outOfSpace(let free) {
-                let gigabytes = Double(free) / 1_000_000_000
-                ToastPresenter.shared.show(String(format: "Only %.1f GB free", gigabytes),
-                                           symbolName: "externaldrive.badge.exclamationmark")
-            } catch RecordingError.windowGone {
-                ToastPresenter.shared.show("That window has gone", symbolName: "macwindow.badge.plus")
             } catch {
-                ToastPresenter.shared.show("Couldn't start recording",
-                                           symbolName: "exclamationmark.triangle")
+                // Logged as well as shown, like the screenshot path: the toast tells the user
+                // something went wrong, and only this says what. Diagnosing the last failure took
+                // a crash report because this line did not exist.
+                let described = String(describing: error)
+                recordingLog.error("couldn't start recording: \(described, privacy: .public)")
+                let failure = RecordingFailureMessage.describe(error)
+                ToastPresenter.shared.show(failure.text, symbolName: failure.symbolName)
             }
         }
     }

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -23,9 +23,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         reconcileUpdateAgent()
         observeActivation()
 
+        // Anything the Finder handed us before this point can be opened now. See
+        // `application(_:open:)` for why it has to wait.
+        hasFinishedLaunching = true
+        let waiting = pendingRecordings
+        pendingRecordings = []
+        for url in waiting { StudioEditorController.shared.open(fileAt: url) }
+
         guard !AppState.shared.hasCompletedOnboarding else { return }
         MainWindowController.shared.show()
     }
+
+    /// Recordings the Finder asked for before the app had finished starting up.
+    ///
+    /// **`application(_:open:)` fires before `applicationDidFinishLaunching` returns** when the
+    /// app is launched by double-clicking a file — which is the very first thing a Finder user
+    /// does. Opening an editor from inside a half-wired app is not worth the risk, so the URL
+    /// waits the few milliseconds until launch is done.
+    private var pendingRecordings: [URL] = []
+    private var hasFinishedLaunching = false
 
     /// The `sarvkrit://` URL scheme.
     ///
@@ -37,6 +53,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `LSMultipleInstancesProhibited` is not in the way.
     func application(_ application: NSApplication, open urls: [URL]) {
         for url in urls {
+            // A recording opened from the Finder, an Open panel or the recordings list. Files
+            // arrive down the same delegate method as the URL scheme, so they are sorted here.
+            if url.isFileURL, url.pathExtension == RecordingBundle.fileExtension {
+                Self.urlLog.info("open recording via file")
+                if hasFinishedLaunching {
+                    StudioEditorController.shared.open(fileAt: url)
+                } else {
+                    pendingRecordings.append(url)
+                }
+                continue
+            }
             guard let command = CaptureURLCommand.parse(url) else {
                 Self.urlLog.error("ignored \(url.absoluteString, privacy: .public)")
                 continue

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -353,11 +353,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     ToastPresenter.shared.show(failure.text, symbolName: failure.symbolName)
                     return
                 }
+                // Opens with a rectangle already on screen — last time's, or a centred default
+                // the first time — so aiming is an adjustment rather than a drag from nothing.
+                let seed = RecordingArea.seed(remembered: setup.lastArea,
+                                              displays: frames.map(\.geometry.frame))
                 CaptureOverlayController.shared.present(
                     frames: frames,
                     chrome: .init(showsCrosshair: true, showsMagnifier: true,
                                   showsDimensions: true,
-                                  hint: "Drag the area to record")
+                                  hint: seed == nil
+                                      ? "Drag the area to record"
+                                      : "Resize the area, then click inside it to record",
+                                  initialSelection: seed)
                 ) { _, display, rect in
                     MainActor.assumeIsolated {
                         guard let display, let rect else { return }
@@ -423,6 +430,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 try FileManager.default.createDirectory(
                     at: RecordingBundle.defaultDirectory(), withIntermediateDirectories: true)
                 try await feature.recorder.start(request, setup: setup)
+                // Remembered only now that a recording is really running. A cancelled or refused
+                // aim must not overwrite the rect the user still wants back.
+                if let areaRect { setup.lastArea = areaRect }
                 feature.noteRecording(true)
                 RecordingHUDController.shared.show(
                     elapsed: { feature.recorder.elapsed },

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -72,6 +72,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let recording = AppState.shared.features
                     .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
                 Task { @MainActor in await Self.record(source, windowID: windowID, with: recording) }
+            case .playPause:
+                if !StudioEditorController.shared.togglePlayback() {
+                    Self.urlLog.error("play with no editor open")
+                }
             case .seek(let seconds):
                 if !StudioEditorController.shared.seek(to: seconds) {
                     Self.urlLog.error("seek with no editor open")

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -68,6 +68,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 Task { @MainActor in
                     await Self.captureRect(rect, displayIndex: displayIndex, with: screenshots)
                 }
+            case .record(let source, let windowID):
+                guard let recording = AppState.shared.features
+                    .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
+                Task { @MainActor in await Self.record(source, windowID: windowID, with: recording) }
+            case .stopRecording:
+                guard let recording = AppState.shared.features
+                    .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
+                guard recording.recorder.isRecording else {
+                    Self.urlLog.error("stop-recording with nothing recording")
+                    return
+                }
+                Self.stopRecording(recording)
             }
         }
     }
@@ -420,6 +432,47 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 ToastPresenter.shared.show(failure.text, symbolName: failure.symbolName)
             }
         }
+    }
+
+    /// Starts a recording without the pre-record bar, for `sarvkrit://record`.
+    ///
+    /// Skips the bar and the countdown deliberately: a script that has asked to record has already
+    /// made both of those decisions, and an unattended run should not wait for a click.
+    @MainActor
+    private static func record(_ source: RecordingSource, windowID: CGWindowID?,
+                               with feature: ScreenRecordingFeature) async {
+        guard !feature.recorder.isRecording, !feature.recorder.isStarting else {
+            urlLog.error("record while one is already starting or running")
+            return
+        }
+        let capturer = AppState.shared.features
+            .compactMap { $0 as? ScreenshotFeature }.first?.capturer ?? SCKScreenCaptureService()
+
+        var window: CapturableWindow?
+        if source == .window {
+            do {
+                let windows = try await capturer.shareableWindows()
+                // Named by id, or else the frontmost window that is not one of ours — a script
+                // has no way to learn a window id ahead of time, and refusing without one would
+                // make the common case unreachable.
+                window = windowID.flatMap { id in windows.first { $0.id == id } }
+                    ?? WindowListFilter.presentable(windows)
+                        .first { $0.owningBundleID != AppIdentity.bundleID }
+            } catch {
+                let described = String(describing: error)
+                urlLog.error("couldn't list windows for record: \(described, privacy: .public)")
+            }
+            guard window != nil else {
+                ToastPresenter.shared.show("No window to record",
+                                           symbolName: "macwindow.badge.plus")
+                return
+            }
+        }
+
+        // Area from a script means the whole display: there is nobody to drag a selection.
+        let effective: RecordingSource = source == .area ? .display : source
+        feature.setup.source = effective
+        start(feature, setup: feature.setup, areaRect: nil, display: nil, window: window)
     }
 
     @MainActor

--- a/Sources/Sarvkrit/App/AppDelegate.swift
+++ b/Sources/Sarvkrit/App/AppDelegate.swift
@@ -72,6 +72,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let recording = AppState.shared.features
                     .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }
                 Task { @MainActor in await Self.record(source, windowID: windowID, with: recording) }
+            case .seek(let seconds):
+                if !StudioEditorController.shared.seek(to: seconds) {
+                    Self.urlLog.error("seek with no editor open")
+                }
             case .stopRecording:
                 guard let recording = AppState.shared.features
                     .compactMap({ $0 as? ScreenRecordingFeature }).first else { return }

--- a/Sources/Sarvkrit/Core/AXHelpers.swift
+++ b/Sources/Sarvkrit/Core/AXHelpers.swift
@@ -17,6 +17,33 @@ enum AX {
         return element
     }
 
+    /// Whether the point falls inside any window this process owns.
+    static func isPointOverOwnWindow(_ point: CGPoint) -> Bool {
+        guard let windows = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID)
+            as? [[String: Any]] else { return false }
+        return isPoint(point, overWindowsOf: ProcessInfo.processInfo.processIdentifier,
+                       in: windows)
+    }
+
+    /// Pure, so the geometry can be tested without a window server.
+    ///
+    /// `kCGWindowBounds` and the coordinates `AXUIElementCopyElementAtPosition` takes are both
+    /// top-left origin with y increasing downwards, which is the only reason one can stand in for
+    /// the other.
+    static func isPoint(_ point: CGPoint, overWindowsOf pid: pid_t,
+                        in windows: [[String: Any]]) -> Bool {
+        for window in windows {
+            guard let owner = window[kCGWindowOwnerPID as String] as? NSNumber,
+                  owner.int32Value == pid,
+                  let bounds = window[kCGWindowBounds as String] as? [String: Any],
+                  let rect = CGRect(dictionaryRepresentation: bounds as CFDictionary)
+            else { continue }
+            if rect.contains(point) { return true }
+        }
+        return false
+    }
+
     static func application(pid: pid_t) -> AXUIElement {
         let element = AXUIElementCreateApplication(pid)
         AXUIElementSetMessagingTimeout(element, messagingTimeout)
@@ -25,7 +52,23 @@ enum AX {
 
     /// Hit-test in global display coordinates. `CGEvent.location` is already in exactly this
     /// space (origin top-left), so no flipping is needed.
+    /// The element at a screen point, or nil.
+    ///
+    /// **Never asks about our own windows, and that is what stops it crashing.**
+    /// `AXUIElementCopyElementAtPosition` is answered *in-process* when the point is over a window
+    /// this app owns: AppKit serves it synchronously on the calling thread, through
+    /// `NSHostingView.accessibilityHitTest` and into SwiftUI, which evaluates a view body and
+    /// asserts it is on the main actor. Both callers run this on a background queue on purpose —
+    /// it costs up to four Accessibility round trips against an app that may be busy — so the
+    /// answer arrives as a trap rather than an element.
+    ///
+    /// Both callers already discard our own process; neither could do it soon enough, because the
+    /// PID they test belongs to the element this call was meant to return. So the question is
+    /// answered here instead, with the window list — Core Graphics, no Accessibility, no SwiftUI,
+    /// safe from any thread. Nothing wants our own windows anyway: the app cannot drive itself
+    /// through the Accessibility API.
     static func element(at point: CGPoint) -> AXUIElement? {
+        guard !isPointOverOwnWindow(point) else { return nil }
         var element: AXUIElement?
         let result = AXUIElementCopyElementAtPosition(
             systemWide(), Float(point.x), Float(point.y), &element

--- a/Sources/Sarvkrit/Core/Feature.swift
+++ b/Sources/Sarvkrit/Core/Feature.swift
@@ -72,12 +72,22 @@ enum Requirement: Hashable, CaseIterable {
     /// restarted. Denial isn't an error either: ScreenCaptureKit simply reports no displays. See
     /// `ScreenRecordingRelaunch`.
     case screenRecording
+    /// Recording you alongside the screen.
+    case camera
+    /// Narration. Separate from `audioCapture`, which is what *other apps* are playing.
+    case microphone
+    /// Captions. Needed even though recognition never leaves this Mac — macOS gates the API, not
+    /// the network.
+    case speechRecognition
 
     var title: String {
         switch self {
         case .accessibility: return "Accessibility access"
         case .audioCapture: return "System audio recording"
         case .screenRecording: return "Screen Recording access"
+        case .camera: return "Camera access"
+        case .microphone: return "Microphone access"
+        case .speechRecognition: return "Speech Recognition access"
         }
     }
 
@@ -86,6 +96,15 @@ enum Requirement: Hashable, CaseIterable {
         switch self {
         case .accessibility:
             return "Sarvkrit can't watch for keys or clicks until you allow it in System Settings."
+        case .camera:
+            return "Recording yourself alongside your screen means using the camera. The video is "
+                 + "written to your Mac and never sent anywhere."
+        case .microphone:
+            return "Recording narration means using the microphone. The audio is written to your "
+                 + "Mac and never sent anywhere."
+        case .speechRecognition:
+            return "Captions are worked out on this Mac. macOS still asks, because it gates the "
+                 + "recognition API rather than the network — nothing is uploaded."
         case .audioCapture:
             return "Setting an app's volume means routing its audio through Sarvkrit, which macOS "
                  + "treats as recording it."
@@ -100,7 +119,8 @@ enum Requirement: Hashable, CaseIterable {
     /// False for audio: there is no query, so the only evidence is silence where sound should be.
     var isQueryable: Bool {
         switch self {
-        case .accessibility, .screenRecording: return true
+        case .accessibility, .screenRecording, .camera, .microphone, .speechRecognition:
+            return true
         case .audioCapture: return false
         }
     }
@@ -115,7 +135,8 @@ enum Requirement: Hashable, CaseIterable {
     /// noticing silence instead.
     var isRequestable: Bool {
         switch self {
-        case .accessibility, .screenRecording: return true
+        case .accessibility, .screenRecording, .camera, .microphone, .speechRecognition:
+            return true
         case .audioCapture: return false
         }
     }
@@ -137,6 +158,15 @@ enum Requirement: Hashable, CaseIterable {
         case .screenRecording:
             return URL(string:
                 "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!
+        case .camera:
+            return URL(string:
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera")!
+        case .microphone:
+            return URL(string:
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!
+        case .speechRecognition:
+            return URL(string:
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition")!
         }
     }
 }

--- a/Sources/Sarvkrit/Core/FeatureRegistry.swift
+++ b/Sources/Sarvkrit/Core/FeatureRegistry.swift
@@ -17,6 +17,7 @@ enum FeatureRegistry {
             AppSweepFeature(),
             ShelfFeature(),
             ScreenshotFeature(),
+            ScreenRecordingFeature(),
             PinToScreenFeature(),
             OutputSwitcherFeature(),
             MuteMicrophoneFeature(),

--- a/Sources/Sarvkrit/Core/GlobalHotkey.swift
+++ b/Sources/Sarvkrit/Core/GlobalHotkey.swift
@@ -46,6 +46,10 @@ final class GlobalHotkey {
         /// never be the reason a user cannot use their own screen.
         static let dismissAllOverlays: UInt32 = 13
         static let historyBrowser: UInt32 = 14
+        static let recordStartStop: UInt32 = 15
+        static let recordArea: UInt32 = 16
+        static let recordPauseResume: UInt32 = 17
+        static let recordFlag: UInt32 = 18
     }
 
     /// Distinct per hotkey. Two sharing an id would collide.

--- a/Sources/Sarvkrit/Core/PermissionsManager.swift
+++ b/Sources/Sarvkrit/Core/PermissionsManager.swift
@@ -2,7 +2,9 @@ import ApplicationServices
 import AppKit
 import Combine
 import CoreGraphics
+import AVFoundation
 import Foundation
+import Speech
 
 /// Tracks the TCC grants the app can actually ask about.
 ///
@@ -108,6 +110,12 @@ final class PermissionsManager: ObservableObject {
         case .accessibility: requestAccess()
         case .screenRecording: requestScreenRecordingAccess()
         case .audioCapture: break
+        case .camera:
+            AVCaptureDevice.requestAccess(for: .video) { _ in }
+        case .microphone:
+            AVCaptureDevice.requestAccess(for: .audio) { _ in }
+        case .speechRecognition:
+            SFSpeechRecognizer.requestAuthorization { _ in }
         }
         openSystemSettings(for: requirement)
     }
@@ -130,6 +138,12 @@ final class PermissionsManager: ObservableObject {
         case .accessibility: return isTrusted
         case .screenRecording: return canCaptureScreen
         case .audioCapture: return true
+        case .camera:
+            return AVCaptureDevice.authorizationStatus(for: .video) == .authorized
+        case .microphone:
+            return AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+        case .speechRecognition:
+            return SFSpeechRecognizer.authorizationStatus() == .authorized
         }
     }
 }

--- a/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
+++ b/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
@@ -37,7 +37,9 @@ enum CaptureURLCommand: Equatable {
     /// Opens whatever image is on the clipboard in the editor.
     case openFromClipboard
     /// Sarvkrit's own window, on the Capture pane.
-    case openSettings
+    /// Opens the settings window, optionally on a named pane — a feature's own id, `general` or
+    /// `about`. Without one it lands wherever the window was last left.
+    case openSettings(pane: String?)
     /// Starts a recording, skipping the pre-record bar — camera, microphone and countdown are
     /// whatever the settings already say.
     ///
@@ -60,6 +62,16 @@ enum CaptureURLCommand: Equatable {
     case editorCommand(StudioEditorCommand)
     /// Brings a picture into the open editor at the playhead.
     case addPicture(URL)
+    /// Raises the pre-record bar, as ⌃⇧R does.
+    ///
+    /// **The bar and the aiming overlay are the two surfaces a script could not reach**, and both
+    /// have now been reported against — "I cannot close it until I record something" and "it
+    /// should be a rectangle already on screen". `record` deliberately skips both, so neither
+    /// could be looked at without a keyboard this machine will not let anything synthesise.
+    case showRecordBar
+    /// Raises the aiming surface for whatever source is currently chosen: the area overlay, the
+    /// window list, or straight to the countdown for a whole display.
+    case aimRecording
 
     static let scheme = "sarvkrit"
 
@@ -79,6 +91,8 @@ enum CaptureURLCommand: Equatable {
         case .exportEditor: return "export"
         case .editorCommand: return "editor"
         case .addPicture: return "picture"
+        case .showRecordBar: return "record-bar"
+        case .aimRecording: return "aim"
         case .action(let action): return Self.names[action] ?? action.rawValue
         }
     }
@@ -102,10 +116,11 @@ enum CaptureURLCommand: Equatable {
     /// and a settings row offering a URL with somebody else's coordinates in it would be noise.
     static var all: [CaptureURLCommand] {
         ScreenshotAction.allCases.map { .action($0) }
-            + [.capturePreviousArea, .openAnnotate(nil), .openFromClipboard, .openSettings,
+            + [.capturePreviousArea, .openAnnotate(nil), .openFromClipboard, .openSettings(pane: nil),
                .cancel, .record(.display, windowID: nil), .stopRecording, .seek(0), .playPause,
                .exportEditor(URL(fileURLWithPath: "/tmp/Recording.mp4")),
-               .editorCommand(.split), .addPicture(URL(fileURLWithPath: "/tmp/logo.png"))]
+               .editorCommand(.split), .addPicture(URL(fileURLWithPath: "/tmp/logo.png")),
+               .showRecordBar, .aimRecording]
     }
 
     private static func rect(from url: URL) -> CGRect? {
@@ -167,6 +182,14 @@ enum CaptureURLCommand: Equatable {
 
     /// Refused rather than clamped when absent or negative: a script that computed a time wrongly
     /// should move nothing, the same rule the rest of this parser follows.
+    private static func pane(from url: URL) -> String? {
+        let raw = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?
+            .first { $0.name.lowercased() == "pane" }?.value?
+            .trimmingCharacters(in: .whitespaces)
+            .lowercased()
+        return raw?.isEmpty == false ? raw : nil
+    }
+
     private static func seconds(from url: URL) -> TimeInterval? {
         guard let raw = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?
             .first(where: { $0.name.lowercased() == "t" })?.value,
@@ -189,8 +212,10 @@ enum CaptureURLCommand: Equatable {
         if name == "capture-previous-area" { return .capturePreviousArea }
         if name == "open-annotate" { return .openAnnotate(filepath(from: url)) }
         if name == "open-from-clipboard" { return .openFromClipboard }
-        if name == "open-settings" { return .openSettings }
+        if name == "open-settings" { return .openSettings(pane: pane(from: url)) }
         if name == "stop-recording" { return .stopRecording }
+        if name == "record-bar" { return .showRecordBar }
+        if name == "aim" { return .aimRecording }
         if name == "seek" { return seconds(from: url).map { .seek($0) } }
         if name == "play" { return .playPause }
         if name == "export" { return filepath(from: url).map { .exportEditor($0) } }

--- a/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
+++ b/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
@@ -56,6 +56,8 @@ enum CaptureURLCommand: Equatable {
     case playPause
     /// Exports the open editor to a file, skipping the save panel.
     case exportEditor(URL)
+    /// Performs one of the editor's own actions by name — the same ones the keyboard routes.
+    case editorCommand(StudioEditorCommand)
 
     static let scheme = "sarvkrit"
 
@@ -73,6 +75,7 @@ enum CaptureURLCommand: Equatable {
         case .seek: return "seek"
         case .playPause: return "play"
         case .exportEditor: return "export"
+        case .editorCommand: return "editor"
         case .action(let action): return Self.names[action] ?? action.rawValue
         }
     }
@@ -98,7 +101,8 @@ enum CaptureURLCommand: Equatable {
         ScreenshotAction.allCases.map { .action($0) }
             + [.capturePreviousArea, .openAnnotate(nil), .openFromClipboard, .openSettings,
                .cancel, .record(.display, windowID: nil), .stopRecording, .seek(0), .playPause,
-               .exportEditor(URL(fileURLWithPath: "/tmp/Recording.mp4"))]
+               .exportEditor(URL(fileURLWithPath: "/tmp/Recording.mp4")),
+               .editorCommand(.split)]
     }
 
     private static func rect(from url: URL) -> CGRect? {
@@ -187,6 +191,13 @@ enum CaptureURLCommand: Equatable {
         if name == "seek" { return seconds(from: url).map { .seek($0) } }
         if name == "play" { return .playPause }
         if name == "export" { return filepath(from: url).map { .exportEditor($0) } }
+        if name == "editor" {
+            guard let raw = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?
+                .first(where: { $0.name.lowercased() == "do" })?.value,
+                let command = StudioEditorCommand(rawValue: raw.lowercased())
+            else { return nil }
+            return .editorCommand(command)
+        }
         if name == "record" {
             guard let source = recordingSource(from: url) else { return nil }
             return .record(source, windowID: windowID(from: url))

--- a/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
+++ b/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
@@ -54,6 +54,8 @@ enum CaptureURLCommand: Equatable {
     case seek(TimeInterval)
     /// Starts or stops playback in the open editor.
     case playPause
+    /// Exports the open editor to a file, skipping the save panel.
+    case exportEditor(URL)
 
     static let scheme = "sarvkrit"
 
@@ -70,6 +72,7 @@ enum CaptureURLCommand: Equatable {
         case .stopRecording: return "stop-recording"
         case .seek: return "seek"
         case .playPause: return "play"
+        case .exportEditor: return "export"
         case .action(let action): return Self.names[action] ?? action.rawValue
         }
     }
@@ -94,7 +97,8 @@ enum CaptureURLCommand: Equatable {
     static var all: [CaptureURLCommand] {
         ScreenshotAction.allCases.map { .action($0) }
             + [.capturePreviousArea, .openAnnotate(nil), .openFromClipboard, .openSettings,
-               .cancel, .record(.display, windowID: nil), .stopRecording, .seek(0), .playPause]
+               .cancel, .record(.display, windowID: nil), .stopRecording, .seek(0), .playPause,
+               .exportEditor(URL(fileURLWithPath: "/tmp/Recording.mp4"))]
     }
 
     private static func rect(from url: URL) -> CGRect? {
@@ -182,6 +186,7 @@ enum CaptureURLCommand: Equatable {
         if name == "stop-recording" { return .stopRecording }
         if name == "seek" { return seconds(from: url).map { .seek($0) } }
         if name == "play" { return .playPause }
+        if name == "export" { return filepath(from: url).map { .exportEditor($0) } }
         if name == "record" {
             guard let source = recordingSource(from: url) else { return nil }
             return .record(source, windowID: windowID(from: url))

--- a/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
+++ b/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
@@ -56,8 +56,12 @@ enum CaptureURLCommand: Equatable {
     case seek(TimeInterval)
     /// Starts or stops playback in the open editor.
     case playPause
-    /// Exports the open editor to a file, skipping the save panel.
-    case exportEditor(URL)
+    /// Exports the open editor to a file, skipping both export dialogs.
+    ///
+    /// `preset=` names one of `ExportPreset.all` by id; `height=` overrides the size and permits an
+    /// upscale, since naming a size explicitly is the deliberate choice the cap exists to protect
+    /// against making by accident.
+    case exportEditor(URL, preset: ExportPreset)
     /// Performs one of the editor's own actions by name — the same ones the keyboard routes.
     case editorCommand(StudioEditorCommand)
     /// Brings a picture into the open editor at the playhead.
@@ -118,7 +122,7 @@ enum CaptureURLCommand: Equatable {
         ScreenshotAction.allCases.map { .action($0) }
             + [.capturePreviousArea, .openAnnotate(nil), .openFromClipboard, .openSettings(pane: nil),
                .cancel, .record(.display, windowID: nil), .stopRecording, .seek(0), .playPause,
-               .exportEditor(URL(fileURLWithPath: "/tmp/Recording.mp4")),
+               .exportEditor(URL(fileURLWithPath: "/tmp/Recording.mp4"), preset: .web),
                .editorCommand(.split), .addPicture(URL(fileURLWithPath: "/tmp/logo.png")),
                .showRecordBar, .aimRecording]
     }
@@ -182,6 +186,24 @@ enum CaptureURLCommand: Equatable {
 
     /// Refused rather than clamped when absent or negative: a script that computed a time wrongly
     /// should move nothing, the same rule the rest of this parser follows.
+    /// The export settings named in the URL, falling back to the default preset.
+    private static func preset(from url: URL) -> ExportPreset {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        func value(_ name: String) -> String? {
+            items.first { $0.name.lowercased() == name }?.value
+        }
+        var preset = value("preset")
+            .flatMap { named in ExportPreset.all.first { $0.id == named.lowercased() } }
+            ?? .web
+        if let raw = value("height"), let height = Int(raw), height > 0 {
+            preset.height = height
+            // Named explicitly, so it is the deliberate choice the cap exists to protect against
+            // making by accident.
+            preset.allowsUpscale = true
+        }
+        return preset
+    }
+
     private static func pane(from url: URL) -> String? {
         let raw = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?
             .first { $0.name.lowercased() == "pane" }?.value?
@@ -218,7 +240,9 @@ enum CaptureURLCommand: Equatable {
         if name == "aim" { return .aimRecording }
         if name == "seek" { return seconds(from: url).map { .seek($0) } }
         if name == "play" { return .playPause }
-        if name == "export" { return filepath(from: url).map { .exportEditor($0) } }
+        if name == "export" {
+            return filepath(from: url).map { .exportEditor($0, preset: preset(from: url)) }
+        }
         if name == "picture" { return filepath(from: url).map { .addPicture($0) } }
         if name == "editor" {
             guard let raw = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?

--- a/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
+++ b/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
@@ -58,6 +58,8 @@ enum CaptureURLCommand: Equatable {
     case exportEditor(URL)
     /// Performs one of the editor's own actions by name — the same ones the keyboard routes.
     case editorCommand(StudioEditorCommand)
+    /// Brings a picture into the open editor at the playhead.
+    case addPicture(URL)
 
     static let scheme = "sarvkrit"
 
@@ -76,6 +78,7 @@ enum CaptureURLCommand: Equatable {
         case .playPause: return "play"
         case .exportEditor: return "export"
         case .editorCommand: return "editor"
+        case .addPicture: return "picture"
         case .action(let action): return Self.names[action] ?? action.rawValue
         }
     }
@@ -102,7 +105,7 @@ enum CaptureURLCommand: Equatable {
             + [.capturePreviousArea, .openAnnotate(nil), .openFromClipboard, .openSettings,
                .cancel, .record(.display, windowID: nil), .stopRecording, .seek(0), .playPause,
                .exportEditor(URL(fileURLWithPath: "/tmp/Recording.mp4")),
-               .editorCommand(.split)]
+               .editorCommand(.split), .addPicture(URL(fileURLWithPath: "/tmp/logo.png"))]
     }
 
     private static func rect(from url: URL) -> CGRect? {
@@ -191,6 +194,7 @@ enum CaptureURLCommand: Equatable {
         if name == "seek" { return seconds(from: url).map { .seek($0) } }
         if name == "play" { return .playPause }
         if name == "export" { return filepath(from: url).map { .exportEditor($0) } }
+        if name == "picture" { return filepath(from: url).map { .addPicture($0) } }
         if name == "editor" {
             guard let raw = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?
                 .first(where: { $0.name.lowercased() == "do" })?.value,

--- a/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
+++ b/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
@@ -47,6 +47,11 @@ enum CaptureURLCommand: Equatable {
     case record(RecordingSource, windowID: CGWindowID?)
     /// Stops the recording in progress and opens it in the editor.
     case stopRecording
+    /// Moves the open editor's playhead, in seconds.
+    ///
+    /// **The scriptable form of dragging the scrubber**, which is otherwise unreachable without a
+    /// mouse — and therefore untestable on a machine that refuses synthetic input.
+    case seek(TimeInterval)
 
     static let scheme = "sarvkrit"
 
@@ -61,6 +66,7 @@ enum CaptureURLCommand: Equatable {
         case .captureRect: return "capture-area"
         case .record: return "record"
         case .stopRecording: return "stop-recording"
+        case .seek: return "seek"
         case .action(let action): return Self.names[action] ?? action.rawValue
         }
     }
@@ -85,7 +91,7 @@ enum CaptureURLCommand: Equatable {
     static var all: [CaptureURLCommand] {
         ScreenshotAction.allCases.map { .action($0) }
             + [.capturePreviousArea, .openAnnotate(nil), .openFromClipboard, .openSettings,
-               .cancel, .record(.display, windowID: nil), .stopRecording]
+               .cancel, .record(.display, windowID: nil), .stopRecording, .seek(0)]
     }
 
     private static func rect(from url: URL) -> CGRect? {
@@ -145,6 +151,16 @@ enum CaptureURLCommand: Equatable {
         return CGWindowID(value)
     }
 
+    /// Refused rather than clamped when absent or negative: a script that computed a time wrongly
+    /// should move nothing, the same rule the rest of this parser follows.
+    private static func seconds(from url: URL) -> TimeInterval? {
+        guard let raw = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?
+            .first(where: { $0.name.lowercased() == "t" })?.value,
+            let value = Double(raw), value >= 0, value.isFinite
+        else { return nil }
+        return value
+    }
+
     static func parse(_ url: URL) -> CaptureURLCommand? {
         guard url.scheme?.lowercased() == scheme else { return nil }
 
@@ -161,6 +177,7 @@ enum CaptureURLCommand: Equatable {
         if name == "open-from-clipboard" { return .openFromClipboard }
         if name == "open-settings" { return .openSettings }
         if name == "stop-recording" { return .stopRecording }
+        if name == "seek" { return seconds(from: url).map { .seek($0) } }
         if name == "record" {
             guard let source = recordingSource(from: url) else { return nil }
             return .record(source, windowID: windowID(from: url))

--- a/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
+++ b/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
@@ -52,6 +52,8 @@ enum CaptureURLCommand: Equatable {
     /// **The scriptable form of dragging the scrubber**, which is otherwise unreachable without a
     /// mouse — and therefore untestable on a machine that refuses synthetic input.
     case seek(TimeInterval)
+    /// Starts or stops playback in the open editor.
+    case playPause
 
     static let scheme = "sarvkrit"
 
@@ -67,6 +69,7 @@ enum CaptureURLCommand: Equatable {
         case .record: return "record"
         case .stopRecording: return "stop-recording"
         case .seek: return "seek"
+        case .playPause: return "play"
         case .action(let action): return Self.names[action] ?? action.rawValue
         }
     }
@@ -91,7 +94,7 @@ enum CaptureURLCommand: Equatable {
     static var all: [CaptureURLCommand] {
         ScreenshotAction.allCases.map { .action($0) }
             + [.capturePreviousArea, .openAnnotate(nil), .openFromClipboard, .openSettings,
-               .cancel, .record(.display, windowID: nil), .stopRecording, .seek(0)]
+               .cancel, .record(.display, windowID: nil), .stopRecording, .seek(0), .playPause]
     }
 
     private static func rect(from url: URL) -> CGRect? {
@@ -178,6 +181,7 @@ enum CaptureURLCommand: Equatable {
         if name == "open-settings" { return .openSettings }
         if name == "stop-recording" { return .stopRecording }
         if name == "seek" { return seconds(from: url).map { .seek($0) } }
+        if name == "play" { return .playPause }
         if name == "record" {
             guard let source = recordingSource(from: url) else { return nil }
             return .record(source, windowID: windowID(from: url))

--- a/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
+++ b/Sources/Sarvkrit/Features/Screenshots/CaptureURLCommand.swift
@@ -38,6 +38,15 @@ enum CaptureURLCommand: Equatable {
     case openFromClipboard
     /// Sarvkrit's own window, on the Capture pane.
     case openSettings
+    /// Starts a recording, skipping the pre-record bar — camera, microphone and countdown are
+    /// whatever the settings already say.
+    ///
+    /// **The window selector is the point.** Recording a *window* is the case that has been
+    /// hardest to diagnose, and without a way to name one from a script it can only be reached by
+    /// hand. Nil with `.window` means the frontmost window that is not one of ours.
+    case record(RecordingSource, windowID: CGWindowID?)
+    /// Stops the recording in progress and opens it in the editor.
+    case stopRecording
 
     static let scheme = "sarvkrit"
 
@@ -50,6 +59,8 @@ enum CaptureURLCommand: Equatable {
         case .openFromClipboard: return "open-from-clipboard"
         case .openSettings: return "open-settings"
         case .captureRect: return "capture-area"
+        case .record: return "record"
+        case .stopRecording: return "stop-recording"
         case .action(let action): return Self.names[action] ?? action.rawValue
         }
     }
@@ -74,7 +85,7 @@ enum CaptureURLCommand: Equatable {
     static var all: [CaptureURLCommand] {
         ScreenshotAction.allCases.map { .action($0) }
             + [.capturePreviousArea, .openAnnotate(nil), .openFromClipboard, .openSettings,
-               .cancel]
+               .cancel, .record(.display, windowID: nil), .stopRecording]
     }
 
     private static func rect(from url: URL) -> CGRect? {
@@ -116,6 +127,24 @@ enum CaptureURLCommand: Equatable {
         return index
     }
 
+    /// Absent means the whole display, which is the right default for an unattended script.
+    /// A source we do not have returns nil rather than falling back — a typo should record
+    /// nothing, the same rule the rest of this parser follows.
+    private static func recordingSource(from url: URL) -> RecordingSource? {
+        guard let raw = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?
+            .first(where: { $0.name.lowercased() == "source" })?.value, !raw.isEmpty
+        else { return .display }
+        return RecordingSource(rawValue: raw.lowercased())
+    }
+
+    private static func windowID(from url: URL) -> CGWindowID? {
+        guard let raw = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?
+            .first(where: { $0.name.lowercased() == "window" })?.value,
+              let value = UInt32(raw)
+        else { return nil }
+        return CGWindowID(value)
+    }
+
     static func parse(_ url: URL) -> CaptureURLCommand? {
         guard url.scheme?.lowercased() == scheme else { return nil }
 
@@ -131,6 +160,11 @@ enum CaptureURLCommand: Equatable {
         if name == "open-annotate" { return .openAnnotate(filepath(from: url)) }
         if name == "open-from-clipboard" { return .openFromClipboard }
         if name == "open-settings" { return .openSettings }
+        if name == "stop-recording" { return .stopRecording }
+        if name == "record" {
+            guard let source = recordingSource(from: url) else { return nil }
+            return .record(source, windowID: windowID(from: url))
+        }
         if let match = names.first(where: { $0.value == name })?.key {
             // All four or none. Three of them is a script with a bug in it, and guessing the
             // fourth would take a screenshot of the wrong thing rather than saying so.

--- a/Sources/Sarvkrit/Features/Studio/CameraLayout.swift
+++ b/Sources/Sarvkrit/Features/Studio/CameraLayout.swift
@@ -105,11 +105,16 @@ struct CameraState: Equatable {
 /// *becomes* the picture-in-picture rather than cutting to it.
 enum CameraLayoutResolver {
 
+    /// - Parameter clipSource: the source range of the clip this frame came from. The blend is
+    ///   clamped to it for the same reason the zoom envelope is — after a cut, source time is not
+    ///   monotonic in output time, so a blend measured from the segment's own end is still running
+    ///   when the picture jumps and the camera snaps mid-move.
     static func state(at t: TimeInterval,
                       segments: [CameraSegment],
                       settings: CameraSettings,
                       canvas: CGSize,
-                      zoom: Double) -> CameraState? {
+                      zoom: Double,
+                      clipSource: Range<TimeInterval>? = nil) -> CameraState? {
         guard canvas.width > 0, canvas.height > 0 else { return nil }
 
         let pip = pipRect(settings: settings, canvas: canvas, zoom: zoom)
@@ -130,7 +135,7 @@ enum CameraLayoutResolver {
 
         // Blended towards the neighbouring layout across the transition, at both ends, so the
         // change reads as one movement rather than as two cuts.
-        let blend = blendFraction(at: t, segment: segment)
+        let blend = blendFraction(at: t, segment: segment, clipSource: clipSource)
         guard blend < 1 else {
             return CameraState(rect: target, cornerRadius: radius(for: target, settings: settings),
                                opacity: opacity)
@@ -142,10 +147,13 @@ enum CameraLayoutResolver {
     }
 
     /// 1 while the segment holds, ramping from 0 at each edge.
-    private static func blendFraction(at t: TimeInterval, segment: CameraSegment) -> Double {
+    private static func blendFraction(at t: TimeInterval, segment: CameraSegment,
+                                      clipSource: Range<TimeInterval>?) -> Double {
         guard segment.transition > 0 else { return 1 }
-        let intoStart = t - segment.start
-        let toEnd = segment.end - t
+        let start = max(segment.start, clipSource?.lowerBound ?? -.greatestFiniteMagnitude)
+        let end = min(segment.end, clipSource?.upperBound ?? .greatestFiniteMagnitude)
+        let intoStart = t - start
+        let toEnd = end - t
         return min(1, min(intoStart, toEnd) / segment.transition)
     }
 

--- a/Sources/Sarvkrit/Features/Studio/CameraLayout.swift
+++ b/Sources/Sarvkrit/Features/Studio/CameraLayout.swift
@@ -1,0 +1,179 @@
+import CoreGraphics
+import Foundation
+
+/// How the camera is framed when it is a picture-in-picture.
+struct CameraSettings: Codable, Equatable {
+
+    enum Shape: String, Codable, CaseIterable, Equatable {
+        case circle, squircle, rectangle
+
+        var title: String {
+            switch self {
+            case .circle: return "Circle"
+            case .squircle: return "Squircle"
+            case .rectangle: return "Rectangle"
+            }
+        }
+    }
+
+    /// What happens to the camera while the frame is zoomed in.
+    enum ZoomSizing: String, Codable, CaseIterable, Equatable {
+        /// **The default, and the opposite of the instinct.** A zoom exists to show something, and
+        /// the camera covering it defeats the zoom.
+        case shrink
+        case hold
+        case grow
+
+        var title: String {
+            switch self {
+            case .shrink: return "Get smaller"
+            case .hold: return "Stay the same"
+            case .grow: return "Get larger"
+            }
+        }
+
+        fileprivate var exponent: Double {
+            switch self {
+            case .shrink: return -0.2
+            case .hold: return 0
+            case .grow: return 0.15
+            }
+        }
+    }
+
+    var shape: Shape = .squircle
+    /// Of the shorter side. The reference's PiP is a continuous-curve squircle and the difference
+    /// from a circular corner is visible at this size.
+    var cornerRadiusFraction: Double = 0.26
+    /// Of the canvas height.
+    var sizeFraction: Double = 0.22
+    var aspect: Double = 1
+    var corner: CaptureBackground.Alignment = .bottomLeading
+    /// Of the canvas, measured from its edge — not from the project's padding, or raising the
+    /// padding would appear to move the camera.
+    var marginFraction: Double = 0.03
+    var shadow: CaptureBackground.Shadow? = CaptureBackground.Shadow()
+    /// Front cameras look wrong un-mirrored.
+    var mirrored = true
+    var sizeDuringZoom: ZoomSizing = .shrink
+    var fadeSeconds: TimeInterval = 0.35
+    var removesBackground = false
+
+    init() {}
+}
+
+/// One stretch with a particular camera layout.
+///
+/// **A track rather than a setting**, because the shape of a good demo is full-frame camera for a
+/// short intro, picture-in-picture for the walkthrough, and hidden over a dense diagram. A single
+/// "camera position" cannot express any of that.
+struct CameraSegment: Codable, Equatable, Identifiable {
+    enum Layout: String, Codable, CaseIterable, Equatable {
+        case pip, fullFrame, hidden
+
+        var title: String {
+            switch self {
+            case .pip: return "Picture in picture"
+            case .fullFrame: return "Full frame"
+            case .hidden: return "Hidden"
+            }
+        }
+    }
+
+    var id = UUID()
+    var start: TimeInterval
+    var end: TimeInterval
+    var layout: Layout
+    var transition: TimeInterval = 0.45
+}
+
+/// Where the camera is, right now.
+struct CameraState: Equatable {
+    var rect: CGRect
+    var cornerRadius: CGFloat
+    var opacity: Double
+}
+
+/// Resolving the camera track into one rectangle.
+///
+/// Position, size and corner radius all animate together on a single curve, so a full-frame camera
+/// *becomes* the picture-in-picture rather than cutting to it.
+enum CameraLayoutResolver {
+
+    static func state(at t: TimeInterval,
+                      segments: [CameraSegment],
+                      settings: CameraSettings,
+                      canvas: CGSize,
+                      zoom: Double) -> CameraState? {
+        guard canvas.width > 0, canvas.height > 0 else { return nil }
+
+        let pip = pipRect(settings: settings, canvas: canvas, zoom: zoom)
+        let full = CGRect(origin: .zero, size: canvas)
+
+        guard let segment = segments.first(where: { t >= $0.start && t < $0.end }) else {
+            return CameraState(rect: pip, cornerRadius: radius(for: pip, settings: settings),
+                               opacity: 1)
+        }
+
+        let target: CGRect
+        let opacity: Double
+        switch segment.layout {
+        case .pip: target = pip; opacity = 1
+        case .fullFrame: target = full; opacity = 1
+        case .hidden: return nil
+        }
+
+        // Blended towards the neighbouring layout across the transition, at both ends, so the
+        // change reads as one movement rather than as two cuts.
+        let blend = blendFraction(at: t, segment: segment)
+        guard blend < 1 else {
+            return CameraState(rect: target, cornerRadius: radius(for: target, settings: settings),
+                               opacity: opacity)
+        }
+        let eased = CGFloat(ZoomEase.smooth.value(blend))
+        let rect = interpolate(from: pip, to: target, fraction: eased)
+        return CameraState(rect: rect, cornerRadius: radius(for: rect, settings: settings),
+                           opacity: opacity)
+    }
+
+    /// 1 while the segment holds, ramping from 0 at each edge.
+    private static func blendFraction(at t: TimeInterval, segment: CameraSegment) -> Double {
+        guard segment.transition > 0 else { return 1 }
+        let intoStart = t - segment.start
+        let toEnd = segment.end - t
+        return min(1, min(intoStart, toEnd) / segment.transition)
+    }
+
+    private static func interpolate(from: CGRect, to: CGRect, fraction: CGFloat) -> CGRect {
+        CGRect(x: from.minX + (to.minX - from.minX) * fraction,
+               y: from.minY + (to.minY - from.minY) * fraction,
+               width: from.width + (to.width - from.width) * fraction,
+               height: from.height + (to.height - from.height) * fraction)
+    }
+
+    private static func pipRect(settings: CameraSettings, canvas: CGSize,
+                                zoom: Double) -> CGRect {
+        let scale = pow(max(zoom, 1), settings.sizeDuringZoom.exponent)
+        let height = canvas.height * CGFloat(settings.sizeFraction * scale)
+        let width = height * CGFloat(max(settings.aspect, 0.1))
+        let margin = CGSize(width: canvas.width * CGFloat(settings.marginFraction),
+                            height: canvas.height * CGFloat(settings.marginFraction))
+
+        let unit = settings.corner.unitPoint
+        let free = CGSize(width: max(0, canvas.width - width - margin.width * 2),
+                          height: max(0, canvas.height - height - margin.height * 2))
+        return CGRect(x: margin.width + free.width * unit.x,
+                      y: margin.height + free.height * unit.y,
+                      width: width, height: height)
+    }
+
+    /// From the *shorter* side, so a non-square camera does not end up with lozenge ends.
+    private static func radius(for rect: CGRect, settings: CameraSettings) -> CGFloat {
+        let shorter = min(rect.width, rect.height)
+        switch settings.shape {
+        case .circle: return shorter / 2
+        case .rectangle: return 0
+        case .squircle: return min(shorter / 2, shorter * CGFloat(settings.cornerRadiusFraction))
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/CameraLayout.swift
+++ b/Sources/Sarvkrit/Features/Studio/CameraLayout.swift
@@ -18,8 +18,12 @@ struct CameraSettings: Codable, Equatable {
 
     /// What happens to the camera while the frame is zoomed in.
     enum ZoomSizing: String, Codable, CaseIterable, Equatable {
-        /// **The default, and the opposite of the instinct.** A zoom exists to show something, and
-        /// the camera covering it defeats the zoom.
+        /// A zoom exists to show something, and the camera covering it defeats the zoom.
+        ///
+        /// **No longer the default, and the argument against it is stronger.** A camera that
+        /// quietly changes size every time the auto-zoom fires reads as a glitch — you notice your
+        /// own face breathing in and out and cannot tell why. Holding still is the calmer default;
+        /// this stays for anyone who prefers the trade.
         case shrink
         case hold
         case grow
@@ -55,7 +59,8 @@ struct CameraSettings: Codable, Equatable {
     var shadow: CaptureBackground.Shadow? = CaptureBackground.Shadow()
     /// Front cameras look wrong un-mirrored.
     var mirrored = true
-    var sizeDuringZoom: ZoomSizing = .shrink
+    /// **Fixed by default.** See `ZoomSizing.shrink` for the argument this reverses.
+    var sizeDuringZoom: ZoomSizing = .hold
     var fadeSeconds: TimeInterval = 0.35
     var removesBackground = false
 

--- a/Sources/Sarvkrit/Features/Studio/CameraLayout.swift
+++ b/Sources/Sarvkrit/Features/Studio/CameraLayout.swift
@@ -126,7 +126,8 @@ enum CameraLayoutResolver {
         let pip = pipRect(settings: settings, canvas: canvas, zoom: zoom)
         let full = CGRect(origin: .zero, size: canvas)
 
-        let arriving = arrival(at: t, start: cameraStart, fade: settings.fadeSeconds)
+        let arriving = arrival(at: t, start: cameraStart, fade: settings.fadeSeconds,
+                               clipStart: clipSource?.lowerBound)
 
         guard let segment = segments.first(where: { t >= $0.start && t < $0.end }) else {
             return CameraState(rect: pip, cornerRadius: radius(for: pip, settings: settings),
@@ -155,9 +156,17 @@ enum CameraLayoutResolver {
     }
 
     /// How far in the camera is, having only just started.
+    ///
+    /// **The fade softens an arrival, and there is no arrival if the camera was already running
+    /// when the visible material begins.** The trimmed lead-in puts this exactly on the seam: a
+    /// project whose first clip starts at the capture offset opens at `t == cameraStart`, which is
+    /// the first frame of the fade — so the very frame the user looks at first would carry no
+    /// camera, and trimming would have moved the hole rather than closed it. Anything past a
+    /// split is the same case.
     private static func arrival(at t: TimeInterval, start: TimeInterval,
-                                fade: TimeInterval) -> Double {
-        guard fade > 0 else { return 1 }
+                                fade: TimeInterval,
+                                clipStart: TimeInterval? = nil) -> Double {
+        guard fade > 0, (clipStart ?? 0) < start else { return 1 }
         return min(1, max(0, (t - start) / fade))
     }
 

--- a/Sources/Sarvkrit/Features/Studio/CameraLayout.swift
+++ b/Sources/Sarvkrit/Features/Studio/CameraLayout.swift
@@ -109,27 +109,35 @@ enum CameraLayoutResolver {
     ///   clamped to it for the same reason the zoom envelope is — after a cut, source time is not
     ///   monotonic in output time, so a blend measured from the segment's own end is still running
     ///   when the picture jumps and the camera snaps mid-move.
+    /// - Parameter cameraStart: when the camera track begins, in source time. It is a couple of
+    ///   seconds after the screen, because that is how long a capture session takes to come up —
+    ///   so the bubble is faded in over `settings.fadeSeconds` from there rather than arriving in
+    ///   one frame. `fadeSeconds` existed and was offered in the inspector, and nothing rendered
+    ///   it.
     static func state(at t: TimeInterval,
                       segments: [CameraSegment],
                       settings: CameraSettings,
                       canvas: CGSize,
                       zoom: Double,
-                      clipSource: Range<TimeInterval>? = nil) -> CameraState? {
+                      clipSource: Range<TimeInterval>? = nil,
+                      cameraStart: TimeInterval = 0) -> CameraState? {
         guard canvas.width > 0, canvas.height > 0 else { return nil }
 
         let pip = pipRect(settings: settings, canvas: canvas, zoom: zoom)
         let full = CGRect(origin: .zero, size: canvas)
 
+        let arriving = arrival(at: t, start: cameraStart, fade: settings.fadeSeconds)
+
         guard let segment = segments.first(where: { t >= $0.start && t < $0.end }) else {
             return CameraState(rect: pip, cornerRadius: radius(for: pip, settings: settings),
-                               opacity: 1)
+                               opacity: arriving)
         }
 
         let target: CGRect
         let opacity: Double
         switch segment.layout {
-        case .pip: target = pip; opacity = 1
-        case .fullFrame: target = full; opacity = 1
+        case .pip: target = pip; opacity = arriving
+        case .fullFrame: target = full; opacity = arriving
         case .hidden: return nil
         }
 
@@ -144,6 +152,13 @@ enum CameraLayoutResolver {
         let rect = interpolate(from: pip, to: target, fraction: eased)
         return CameraState(rect: rect, cornerRadius: radius(for: rect, settings: settings),
                            opacity: opacity)
+    }
+
+    /// How far in the camera is, having only just started.
+    private static func arrival(at t: TimeInterval, start: TimeInterval,
+                                fade: TimeInterval) -> Double {
+        guard fade > 0 else { return 1 }
+        return min(1, max(0, (t - start) / fade))
     }
 
     /// 1 while the segment holds, ramping from 0 at each edge.

--- a/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
+++ b/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
@@ -17,6 +17,10 @@ final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
     private var session: AVCaptureSession?
     private var movieOutput: AVCaptureMovieFileOutput?
 
+    /// Every blocking call into the capture graph goes through here, in order. The type's own
+    /// documentation carries the crash that made it necessary.
+    private let runner = CaptureSessionRunner(label: "ai.psylief.sarvkrit.camera")
+
     private(set) var isRecording = false
 
     /// Every camera on this Mac.
@@ -65,26 +69,34 @@ final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         session.addOutput(output)
         session.commitConfiguration()
 
-        // Off the main thread: starting a capture session blocks for a noticeable moment, and
-        // doing it on the main actor stalls the countdown the user is watching.
-        Task.detached { session.startRunning() }
-
-        try? FileManager.default.removeItem(at: url)
-        output.startRecording(to: url, recordingDelegate: self)
-
         self.session = session
         self.movieOutput = output
         isRecording = true
+
+        // Building the graph above is cheap. These two calls are not: `startRunning()` blocks
+        // until the graph is up, and `startRecording(to:)` blocks until the session is running.
+        // They go one after the other on one thread, off the main actor — the previous version
+        // detached the first and made the second here, and see `CaptureSessionRunner` for how
+        // that ended.
+        runner.submit {
+            session.startRunning()
+            try? FileManager.default.removeItem(at: url)
+            output.startRecording(to: url, recordingDelegate: self)
+        }
     }
 
     func finish() {
         guard isRecording else { return }
-        movieOutput?.stopRecording()
         isRecording = false
         let session = self.session
-        Task.detached { session?.stopRunning() }
+        let output = movieOutput
         self.session = nil
         movieOutput = nil
+        // The same queue as `start`, so a stop can never overtake the start it is meant to end.
+        runner.submit {
+            output?.stopRecording()
+            session?.stopRunning()
+        }
     }
 
     nonisolated func fileOutput(_ output: AVCaptureFileOutput,

--- a/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
+++ b/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
@@ -33,6 +33,18 @@ final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
 
     private(set) var isRecording = false
 
+    /// `systemUptime` at the instant the camera's first sample was written, or nil if it never was.
+    ///
+    /// The same clock `RecordingWriter.firstFrameHostTime` uses, so the gap between the two tracks
+    /// is a plain subtraction. Written from AVFoundation's queue, read from the main actor once the
+    /// take has ended, and guarded because of it.
+    var startedAtHostTime: TimeInterval? {
+        startLock.lock(); defer { startLock.unlock() }
+        return _startedAtHostTime
+    }
+    private let startLock = NSLock()
+    private nonisolated(unsafe) var _startedAtHostTime: TimeInterval?
+
     /// Every camera on this Mac.
     static func devices() -> [AVCaptureDevice] {
         AVCaptureDevice.DiscoverySession(
@@ -56,6 +68,8 @@ final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
     func start(device: AVCaptureDevice?, microphone: AVCaptureDevice?,
                to url: URL, height: Int = 1080) throws {
         guard !isRecording, device != nil || microphone != nil else { return }
+        // Cleared here rather than in `finish()`, which is called *before* the service reads it.
+        startLock.lock(); _startedAtHostTime = nil; startLock.unlock()
 
         let session = AVCaptureSession()
         session.beginConfiguration()
@@ -115,6 +129,18 @@ final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
             output?.stopRecording()
             session?.stopRunning()
         }
+    }
+
+    /// **The camera does not start when the screen does.** Bringing an `AVCaptureSession` up takes
+    /// a couple of seconds, so this fires that much later than the first screen frame. Recording
+    /// the moment is what lets the editor put the two tracks back in step; without it the camera
+    /// plays seconds ahead of what it is reacting to.
+    nonisolated func fileOutput(_ output: AVCaptureFileOutput,
+                                didStartRecordingTo fileURL: URL,
+                                from connections: [AVCaptureConnection]) {
+        startLock.lock()
+        _startedAtHostTime = ProcessInfo.processInfo.systemUptime
+        startLock.unlock()
     }
 
     nonisolated func fileOutput(_ output: AVCaptureFileOutput,

--- a/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
+++ b/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
@@ -1,0 +1,144 @@
+import AVFoundation
+import Foundation
+import os
+
+/// Recording the camera alongside the screen.
+///
+/// Its own `AVCaptureSession` writing its own file, rather than a track muxed into the screen
+/// recording. Separate because the editor has to be able to hide the camera for a stretch, change
+/// its shape, or drop it entirely — none of which is possible once it has been composited in.
+@MainActor
+final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
+    private let log = Logger(subsystem: AppIdentity.logSubsystem, category: "Recording")
+
+    private var session: AVCaptureSession?
+    private var movieOutput: AVCaptureMovieFileOutput?
+
+    private(set) var isRecording = false
+
+    /// Every camera on this Mac.
+    static func devices() -> [AVCaptureDevice] {
+        AVCaptureDevice.DiscoverySession(
+            deviceTypes: [.builtInWideAngleCamera, .external, .continuityCamera],
+            mediaType: .video, position: .unspecified).devices
+    }
+
+    static func microphones() -> [AVCaptureDevice] {
+        AVCaptureDevice.DiscoverySession(deviceTypes: [.microphone],
+                                         mediaType: .audio, position: .unspecified).devices
+    }
+
+    static func requestAccess(for media: AVMediaType) async -> Bool {
+        await AVCaptureDevice.requestAccess(for: media)
+    }
+
+    /// - Parameter height: capped, because a 4K webcam feed for a 300-point circle is pure waste —
+    ///   it costs encode time and disk for detail the canvas throws away.
+    func start(device: AVCaptureDevice, microphone: AVCaptureDevice?,
+               to url: URL, height: Int = 1080) throws {
+        guard !isRecording else { return }
+
+        let session = AVCaptureSession()
+        session.beginConfiguration()
+        session.sessionPreset = height >= 1080 ? .hd1920x1080 : .hd1280x720
+
+        let videoInput = try AVCaptureDeviceInput(device: device)
+        guard session.canAddInput(videoInput) else { throw RecordingError.cannotWrite }
+        session.addInput(videoInput)
+
+        if let microphone, let audioInput = try? AVCaptureDeviceInput(device: microphone),
+           session.canAddInput(audioInput) {
+            session.addInput(audioInput)
+        }
+
+        let output = AVCaptureMovieFileOutput()
+        guard session.canAddOutput(output) else { throw RecordingError.cannotWrite }
+        session.addOutput(output)
+        session.commitConfiguration()
+
+        // Off the main thread: starting a capture session blocks for a noticeable moment, and
+        // doing it on the main actor stalls the countdown the user is watching.
+        Task.detached { session.startRunning() }
+
+        try? FileManager.default.removeItem(at: url)
+        output.startRecording(to: url, recordingDelegate: self)
+
+        self.session = session
+        self.movieOutput = output
+        isRecording = true
+    }
+
+    func finish() {
+        guard isRecording else { return }
+        movieOutput?.stopRecording()
+        isRecording = false
+        let session = self.session
+        Task.detached { session?.stopRunning() }
+        self.session = nil
+        movieOutput = nil
+    }
+
+    nonisolated func fileOutput(_ output: AVCaptureFileOutput,
+                                didFinishRecordingTo outputFileURL: URL,
+                                from connections: [AVCaptureConnection],
+                                error: Error?) {
+        guard let error else { return }
+        MainActor.assumeIsolated {
+            log.error("camera recording failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}
+
+/// Turning an audio file into the amplitude envelope the silence detector and the waveform both
+/// read.
+///
+/// Pure arithmetic over decoded samples, kept here rather than inside `SilenceDetector` so that
+/// detector stays free of AVFoundation and testable with an array of floats.
+enum AudioEnvelope {
+
+    /// - Parameter samplesPerSecond: the envelope's own resolution, not the audio's.
+    static func read(url: URL, samplesPerSecond: Double = 100) async throws -> [Float] {
+        let asset = AVURLAsset(url: url)
+        guard let track = try await asset.loadTracks(withMediaType: .audio).first else { return [] }
+
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsNonInterleaved: false,
+        ])
+        reader.add(output)
+        guard reader.startReading() else { return [] }
+
+        let rate = try await track.load(.naturalTimeScale)
+        let perSlice = max(1, Int(Double(rate) / samplesPerSecond))
+        var envelope: [Float] = []
+        var peak: Float = 0
+        var counted = 0
+
+        while let sample = output.copyNextSampleBuffer() {
+            guard let block = CMSampleBufferGetDataBuffer(sample) else { continue }
+            var length = 0
+            var pointer: UnsafeMutablePointer<Int8>?
+            guard CMBlockBufferGetDataPointer(block, atOffset: 0, lengthAtOffsetOut: nil,
+                                              totalLengthOut: &length,
+                                              dataPointerOut: &pointer) == noErr,
+                  let pointer else { continue }
+
+            pointer.withMemoryRebound(to: Float.self, capacity: length / 4) { floats in
+                for index in 0..<(length / 4) {
+                    peak = max(peak, abs(floats[index]))
+                    counted += 1
+                    if counted >= perSlice {
+                        envelope.append(peak)
+                        peak = 0
+                        counted = 0
+                    }
+                }
+            }
+        }
+        if counted > 0 { envelope.append(peak) }
+        return envelope
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
+++ b/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
@@ -9,7 +9,10 @@ import os
 /// its shape, or drop it entirely — none of which is possible once it has been composited in.
 @MainActor
 final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
-    private let log = Logger(subsystem: AppIdentity.logSubsystem, category: "Recording")
+    /// Nonisolated: `os.Logger` is Sendable, and the delegate callback below arrives on
+    /// AVFoundation's own queue.
+    private nonisolated let log = Logger(subsystem: AppIdentity.logSubsystem,
+                                         category: "Recording")
 
     private var session: AVCaptureSession?
     private var movieOutput: AVCaptureMovieFileOutput?
@@ -89,9 +92,10 @@ final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
                                 from connections: [AVCaptureConnection],
                                 error: Error?) {
         guard let error else { return }
-        MainActor.assumeIsolated {
-            log.error("camera recording failed: \(error.localizedDescription, privacy: .public)")
-        }
+        // Logged straight from AVFoundation's queue. Hopping to the main actor to write a line —
+        // and asserting our way onto it — turned "the camera recording failed" into "the app
+        // died", which is a strictly worse outcome for the same event.
+        log.error("camera recording failed: \(error.localizedDescription, privacy: .public)")
     }
 }
 

--- a/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
+++ b/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
@@ -17,6 +17,16 @@ final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
     private var session: AVCaptureSession?
     private var movieOutput: AVCaptureMovieFileOutput?
 
+    /// A view of the session, for the on-screen preview.
+    ///
+    /// **Built during configuration, before the graph is running.** Creating it later — while the
+    /// file output was already recording — adds a connection to a live session, which
+    /// reconfigures it and stops the take: the camera file ended 1.2 seconds in with
+    /// "Recording Stopped" and nothing said why. It is also deliberately a view of this session
+    /// rather than a second `AVCaptureSession`, which is how the pre-record bar's preview and the
+    /// recorder came to be fighting over one device.
+    private(set) var previewLayer: AVCaptureVideoPreviewLayer?
+
     /// Every blocking call into the capture graph goes through here, in order. The type's own
     /// documentation carries the crash that made it necessary.
     private let runner = CaptureSessionRunner(label: "ai.psylief.sarvkrit.camera")
@@ -69,6 +79,13 @@ final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         session.addOutput(output)
         session.commitConfiguration()
 
+        // Before anything starts running, for the reason on the property.
+        if device != nil {
+            let preview = AVCaptureVideoPreviewLayer(session: session)
+            preview.videoGravity = .resizeAspectFill
+            previewLayer = preview
+        }
+
         self.session = session
         self.movieOutput = output
         isRecording = true
@@ -92,6 +109,7 @@ final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
         let output = movieOutput
         self.session = nil
         movieOutput = nil
+        previewLayer = nil
         // The same queue as `start`, so a stop can never overtake the start it is meant to end.
         runner.submit {
             output?.stopRecording()

--- a/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
+++ b/Sources/Sarvkrit/Features/Studio/CameraRecorder.swift
@@ -34,17 +34,23 @@ final class CameraRecorder: NSObject, AVCaptureFileOutputRecordingDelegate {
 
     /// - Parameter height: capped, because a 4K webcam feed for a 300-point circle is pure waste —
     ///   it costs encode time and disk for detail the canvas throws away.
-    func start(device: AVCaptureDevice, microphone: AVCaptureDevice?,
+    /// - Parameter device: nil records the microphone alone, which is what somebody who wants
+    ///   narration without appearing on camera has asked for.
+    func start(device: AVCaptureDevice?, microphone: AVCaptureDevice?,
                to url: URL, height: Int = 1080) throws {
-        guard !isRecording else { return }
+        guard !isRecording, device != nil || microphone != nil else { return }
 
         let session = AVCaptureSession()
         session.beginConfiguration()
-        session.sessionPreset = height >= 1080 ? .hd1920x1080 : .hd1280x720
+        if device != nil {
+            session.sessionPreset = height >= 1080 ? .hd1920x1080 : .hd1280x720
+        }
 
-        let videoInput = try AVCaptureDeviceInput(device: device)
-        guard session.canAddInput(videoInput) else { throw RecordingError.cannotWrite }
-        session.addInput(videoInput)
+        if let device {
+            let videoInput = try AVCaptureDeviceInput(device: device)
+            guard session.canAddInput(videoInput) else { throw RecordingError.cannotWrite }
+            session.addInput(videoInput)
+        }
 
         if let microphone, let audioInput = try? AVCaptureDeviceInput(device: microphone),
            session.canAddInput(audioInput) {

--- a/Sources/Sarvkrit/Features/Studio/Caption.swift
+++ b/Sources/Sarvkrit/Features/Studio/Caption.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// One word, with the timing the recogniser gave it.
+///
+/// `SFSpeechRecognizer` hands back per-word `timestamp` and `duration`, which is the only reason
+/// word-level highlighting is possible at all — it is not something the app could work out.
+struct TranscriptWord: Codable, Equatable {
+    var text: String
+    var start: TimeInterval
+    var duration: TimeInterval
+
+    var end: TimeInterval { start + duration }
+}
+
+/// One line of captions.
+struct Caption: Codable, Equatable, Identifiable {
+    var id = UUID()
+    var words: [TranscriptWord]
+
+    var start: TimeInterval { words.first?.start ?? 0 }
+    var end: TimeInterval { words.last?.end ?? 0 }
+    var text: String { words.map(\.text).joined(separator: " ") }
+
+    /// How many words have been spoken by `t`.
+    ///
+    /// The renderer draws this many in the spoken colour and the rest in the upcoming one, which is
+    /// the karaoke effect. A word counts as spoken the moment it *starts* — waiting for it to
+    /// finish puts the highlight permanently behind the voice.
+    func spokenWordCount(at t: TimeInterval) -> Int {
+        words.filter { $0.start <= t }.count
+    }
+}
+
+/// Breaking a stream of timed words into lines worth reading.
+///
+/// **This is where caption quality lives.** The recogniser decides the words; where the lines break
+/// decides whether anyone can read them. The answer is the one a person would give: at a breath, at
+/// a full stop, and never so long that the eye has to travel.
+enum CaptionGrouper {
+
+    struct Tuning: Equatable {
+        /// A gap longer than this is where the speaker drew breath.
+        var pause: TimeInterval = 0.45
+        /// Roughly two seconds of reading at a comfortable size.
+        var maximumCharacters: Int = 42
+        var maximumWords: Int = 9
+        /// Sentence enders. A line that runs past a full stop reads as two thoughts at once.
+        var terminators: Set<Character> = [".", "!", "?"]
+
+        init() {}
+    }
+
+    static func lines(from words: [TranscriptWord], tuning: Tuning = Tuning()) -> [Caption] {
+        guard !words.isEmpty else { return [] }
+
+        var lines: [[TranscriptWord]] = []
+        var current: [TranscriptWord] = []
+
+        func flush() {
+            guard !current.isEmpty else { return }
+            lines.append(current)
+            current = []
+        }
+
+        for word in words {
+            if let previous = current.last {
+                let drewBreath = word.start - previous.end > tuning.pause
+                let sentenceEnded = previous.text.last.map { tuning.terminators.contains($0) }
+                    ?? false
+                let wouldBeTooLong = characterCount(current) + word.text.count + 1
+                    > tuning.maximumCharacters
+                let wouldBeTooMany = current.count + 1 > tuning.maximumWords
+
+                if drewBreath || sentenceEnded || wouldBeTooLong || wouldBeTooMany { flush() }
+            }
+            current.append(word)
+        }
+        flush()
+
+        return mergingOrphans(lines).map { Caption(words: $0) }
+    }
+
+    private static func characterCount(_ words: [TranscriptWord]) -> Int {
+        guard !words.isEmpty else { return 0 }
+        return words.reduce(0) { $0 + $1.text.count } + words.count - 1
+    }
+
+    /// A line holding a single word looks like a mistake on screen, so it is pulled back onto the
+    /// line before it. Merging backwards rather than forwards keeps the break at the pause or the
+    /// full stop that caused it, which is the one the reader can hear.
+    private static func mergingOrphans(_ lines: [[TranscriptWord]]) -> [[TranscriptWord]] {
+        guard lines.count > 1 else { return lines }
+        var result: [[TranscriptWord]] = []
+        for line in lines {
+            if line.count == 1, var previous = result.popLast() {
+                previous.append(contentsOf: line)
+                result.append(previous)
+            } else {
+                result.append(line)
+            }
+        }
+        return result
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/CaptionStyle.swift
+++ b/Sources/Sarvkrit/Features/Studio/CaptionStyle.swift
@@ -1,0 +1,120 @@
+import AppKit
+import CoreGraphics
+import CoreText
+import Foundation
+
+/// How captions look.
+struct CaptionStyle: Codable, Equatable {
+    enum Position: String, Codable, CaseIterable, Equatable { case top, centre, bottom }
+    enum Highlight: String, Codable, CaseIterable, Equatable { case word, line, none }
+
+    var fontName = "SF Pro Rounded"
+    var weight: Double = 0.3
+    /// Fraction of the canvas height, so a caption is the same size at 1080p and 4K.
+    var sizeFraction: Double = 0.042
+    var spoken = RGBAColour.white
+    /// Grey rather than dimmed white, matching what the reference does — the contrast between the
+    /// two is what makes the highlight legible at a glance.
+    var upcoming = RGBAColour(r: 0.6, g: 0.6, b: 0.6, a: 1)
+    var background = RGBAColour(r: 0, g: 0, b: 0, a: 0.78)
+    var cornerRadius: Double = 14
+    var paddingX: Double = 16
+    var paddingY: Double = 12
+    var position: Position = .bottom
+    /// Distance from that edge, as a fraction of the canvas.
+    var inset: Double = 0.08
+    var maxWidthFraction: Double = 0.72
+    var highlight: Highlight = .word
+
+    init() {}
+}
+
+/// Drawing one caption line.
+///
+/// **Word-level highlighting is the thing that makes these look expensive**, and it is only
+/// possible because `SFSpeechRecognizer` returns per-word timings. Spoken words are white and
+/// upcoming ones grey, switching at each word's own start.
+enum CaptionRenderer {
+
+    static func draw(_ caption: Caption, spokenWords: Int, canvas: CGSize,
+                     style: CaptionStyle = CaptionStyle(), in context: CGContext) {
+        guard !caption.words.isEmpty, canvas.height > 0 else { return }
+
+        let size = CGFloat(style.sizeFraction) * canvas.height
+        let font = resolvedFont(style: style, size: size)
+        let text = attributed(caption, spokenWords: spokenWords, style: style, font: font)
+
+        let maxWidth = canvas.width * CGFloat(style.maxWidthFraction)
+        let framesetter = CTFramesetterCreateWithAttributedString(text)
+        let measured = CTFramesetterSuggestFrameSizeWithConstraints(
+            framesetter, CFRange(location: 0, length: 0), nil,
+            CGSize(width: maxWidth, height: .greatestFiniteMagnitude), nil)
+
+        let boxWidth = measured.width + CGFloat(style.paddingX) * 2
+        let boxHeight = measured.height + CGFloat(style.paddingY) * 2
+        let origin = boxOrigin(style: style, canvas: canvas,
+                               size: CGSize(width: boxWidth, height: boxHeight))
+        let box = CGRect(origin: origin, size: CGSize(width: boxWidth, height: boxHeight))
+
+        context.saveGState()
+        context.addPath(CGPath.rounded(box, cornerRadius: CGFloat(style.cornerRadius)))
+        context.setFillColor(style.background.cgColor)
+        context.fillPath()
+
+        // Core Text draws bottom-up; the surrounding context is top-left, so the text block is
+        // flipped back for the duration of the draw and no further.
+        let textRect = box.insetBy(dx: CGFloat(style.paddingX), dy: CGFloat(style.paddingY))
+        context.translateBy(x: 0, y: textRect.midY * 2)
+        context.scaleBy(x: 1, y: -1)
+        let path = CGPath(rect: textRect, transform: nil)
+        let frame = CTFramesetterCreateFrame(framesetter, CFRange(location: 0, length: 0),
+                                             path, nil)
+        CTFrameDraw(frame, context)
+        context.restoreGState()
+    }
+
+    private static func attributed(_ caption: Caption, spokenWords: Int,
+                                   style: CaptionStyle, font: NSFont) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+        paragraph.lineBreakMode = .byWordWrapping
+
+        for (index, word) in caption.words.enumerated() {
+            let spoken = style.highlight == .none
+                || (style.highlight == .line ? spokenWords > 0 : index < spokenWords)
+            let colour = spoken ? style.spoken : style.upcoming
+            let piece = NSAttributedString(
+                string: index == 0 ? word.text : " " + word.text,
+                attributes: [.font: font,
+                             .foregroundColor: NSColor(cgColor: colour.cgColor) ?? .white,
+                             .paragraphStyle: paragraph])
+            result.append(piece)
+        }
+        return result
+    }
+
+    private static func resolvedFont(style: CaptionStyle, size: CGFloat) -> NSFont {
+        let weight = NSFont.Weight(rawValue: CGFloat(style.weight))
+        if style.fontName == "SF Pro Rounded" {
+            let base = NSFont.systemFont(ofSize: size, weight: weight)
+            guard let descriptor = base.fontDescriptor.withDesign(.rounded) else { return base }
+            return NSFont(descriptor: descriptor, size: size) ?? base
+        }
+        return NSFont(name: style.fontName, size: size)
+            ?? NSFont.systemFont(ofSize: size, weight: weight)
+    }
+
+    private static func boxOrigin(style: CaptionStyle, canvas: CGSize, size: CGSize) -> CGPoint {
+        let x = (canvas.width - size.width) / 2
+        switch style.position {
+        case .top:
+            return CGPoint(x: x, y: canvas.height * CGFloat(style.inset))
+        case .centre:
+            return CGPoint(x: x, y: (canvas.height - size.height) / 2)
+        case .bottom:
+            return CGPoint(x: x,
+                           y: canvas.height - size.height - canvas.height * CGFloat(style.inset))
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/CaptureSessionRunner.swift
+++ b/Sources/Sarvkrit/Features/Studio/CaptureSessionRunner.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// The one place calls into an `AVCaptureSession` are allowed to happen.
+///
+/// **This type exists because of a crash.** `AVCaptureSession.startRunning()` blocks until the
+/// capture graph is up, and anything that needs a running session — `AVCaptureMovieFileOutput`'s
+/// `startRecording(to:)` — blocks until it is. `CameraRecorder` handed the first to a detached
+/// task and then made the second call on the main actor, so the main thread sat inside
+/// AVFoundation waiting on work that had been given to a different thread.
+///
+/// That is worse than a stall. AVFoundation pumps the run loop while it waits, so AppKit went on
+/// delivering events with a main-actor frame still on the stack. A click landing in that window
+/// reached a global event monitor, `MainActor.assumeIsolated` asked the concurrency runtime which
+/// executor was current, and the answer was the address `0x1e`. The app died there — eight seconds
+/// after a recording that never started, because `SCStream` was three statements further on and
+/// was never reached.
+///
+/// So: one serial queue, every call in the order it was asked for, none of them on the caller's
+/// thread. `CameraPreviewSession` had the same unordered `Task.detached` pair and the same bug,
+/// which is why this is a shared type rather than a fix in one file.
+final class CaptureSessionRunner: @unchecked Sendable {
+
+    private let queue: DispatchQueue
+
+    init(label: String) {
+        // Serial by default, and utility rather than default QoS: bringing a camera up is
+        // background work that nothing on screen is waiting for.
+        queue = DispatchQueue(label: label, qos: .utility)
+    }
+
+    /// Runs `work` after everything already asked for, and never before this call returns.
+    func submit(_ work: @escaping @Sendable () -> Void) {
+        queue.async(execute: work)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/ClickEffect.swift
+++ b/Sources/Sarvkrit/Features/Studio/ClickEffect.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// What a click looks like in the finished video.
+///
+/// The recording has no cursor in it at all, so a click leaves no visible trace unless one is
+/// drawn — which is the opportunity, not the problem: the effect can be chosen, restyled and
+/// switched off long after the recording was made.
+enum ClickEffectStyle: String, Codable, CaseIterable, Equatable {
+    /// An expanding ring. The default: visible without being loud.
+    case ripple
+    /// A soft filled disc that fades.
+    case highlight
+    /// The pointer itself dips and returns. **The subtle one** — it reads as "the mouse was
+    /// pressed" rather than as "an effect played", which is what you want in a serious demo.
+    case shrink
+    case none
+
+    var title: String {
+        switch self {
+        case .ripple: return "Ripple"
+        case .highlight: return "Highlight"
+        case .shrink: return "Shrink"
+        case .none: return "None"
+        }
+    }
+}
+
+/// What to draw for a click, at one moment.
+///
+/// Radii are multiples of the cursor's own size, so an effect stays in proportion when the pointer
+/// is scaled up — an absolute radius looks enormous beside a small cursor and lost beside a large
+/// one.
+struct ClickEffectState: Equatable {
+    var ringRadius: Double = 0
+    var ringAlpha: Double = 0
+    var fillAlpha: Double = 0
+    /// Multiplier on the cursor glyph.
+    var cursorScale: Double = 1
+}
+
+enum ClickEffect {
+    /// Long enough to register, short enough not to still be on screen at the next click. Faster
+    /// than this and it flickers; slower and a double-click leaves two rings overlapping.
+    static let duration: TimeInterval = 0.32
+
+    /// How far a ripple travels, as a multiple of the cursor's height.
+    static let ringExtent: Double = 2.4
+
+    /// Nil means draw nothing — before the click, after the effect, or for `.none`. A caller that
+    /// gets nil has no branch to write.
+    static func state(_ style: ClickEffectStyle, secondsSinceClick t: TimeInterval)
+        -> ClickEffectState? {
+        guard style != .none, t >= 0, t <= duration else { return nil }
+        let progress = duration > 0 ? t / duration : 1
+
+        switch style {
+        case .none:
+            return nil
+        case .ripple:
+            // Eased outward and faded on a square, so it thins as it grows the way a real
+            // disturbance in a surface does. A linear fade stays visible right up to the moment it
+            // vanishes, which reads as a dropped frame.
+            let remaining = 1 - progress
+            return ClickEffectState(ringRadius: ringExtent * ZoomEase.smooth.value(progress),
+                                    ringAlpha: remaining * remaining)
+        case .highlight:
+            return ClickEffectState(ringRadius: ringExtent * 0.55,
+                                    fillAlpha: 0.35 * pow(1 - progress, 1.5))
+        case .shrink:
+            // One smooth dip and back. Nothing is drawn but the cursor itself.
+            return ClickEffectState(cursorScale: 1 - 0.15 * sin(.pi * progress))
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/ClickTrack.swift
+++ b/Sources/Sarvkrit/Features/Studio/ClickTrack.swift
@@ -1,0 +1,55 @@
+import CoreGraphics
+import Foundation
+
+/// A click placed by hand, rather than one the recording caught.
+///
+/// Carries its own point because the natural place for it is wherever the pointer was at that
+/// moment, and resolving that once — when it is placed — keeps this a plain value.
+struct ManualClick: Codable, Equatable, Identifiable {
+    var id = UUID()
+    var t: TimeInterval
+    /// Recording pixel space, the same as `ClickEvent.point`.
+    var point: CGPoint
+    var button: ClickEvent.Button = .left
+}
+
+/// What the user changed about the clicks, kept beside the recording rather than in it.
+///
+/// **The recording is never modified.** A suppressed click is remembered by its time, not deleted,
+/// so undo brings it back and nothing about the original take is lost.
+struct ClickEdits: Codable, Equatable {
+    var added: [ManualClick] = []
+    /// Times of recorded presses the user took out.
+    var suppressed: [TimeInterval] = []
+}
+
+/// The clicks a finished frame should show.
+///
+/// **Before this there was no way to edit a click at all.** `StudioRenderer` read the recording's
+/// `pressDowns` directly, `EventLog.clicks` is `private(set)`, and `ClickEffect` holds no per-click
+/// state — so a stray click during a take was in the video permanently, and a point worth
+/// emphasising that nobody happened to click on could not be marked.
+///
+/// A pure resolver, in the shape this codebase already uses for decision logic, so the renderer
+/// stays unaware of where any given click came from.
+enum ClickTrack {
+
+    /// How close two times must be to count as the same click.
+    ///
+    /// Times are floats that have been through JSON, so an exact match would let a suppressed click
+    /// reappear on reload. A frame at 120fps is 8ms, so this is comfortably inside "the same click"
+    /// while staying well clear of the next one.
+    static let sameClickTolerance: TimeInterval = 0.001
+
+    static func effective(recorded: [ClickEvent], edits: ClickEdits) -> [ClickEvent] {
+        // Releases are not click effects; the renderer only ever asks about presses.
+        let kept = recorded.filter { event in
+            guard event.isDown else { return false }
+            return !edits.suppressed.contains { abs($0 - event.t) <= sameClickTolerance }
+        }
+        let placed = edits.added.map {
+            ClickEvent(t: $0.t, point: $0.point, button: $0.button, isDown: true, isInside: true)
+        }
+        return (kept + placed).sorted { $0.t < $1.t }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/CursorGlyph.swift
+++ b/Sources/Sarvkrit/Features/Studio/CursorGlyph.swift
@@ -1,0 +1,296 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+/// The pointers, as vector paths.
+///
+/// **Drawn rather than scaled from a bitmap.** A 16×16 system cursor blown up to 3× is exactly the
+/// blurry mess this feature exists to avoid — and the pointer is the thing a viewer's eye follows
+/// for the whole video, so it is the last place to accept softness. Paths are also data, which is
+/// the same argument `CaptureBackground` makes for gradients: no assets, no @2x variants, correct
+/// at every size.
+///
+/// Every path is drawn inside a `unitSize` box with y **down**, matching the `CGImage` convention
+/// the rest of the capture stack uses.
+enum CursorGlyph {
+
+    /// The box every path is drawn in. Multiplied out at draw time.
+    static let unitSize: CGFloat = 24
+
+    /// Black fill with a white outline, which is what makes a pointer legible over both a dark
+    /// terminal and a white document without either being a special case.
+    static let strokeWidth: CGFloat = 1.25
+
+    static func path(for kind: CursorKind) -> CGPath {
+        switch kind {
+        case .arrow, .unknown, .custom: return arrow()
+        case .iBeam: return iBeam()
+        case .pointingHand: return pointingHand()
+        case .openHand, .closedHand: return hand(closed: kind == .closedHand)
+        case .crosshair: return crosshair()
+        case .resizeLeftRight: return resize(horizontal: true)
+        case .resizeUpDown: return resize(horizontal: false)
+        case .resizeDiagonal: return resizeDiagonal()
+        case .notAllowed: return notAllowed()
+        case .contextualMenu: return arrow()
+        }
+    }
+
+    /// Where the click actually happened, normalised inside the unit box.
+    ///
+    /// An arrow's is its tip; an I-beam's is its middle. Wrong here means every click effect is
+    /// offset from the thing it clicked, which reads as the app mis-clicking.
+    static func hotspot(for kind: CursorKind) -> CGPoint {
+        switch kind {
+        case .arrow, .unknown, .custom, .contextualMenu:
+            return CGPoint(x: 0, y: 0)
+        case .pointingHand:
+            return CGPoint(x: 0.35, y: 0.05)
+        case .iBeam, .crosshair, .resizeLeftRight, .resizeUpDown, .resizeDiagonal,
+             .notAllowed, .openHand, .closedHand:
+            return CGPoint(x: 0.5, y: 0.5)
+        }
+    }
+
+    // MARK: - Sizing
+
+    /// How tall to draw the pointer, in canvas points.
+    ///
+    /// **Canvas space, not screen-layer space.** A cursor that scaled with the zoom would be
+    /// comically large in a 2.5× close-up — the reference keeps it roughly constant on screen, and
+    /// so do we. The quarter-power term lets it grow just enough not to look detached from a frame
+    /// that got closer, and nowhere near linearly.
+    ///
+    /// **The user's Accessibility pointer size is deliberately not an input here**, though the plan
+    /// this was built from said to divide it out. That was wrong: the recording is captured with
+    /// `showsCursor = false`, so their enlarged pointer never reaches the video and there is
+    /// nothing for ours to compound with. The manifest still records the setting, because it is
+    /// worth *telling* somebody with a 3× pointer that the recording will not match what they see
+    /// — but correcting for it silently would shrink their cursor for no reason.
+    static func drawnSize(base: Double, zoom: Double) -> Double {
+        base * pow(max(zoom, 1), 0.25) * Double(unitSize)
+    }
+
+    // MARK: - Rendering
+
+    /// A glyph, its bitmap, and where the glyph sits inside it.
+    ///
+    /// The bitmap is larger than the glyph because a shadow needs room — and returning only the
+    /// image would leave the caller scaling the padding as if it were part of the pointer, which
+    /// shrinks the cursor and puts its hotspot in the wrong place.
+    struct Rendered {
+        let image: CGImage
+        /// The glyph's own height, in image pixels.
+        let glyphHeight: CGFloat
+        /// Distance from the image's edge to the glyph's box.
+        let inset: CGFloat
+    }
+
+    /// A ready-to-composite bitmap, cached by kind and size.
+    ///
+    /// Cached because a ten-minute export asks for the same handful of pointers at the same size
+    /// tens of thousands of times, and rebuilding a path and a shadow for each is pure waste.
+    static func rendered(for kind: CursorKind, glyphHeight: Int) -> Rendered? {
+        let key = Key(kind: kind, height: glyphHeight)
+        if let cached = cache.object(forKey: key) { return cached.rendered }
+
+        let scale = CGFloat(glyphHeight) / unitSize
+        let padding = ceil(6 * scale)
+        let side = Int((unitSize * scale + padding * 2).rounded())
+
+        guard let context = CGContext(data: nil, width: max(1, side), height: max(1, side),
+                                      bitsPerComponent: 8, bytesPerRow: 0,
+                                      space: CGColorSpaceCreateDeviceRGB(),
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { return nil }
+
+        // Document space: top-left origin, y down, the same flip the annotation renderer uses.
+        context.translateBy(x: 0, y: CGFloat(side))
+        context.scaleBy(x: 1, y: -1)
+        context.translateBy(x: padding, y: padding)
+        context.scaleBy(x: scale, y: scale)
+
+        let shape = path(for: kind)
+
+        context.saveGState()
+        context.setShadow(offset: CGSize(width: 0, height: -2 / scale), blur: 6 / scale,
+                          color: CGColor(red: 0, green: 0, blue: 0, alpha: 0.25))
+        context.addPath(shape)
+        context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+        context.fillPath()
+        context.restoreGState()
+
+        context.addPath(shape)
+        context.setStrokeColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        context.setLineWidth(strokeWidth)
+        context.setLineJoin(.round)
+        context.strokePath()
+
+        guard let image = context.makeImage() else { return nil }
+        let result = Rendered(image: image, glyphHeight: CGFloat(glyphHeight), inset: padding)
+        cache.setObject(Box(result), forKey: key)
+        return result
+    }
+
+    /// Where the *bitmap's* top-left goes, so that the glyph's hotspot lands on `point`.
+    ///
+    /// The padding is subtracted here rather than by the caller, because forgetting it offsets
+    /// every pointer by a few pixels — near enough to look right and wrong enough to notice.
+    static func origin(for kind: CursorKind, at point: CGPoint,
+                       drawnHeight: CGFloat, insetFraction: CGFloat) -> CGPoint {
+        let hotspot = hotspot(for: kind)
+        return CGPoint(x: point.x - hotspot.x * drawnHeight - insetFraction * drawnHeight,
+                       y: point.y - hotspot.y * drawnHeight - insetFraction * drawnHeight)
+    }
+
+    private final class Key: NSObject {
+        let kind: CursorKind
+        let height: Int
+        init(kind: CursorKind, height: Int) { self.kind = kind; self.height = height }
+        override var hash: Int { kind.rawValue.hashValue ^ height }
+        override func isEqual(_ object: Any?) -> Bool {
+            guard let other = object as? Key else { return false }
+            return other.kind == kind && other.height == height
+        }
+    }
+
+    private final class Box {
+        let rendered: Rendered
+        init(_ rendered: Rendered) { self.rendered = rendered }
+    }
+
+    private static let cache: NSCache<Key, Box> = {
+        let cache = NSCache<Key, Box>()
+        cache.countLimit = 48
+        return cache
+    }()
+
+    // MARK: - The shapes
+
+    /// The macOS arrow: a tip at the origin, a long left edge, a notch, and the tail.
+    private static func arrow() -> CGPath {
+        let path = CGMutablePath()
+        let s = unitSize / 24
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addLine(to: CGPoint(x: 0, y: 16.5 * s))
+        path.addLine(to: CGPoint(x: 4.2 * s, y: 12.6 * s))
+        path.addLine(to: CGPoint(x: 7.0 * s, y: 19.4 * s))
+        path.addLine(to: CGPoint(x: 9.9 * s, y: 18.2 * s))
+        path.addLine(to: CGPoint(x: 7.1 * s, y: 11.5 * s))
+        path.addLine(to: CGPoint(x: 12.4 * s, y: 11.3 * s))
+        path.closeSubpath()
+        return path
+    }
+
+    private static func iBeam() -> CGPath {
+        let path = CGMutablePath()
+        let s = unitSize / 24
+        // Serifs top and bottom, which is what distinguishes it from a plain bar at a glance.
+        path.addRect(CGRect(x: 10.6 * s, y: 4 * s, width: 1.8 * s, height: 16 * s))
+        path.addRect(CGRect(x: 8 * s, y: 3.4 * s, width: 7 * s, height: 1.4 * s))
+        path.addRect(CGRect(x: 8 * s, y: 19.2 * s, width: 7 * s, height: 1.4 * s))
+        return path
+    }
+
+    private static func pointingHand() -> CGPath {
+        let path = CGMutablePath()
+        let s = unitSize / 24
+        // A raised index finger over a fist. Simplified, but the silhouette is what reads.
+        path.move(to: CGPoint(x: 7.2 * s, y: 1.5 * s))
+        path.addCurve(to: CGPoint(x: 10 * s, y: 1.5 * s),
+                      control1: CGPoint(x: 7.2 * s, y: 0.2 * s),
+                      control2: CGPoint(x: 10 * s, y: 0.2 * s))
+        path.addLine(to: CGPoint(x: 10 * s, y: 10 * s))
+        path.addLine(to: CGPoint(x: 13.4 * s, y: 9.4 * s))
+        path.addCurve(to: CGPoint(x: 18.4 * s, y: 13.6 * s),
+                      control1: CGPoint(x: 17 * s, y: 9.2 * s),
+                      control2: CGPoint(x: 18.4 * s, y: 10.6 * s))
+        path.addLine(to: CGPoint(x: 18.4 * s, y: 19 * s))
+        path.addCurve(to: CGPoint(x: 15 * s, y: 22.4 * s),
+                      control1: CGPoint(x: 18.4 * s, y: 21.2 * s),
+                      control2: CGPoint(x: 17 * s, y: 22.4 * s))
+        path.addLine(to: CGPoint(x: 10.4 * s, y: 22.4 * s))
+        path.addCurve(to: CGPoint(x: 6.4 * s, y: 18.6 * s),
+                      control1: CGPoint(x: 8 * s, y: 22.4 * s),
+                      control2: CGPoint(x: 6.4 * s, y: 21 * s))
+        path.closeSubpath()
+        return path
+    }
+
+    private static func hand(closed: Bool) -> CGPath {
+        let path = CGMutablePath()
+        let s = unitSize / 24
+        let top = closed ? 8.0 : 4.0
+        path.addRoundedRect(in: CGRect(x: 5 * s, y: top * s,
+                                       width: 14 * s, height: (22 - top) * s),
+                            cornerWidth: 4 * s, cornerHeight: 4 * s)
+        if !closed {
+            for finger in 0..<3 {
+                path.addRoundedRect(
+                    in: CGRect(x: (7.5 + Double(finger) * 3.2) * s, y: 2 * s,
+                               width: 2.4 * s, height: 6 * s),
+                    cornerWidth: 1.2 * s, cornerHeight: 1.2 * s)
+            }
+        }
+        return path
+    }
+
+    private static func crosshair() -> CGPath {
+        let path = CGMutablePath()
+        let s = unitSize / 24
+        // A gap in the middle, so the thing being aimed at is not covered by the aim.
+        path.addRect(CGRect(x: 11.2 * s, y: 1 * s, width: 1.6 * s, height: 8 * s))
+        path.addRect(CGRect(x: 11.2 * s, y: 15 * s, width: 1.6 * s, height: 8 * s))
+        path.addRect(CGRect(x: 1 * s, y: 11.2 * s, width: 8 * s, height: 1.6 * s))
+        path.addRect(CGRect(x: 15 * s, y: 11.2 * s, width: 8 * s, height: 1.6 * s))
+        return path
+    }
+
+    private static func resize(horizontal: Bool) -> CGPath {
+        let path = CGMutablePath()
+        let s = unitSize / 24
+        if horizontal {
+            path.addRect(CGRect(x: 5 * s, y: 11 * s, width: 14 * s, height: 2 * s))
+            path.move(to: CGPoint(x: 1.5 * s, y: 12 * s))
+            path.addLine(to: CGPoint(x: 6.5 * s, y: 8 * s))
+            path.addLine(to: CGPoint(x: 6.5 * s, y: 16 * s))
+            path.closeSubpath()
+            path.move(to: CGPoint(x: 22.5 * s, y: 12 * s))
+            path.addLine(to: CGPoint(x: 17.5 * s, y: 8 * s))
+            path.addLine(to: CGPoint(x: 17.5 * s, y: 16 * s))
+            path.closeSubpath()
+        } else {
+            path.addRect(CGRect(x: 11 * s, y: 5 * s, width: 2 * s, height: 14 * s))
+            path.move(to: CGPoint(x: 12 * s, y: 1.5 * s))
+            path.addLine(to: CGPoint(x: 8 * s, y: 6.5 * s))
+            path.addLine(to: CGPoint(x: 16 * s, y: 6.5 * s))
+            path.closeSubpath()
+            path.move(to: CGPoint(x: 12 * s, y: 22.5 * s))
+            path.addLine(to: CGPoint(x: 8 * s, y: 17.5 * s))
+            path.addLine(to: CGPoint(x: 16 * s, y: 17.5 * s))
+            path.closeSubpath()
+        }
+        return path
+    }
+
+    private static func resizeDiagonal() -> CGPath {
+        var rotate = CGAffineTransform(translationX: unitSize / 2, y: unitSize / 2)
+            .rotated(by: .pi / 4)
+            .translatedBy(x: -unitSize / 2, y: -unitSize / 2)
+        return resize(horizontal: true).copy(using: &rotate) ?? resize(horizontal: true)
+    }
+
+    private static func notAllowed() -> CGPath {
+        let path = CGMutablePath()
+        let s = unitSize / 24
+        path.addEllipse(in: CGRect(x: 2 * s, y: 2 * s, width: 20 * s, height: 20 * s))
+        path.addEllipse(in: CGRect(x: 5 * s, y: 5 * s, width: 14 * s, height: 14 * s))
+        var rotate = CGAffineTransform(translationX: 12 * s, y: 12 * s)
+            .rotated(by: -.pi / 4)
+            .translatedBy(x: -12 * s, y: -12 * s)
+        let bar = CGPath(rect: CGRect(x: 4 * s, y: 10.8 * s, width: 16 * s, height: 2.4 * s),
+                         transform: &rotate)
+        path.addPath(bar)
+        return path
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/CursorKindReader.swift
+++ b/Sources/Sarvkrit/Features/Studio/CursorKindReader.swift
@@ -60,8 +60,11 @@ enum SecureFieldCheck {
                                             &focused) == .success,
               let element = focused else { return false }
 
-        // Unsafe-looking, and it is the documented shape: the value is an AXUIElement.
-        let axElement = unsafeBitCast(element, to: AXUIElement.self)
+        // Checked, not bit-cast. `unsafeBitCast` here did no type check at all, where every other
+        // Accessibility call site in this codebase does — `SnapAreaController` and
+        // `WindowManipulator` both use exactly this pattern.
+        guard CFGetTypeID(element) == AXUIElementGetTypeID() else { return false }
+        let axElement = element as! AXUIElement   // swiftlint:disable:this force_cast
         for attribute in [kAXRoleAttribute, kAXSubroleAttribute] {
             var value: CFTypeRef?
             guard AXUIElementCopyAttributeValue(axElement, attribute as CFString,

--- a/Sources/Sarvkrit/Features/Studio/CursorKindReader.swift
+++ b/Sources/Sarvkrit/Features/Studio/CursorKindReader.swift
@@ -1,0 +1,114 @@
+import AppKit
+import CryptoKit
+import Foundation
+
+/// Working out which pointer is on screen.
+///
+/// **`NSCursor.currentSystem` hands back an image, not an identifier.** So a known pointer is
+/// recognised by hashing its bitmap and matching against the system set, and anything unmatched is
+/// stored as a bitmap instead.
+///
+/// The instinct — "never store the bitmap, always draw vectors" — gives a beautiful pointer in
+/// Safari and **an arrow where the brush was** in every Photoshop demo. A design tool is exactly
+/// the kind of thing people record, so an unrecognised cursor keeps its picture. It costs a handful
+/// of small PNGs: a session uses a dozen distinct pointers at most, and they are deduplicated.
+enum CursorKindReader {
+
+    private static let knownHashes: [String: CursorKind] = {
+        var table: [String: CursorKind] = [:]
+        let pairs: [(NSCursor, CursorKind)] = [
+            (.arrow, .arrow), (.iBeam, .iBeam), (.pointingHand, .pointingHand),
+            (.openHand, .openHand), (.closedHand, .closedHand), (.crosshair, .crosshair),
+            (.resizeLeftRight, .resizeLeftRight), (.resizeUpDown, .resizeUpDown),
+            (.operationNotAllowed, .notAllowed), (.contextualMenu, .contextualMenu),
+        ]
+        for (cursor, kind) in pairs {
+            if let hash = fingerprint(of: cursor.image) { table[hash] = kind }
+        }
+        return table
+    }()
+
+    /// The kind on screen right now, or `.custom` when nothing matches.
+    static func current() -> CursorKind {
+        guard let image = NSCursor.currentSystem?.image,
+              let hash = fingerprint(of: image) else { return .arrow }
+        return knownHashes[hash] ?? .custom
+    }
+
+    /// A stable name for a bitmap, used both to recognise known pointers and to deduplicate the
+    /// unknown ones on disk.
+    static func fingerprint(of image: NSImage) -> String? {
+        guard let tiff = image.tiffRepresentation else { return nil }
+        return SHA256.hash(data: tiff).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// The bitmap of the current pointer, for storing when it could not be recognised.
+    static func currentImage() -> NSImage? { NSCursor.currentSystem?.image }
+}
+
+/// Whether the focused element is a password field.
+///
+/// **`ClipboardPrivacyFilter` is not this check.** That reads pasteboard markers — the
+/// `org.nspasteboard.ConcealedType` convention password managers set — which says nothing about
+/// where a keystroke was typed. This is the Accessibility question, and it is the one that matters
+/// when the app is watching the keyboard.
+enum SecureFieldCheck {
+    static func isFocusedElementSecure() -> Bool {
+        let system = AXUIElementCreateSystemWide()
+        var focused: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(system, kAXFocusedUIElementAttribute as CFString,
+                                            &focused) == .success,
+              let element = focused else { return false }
+
+        // Unsafe-looking, and it is the documented shape: the value is an AXUIElement.
+        let axElement = unsafeBitCast(element, to: AXUIElement.self)
+        for attribute in [kAXRoleAttribute, kAXSubroleAttribute] {
+            var value: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(axElement, attribute as CFString,
+                                                &value) == .success,
+                  let role = value as? String else { continue }
+            if role == "AXSecureTextField" { return true }
+        }
+        return false
+    }
+}
+
+/// Turning a key event into something worth showing on screen.
+enum KeyLabel {
+    /// Nil for anything not worth drawing — a bare letter while "modifiers only" is chosen, or a
+    /// key with no sensible name.
+    static func describe(_ event: NSEvent) -> String? {
+        let flags = event.modifierFlags
+        var parts = ""
+        if flags.contains(.control) { parts += "⌃" }
+        if flags.contains(.option) { parts += "⌥" }
+        if flags.contains(.shift) { parts += "⇧" }
+        if flags.contains(.command) { parts += "⌘" }
+
+        guard let characters = event.charactersIgnoringModifiers, !characters.isEmpty else {
+            return nil
+        }
+        let name = named(characters) ?? characters.uppercased()
+        return parts + name
+    }
+
+    static func isCombination(_ event: NSEvent) -> Bool {
+        !event.modifierFlags.intersection([.command, .control, .option]).isEmpty
+    }
+
+    /// Spelled out, because a caption reading "⌘ " tells nobody anything.
+    private static func named(_ characters: String) -> String? {
+        switch characters {
+        case " ": return "Space"
+        case "\r": return "Return"
+        case "\t": return "Tab"
+        case "\u{7F}", "\u{8}": return "Delete"
+        case "\u{1B}": return "Esc"
+        case "\u{F700}": return "↑"
+        case "\u{F701}": return "↓"
+        case "\u{F702}": return "←"
+        case "\u{F703}": return "→"
+        default: return nil
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/CursorPath.swift
+++ b/Sources/Sarvkrit/Features/Studio/CursorPath.swift
@@ -1,0 +1,227 @@
+import CoreGraphics
+import Foundation
+
+/// How much the recorded pointer path is tidied before it is drawn.
+///
+/// Raw values are persisted in the project.
+enum CursorSmoothing: String, Codable, CaseIterable, Equatable {
+    /// The raw path. **Genuinely off**, not "a bit less" — a drawing app, or a demo of precise
+    /// dragging, is made worse by any smoothing at all, and the setting has to mean what it says.
+    case off
+    case light
+    case standard
+    case heavy
+
+    var title: String {
+        switch self {
+        case .off: return "Off"
+        case .light: return "Light"
+        case .standard: return "Standard"
+        case .heavy: return "Heavy"
+        }
+    }
+
+    /// Width of the smoothing kernel, in samples.
+    fileprivate var sigma: Double {
+        switch self {
+        case .off: return 0
+        case .light: return 0.6
+        case .standard: return 1.2
+        case .heavy: return 2.4
+        }
+    }
+}
+
+/// Turning the recorded pointer path into one that looks like it has weight.
+///
+/// Pure, over an array of samples — no AV types, no drawing. Everything here is *offline*
+/// post-processing, which is worth stating because it changes what the right algorithm is: a live
+/// filter can only look backwards and therefore always lags, but we hold the entire path before we
+/// draw a single frame, so a **zero-phase symmetric filter** is available and is strictly better.
+/// The realtime answer would smooth the jitter and arrive late; this one does not arrive late.
+enum CursorPath {
+
+    /// How near a click the smoother is suspended, in seconds.
+    ///
+    /// **The tension this whole type exists to resolve.** Smoothing removes hand jitter that is
+    /// invisible at 1× and obvious at 2.5×; smoothing is also lag. A cursor that arrives after the
+    /// click it made looks like the app mis-clicked, which is far worse than any amount of jitter
+    /// — so around a click the raw position wins outright and blends back out.
+    static let clickSnapWindow: TimeInterval = 0.12
+
+    // MARK: - Smoothing
+
+    static func smoothed(_ samples: [CursorSample],
+                         smoothing: CursorSmoothing,
+                         snappingTo clickTimes: [TimeInterval] = []) -> [CursorSample] {
+        guard smoothing != .off, samples.count > 2 else { return samples }
+
+        let kernel = gaussian(sigma: smoothing.sigma)
+        var result = samples
+
+        for index in samples.indices {
+            var sumX = 0.0, sumY = 0.0, sumWeight = 0.0
+            for (offset, weight) in kernel {
+                let point = reflected(samples, around: index, offset: offset)
+                sumX += Double(point.x) * weight
+                sumY += Double(point.y) * weight
+                sumWeight += weight
+            }
+            var point = CGPoint(x: sumX / sumWeight, y: sumY / sumWeight)
+
+            if let snap = snapWeight(at: samples[index].t, clickTimes: clickTimes), snap > 0 {
+                let raw = samples[index].point
+                point = CGPoint(x: raw.x * CGFloat(snap) + point.x * CGFloat(1 - snap),
+                                y: raw.y * CGFloat(snap) + point.y * CGFloat(1 - snap))
+            }
+            result[index].point = point
+        }
+        return result
+    }
+
+    private static func gaussian(sigma: Double) -> [(offset: Int, weight: Double)] {
+        let radius = max(1, Int((sigma * 3).rounded(.up)))
+        return (-radius...radius).map { offset in
+            (offset, exp(-Double(offset * offset) / (2 * sigma * sigma)))
+        }
+    }
+
+    /// Odd reflection past either end: `p[-k] = 2·p[0] − p[k]`.
+    ///
+    /// Chosen over repeating the edge sample because it is **exact for a straight path** — the
+    /// reflection continues the line rather than flattening it — so a pointer moving steadily
+    /// across the screen is not dragged off course in its first and last few frames, which is
+    /// precisely where a viewer's eye is when a clip begins.
+    private static func reflected(_ samples: [CursorSample], around index: Int,
+                                  offset: Int) -> CGPoint {
+        let target = index + offset
+        if target >= 0 && target < samples.count { return samples[target].point }
+        if target < 0 {
+            let mirrored = samples[min(-target, samples.count - 1)].point
+            let anchor = samples[0].point
+            return CGPoint(x: 2 * anchor.x - mirrored.x, y: 2 * anchor.y - mirrored.y)
+        }
+        let last = samples.count - 1
+        let mirrored = samples[max(0, 2 * last - target)].point
+        let anchor = samples[last].point
+        return CGPoint(x: 2 * anchor.x - mirrored.x, y: 2 * anchor.y - mirrored.y)
+    }
+
+    /// 1 exactly on a click, easing to 0 at the edge of the window.
+    private static func snapWeight(at t: TimeInterval, clickTimes: [TimeInterval]) -> Double? {
+        var best: Double?
+        for click in clickTimes {
+            let distance = abs(t - click)
+            guard distance < clickSnapWindow else { continue }
+            let unit = 1 - distance / clickSnapWindow
+            // Smoothstep, so the blend has no visible corner where it starts and stops.
+            let weight = unit * unit * (3 - 2 * unit)
+            best = max(best ?? 0, weight)
+        }
+        return best
+    }
+
+    // MARK: - Shakes
+
+    struct ShakeTuning: Equatable {
+        /// Direction reversals needed inside `window` before a span counts as a shake.
+        var reversals: Int = 4
+        var window: TimeInterval = 0.35
+        /// A shake stays roughly in one place; a genuine fast scribble does not.
+        var radius: CGFloat = 260
+
+        init() {}
+    }
+
+    /// Removes the zigzag macOS's shake-to-locate gesture leaves in the path.
+    ///
+    /// The pointer's *size* never reaches us — a recognised cursor is redrawn from vector paths,
+    /// so the system's enlargement is not in the recording. The **path** does reach us, and left
+    /// alone it makes `ZoomPlanner` read a burst of activity where nothing happened while the
+    /// smoother chases a target moving 2,000 px a second.
+    static func removingShakes(_ samples: [CursorSample],
+                               tuning: ShakeTuning = ShakeTuning()) -> [CursorSample] {
+        guard samples.count > 4 else { return samples }
+
+        var spans: [ClosedRange<Int>] = []
+        var index = 1
+        while index < samples.count - 1 {
+            guard let end = shakeEnd(from: index, in: samples, tuning: tuning) else {
+                index += 1
+                continue
+            }
+            spans.append(index...end)
+            index = end + 1
+        }
+        guard !spans.isEmpty else { return samples }
+
+        // Straight-line replacement rather than heavier smoothing: a shake carries no information
+        // about where the user meant to be, so there is nothing in it worth preserving.
+        var result = samples
+        for span in spans {
+            let from = samples[max(0, span.lowerBound - 1)].point
+            let to = samples[min(samples.count - 1, span.upperBound + 1)].point
+            let steps = span.count + 1
+            for (step, position) in span.enumerated() {
+                let fraction = CGFloat(step + 1) / CGFloat(steps)
+                result[position].point = CGPoint(x: from.x + (to.x - from.x) * fraction,
+                                                 y: from.y + (to.y - from.y) * fraction)
+            }
+        }
+        return result
+    }
+
+    /// The last index of a shake beginning at `start`, or nil if there is not one.
+    private static func shakeEnd(from start: Int, in samples: [CursorSample],
+                                 tuning: ShakeTuning) -> Int? {
+        var reversals = 0
+        var lastSign = 0
+        var minX = samples[start].point.x, maxX = minX
+        var minY = samples[start].point.y, maxY = minY
+        var end: Int?
+
+        var index = start
+        while index < samples.count - 1, samples[index].t - samples[start].t <= tuning.window {
+            let delta = samples[index + 1].point.x - samples[index].point.x
+            let sign = delta > 0 ? 1 : (delta < 0 ? -1 : 0)
+            if sign != 0 {
+                if lastSign != 0 && sign != lastSign { reversals += 1 }
+                lastSign = sign
+            }
+            let point = samples[index + 1].point
+            minX = min(minX, point.x); maxX = max(maxX, point.x)
+            minY = min(minY, point.y); maxY = max(maxY, point.y)
+
+            if reversals >= tuning.reversals,
+               maxX - minX <= tuning.radius, maxY - minY <= tuning.radius {
+                end = index + 1
+            }
+            index += 1
+        }
+        return end
+    }
+
+    // MARK: - Looping
+
+    /// Eases the pointer back to where it started over the last `seconds` of the recording.
+    ///
+    /// For a clip meant to loop — a demo GIF, a landing-page hero — a cursor that ends far from
+    /// where it began makes the seam obvious. A render-time transform only: the events are
+    /// untouched, so this can be switched off again.
+    static func looped(_ samples: [CursorSample], over seconds: TimeInterval) -> [CursorSample] {
+        guard seconds > 0, samples.count > 1,
+              let first = samples.first, let last = samples.last else { return samples }
+        let tailStart = last.t - seconds
+        guard tailStart > first.t else { return samples }
+
+        var result = samples
+        for index in samples.indices where samples[index].t >= tailStart {
+            let progress = (samples[index].t - tailStart) / seconds
+            let eased = CGFloat(ZoomEase.smooth.value(progress))
+            let point = samples[index].point
+            result[index].point = CGPoint(x: point.x + (first.point.x - point.x) * eased,
+                                          y: point.y + (first.point.y - point.y) * eased)
+        }
+        return result
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/CursorSettings.swift
+++ b/Sources/Sarvkrit/Features/Studio/CursorSettings.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// How the pointer is drawn back into the video.
+///
+/// Every one of these is a decision made *after* recording, which is only possible because the
+/// screen was captured with `showsCursor = false` and the pointer's path was logged instead.
+struct CursorSettings: Codable, Equatable {
+    var isHidden = false
+    /// Multiplier on the glyph, applied in canvas space.
+    ///
+    /// Canvas space, not screen-layer space, and the difference matters: a cursor that scaled with
+    /// the zoom would be comically large at 2.5×. It grows a little with zoom so it does not look
+    /// detached, but nowhere near linearly.
+    var size: Double = 1.6
+    var smoothing: CursorSmoothing = .standard
+    var clickEffect: ClickEffectStyle = .ripple
+    var playsClickSound = false
+
+    /// Master switch, then the three independent channels.
+    ///
+    /// Separate because they answer different questions: a blurred cursor over a sharp frame is
+    /// right when only the mouse moved, and a blurred frame is right when the zoom raced somewhere.
+    /// One slider cannot say both.
+    var motionBlur = true
+    var motionBlurCursor: Double = 1
+    var motionBlurZoom: Double = 1
+    var motionBlurPan: Double = 1
+
+    /// Stops a recording that pauses on a diagram having a pointer sitting in the middle of it.
+    var hidesWhenIdle = true
+    var idleDelay: TimeInterval = 3
+
+    /// For a clip meant to loop: eases the pointer back to where it started.
+    var loopsToStart = false
+    var loopSeconds: TimeInterval = 1
+
+    /// A few degrees into the direction of travel while moving fast. Felt more than seen.
+    var rotatesWhileMoving = true
+    /// Filters out macOS's shake-to-locate zigzag.
+    var removesShakes = true
+
+    /// Names a `CursorSet`. Held as a string so a set added by a newer build round-trips rather
+    /// than being reset to the default on save.
+    var setID = "macOS"
+
+    init() {}
+}

--- a/Sources/Sarvkrit/Features/Studio/DeviceFrame.swift
+++ b/Sources/Sarvkrit/Features/Studio/DeviceFrame.swift
@@ -1,0 +1,94 @@
+import CoreGraphics
+import Foundation
+
+/// A bezel drawn around the recording.
+///
+/// **Data, not image assets** — the same argument `BackgroundCatalogue` makes for gradients. A set
+/// of device photographs large enough for a 4K canvas would add tens of megabytes to a menu-bar
+/// utility, be wrong at every aspect ratio but the one they were shot at, and need @2x variants.
+/// A bezel is a rounded rectangle, an inset and a colour.
+struct DeviceFrame: Codable, Equatable, Identifiable {
+
+    struct Colourway: Codable, Equatable, Identifiable {
+        var id: String
+        var name: String
+        var body: RGBAColour
+        /// A hairline highlight along the bezel's inner edge, which is what stops a flat rectangle
+        /// reading as a border rather than as a device.
+        var rim: RGBAColour
+    }
+
+    var id: String
+    var name: String
+    /// Bezel thickness as a fraction of the *shorter* side, so it stays in proportion at any size.
+    var bezelFraction: Double
+    /// The device's own screen corner radius, as a fraction of the shorter side.
+    var screenCornerFraction: Double
+    var outerCornerFraction: Double
+    var colourways: [Colourway]
+    /// Native aspect, used to suggest a frame that matches the recording.
+    var aspect: Double
+
+    static let macBook = DeviceFrame(
+        id: "macbook", name: "MacBook", bezelFraction: 0.018,
+        screenCornerFraction: 0.012, outerCornerFraction: 0.028,
+        colourways: [
+            .init(id: "space-black", name: "Space Black",
+                  body: RGBAColour(hex: "1D1D1F"), rim: RGBAColour(hex: "3A3A3C")),
+            .init(id: "silver", name: "Silver",
+                  body: RGBAColour(hex: "C9CBCD"), rim: RGBAColour(hex: "E8E9EA")),
+        ],
+        aspect: 16.0 / 10.0)
+
+    static let iPhone = DeviceFrame(
+        id: "iphone", name: "iPhone", bezelFraction: 0.035,
+        screenCornerFraction: 0.09, outerCornerFraction: 0.12,
+        colourways: [
+            .init(id: "titanium", name: "Natural Titanium",
+                  body: RGBAColour(hex: "8F8A81"), rim: RGBAColour(hex: "C7C2B8")),
+            .init(id: "black", name: "Black Titanium",
+                  body: RGBAColour(hex: "1F1F21"), rim: RGBAColour(hex: "45454A")),
+        ],
+        aspect: 9.0 / 19.5)
+
+    static let iPad = DeviceFrame(
+        id: "ipad", name: "iPad", bezelFraction: 0.045,
+        screenCornerFraction: 0.035, outerCornerFraction: 0.055,
+        colourways: [
+            .init(id: "space-grey", name: "Space Grey",
+                  body: RGBAColour(hex: "53565A"), rim: RGBAColour(hex: "7E8287")),
+            .init(id: "silver", name: "Silver",
+                  body: RGBAColour(hex: "D5D7D9"), rim: RGBAColour(hex: "F0F1F2")),
+        ],
+        aspect: 4.0 / 3.0)
+
+    static let all: [DeviceFrame] = [.macBook, .iPhone, .iPad]
+
+    static func frame(id: String) -> DeviceFrame? { all.first { $0.id == id } }
+
+    /// The frame whose aspect is nearest the recording's.
+    ///
+    /// **A default, never a lock.** Detection that overrides the picker is worse than no detection:
+    /// somebody recording a phone-shaped window on a Mac wants whichever they choose.
+    static func suggested(for size: CGSize) -> DeviceFrame? {
+        guard size.width > 0, size.height > 0 else { return nil }
+        let aspect = Double(size.width / size.height)
+        return all.min { abs($0.aspect - aspect) < abs($1.aspect - aspect) }
+    }
+}
+
+/// Which device frame a project is wearing, if any.
+struct DeviceFrameSelection: Codable, Equatable {
+    var frameID: String?
+    var colourwayID: String?
+
+    init() {}
+
+    var isOn: Bool { frameID != nil }
+
+    func resolved() -> (frame: DeviceFrame, colourway: DeviceFrame.Colourway)? {
+        guard let frameID, let frame = DeviceFrame.frame(id: frameID) else { return nil }
+        let colourway = frame.colourways.first { $0.id == colourwayID } ?? frame.colourways[0]
+        return (frame, colourway)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/DeviceFrameRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/DeviceFrameRenderer.swift
@@ -1,0 +1,60 @@
+import CoreGraphics
+import Foundation
+
+/// Drawing the bezel around the recording.
+///
+/// The screen is inset *inside* the frame rather than the frame being drawn around the screen, so
+/// turning a device frame on does not change how much of the recording is visible — only how much
+/// canvas the whole assembly occupies.
+enum DeviceFrameRenderer {
+
+    /// Where the recording goes once a frame is worn, and the paths to draw around it.
+    struct Layout {
+        let outer: CGPath
+        let screen: CGPath
+        let screenRect: CGRect
+        let bezel: RGBAColour
+        let rim: RGBAColour
+    }
+
+    /// - Parameter imageRect: where the recording would sit with no frame.
+    static func layout(_ selection: DeviceFrameSelection, imageRect: CGRect) -> Layout? {
+        guard let (frame, colourway) = selection.resolved() else { return nil }
+
+        let shorter = min(imageRect.width, imageRect.height)
+        let bezel = shorter * CGFloat(frame.bezelFraction)
+        let screenRect = imageRect.insetBy(dx: bezel, dy: bezel)
+        guard screenRect.width > 1, screenRect.height > 1 else { return nil }
+
+        return Layout(
+            outer: CGPath.rounded(imageRect,
+                                  cornerRadius: shorter * CGFloat(frame.outerCornerFraction)),
+            screen: CGPath.rounded(screenRect,
+                                   cornerRadius: shorter * CGFloat(frame.screenCornerFraction)),
+            screenRect: screenRect,
+            bezel: colourway.body,
+            rim: colourway.rim)
+    }
+
+    /// The body, drawn before the recording.
+    static func drawBody(_ layout: Layout, in context: CGContext) {
+        context.saveGState()
+        context.addPath(layout.outer)
+        context.setFillColor(layout.bezel.cgColor)
+        context.fillPath()
+        context.restoreGState()
+    }
+
+    /// The rim, drawn after — a hairline highlight along the bezel's inner edge.
+    ///
+    /// **This one line is what stops the frame reading as a border.** A flat rounded rectangle
+    /// around a video looks like a mistake; a lit inner edge looks like glass in a case.
+    static func drawRim(_ layout: Layout, in context: CGContext) {
+        context.saveGState()
+        context.addPath(layout.screen)
+        context.setStrokeColor(layout.rim.cgColor)
+        context.setLineWidth(max(1, layout.screenRect.width * 0.0018))
+        context.strokePath()
+        context.restoreGState()
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/Ducker.swift
+++ b/Sources/Sarvkrit/Features/Studio/Ducker.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Pulling one track down while another is speaking.
+///
+/// Pure over the speech envelope, producing a gain curve for the *other* track. Applying it is
+/// somebody else's job; deciding the shape is this one's.
+enum Ducker {
+
+    struct Tuning: Equatable {
+        /// dBFS. Above this, someone is talking.
+        var threshold: Double = -35
+        /// How far the other track comes down, in dB.
+        var depth: Double = -12
+        /// Quick, so the duck is already there by the time the first syllable lands.
+        var attack: TimeInterval = 0.08
+        /// **Slow, and the reason is audible.** A release as fast as the attack makes the music
+        /// surge back between every word, which is the pumping that gives away a badly ducked mix.
+        var release: TimeInterval = 0.4
+
+        init() {}
+
+        var thresholdAmplitude: Float { Float(pow(10, threshold / 20)) }
+        /// The duck expressed as a multiplier rather than in dB, which is what a mixer wants.
+        var depthGain: Double { pow(10, depth / 20) }
+    }
+
+    /// A gain multiplier per envelope sample, in 0…1.
+    static func gains(forSpeech envelope: [Float], sampleRate: Double,
+                      tuning: Tuning = Tuning()) -> [Float] {
+        guard !envelope.isEmpty, sampleRate > 0 else { return [] }
+
+        let step = 1 / sampleRate
+        let duckTo = Float(tuning.depthGain)
+        let limit = tuning.thresholdAmplitude
+        // A one-pole step per sample. Two coefficients rather than one is the whole point: the
+        // direction of travel is what decides how fast the gain is allowed to move.
+        let downward = Float(1 - exp(-step / tuning.attack))
+        let upward = Float(1 - exp(-step / tuning.release))
+
+        var gain: Float = 1
+        var result: [Float] = []
+        result.reserveCapacity(envelope.count)
+
+        for level in envelope {
+            let target: Float = abs(level) >= limit ? duckTo : 1
+            gain += (target - gain) * (target < gain ? downward : upward)
+            result.append(min(1, max(duckTo, gain)))
+        }
+        return result
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/EventRecorder.swift
+++ b/Sources/Sarvkrit/Features/Studio/EventRecorder.swift
@@ -11,8 +11,18 @@ import Foundation
 /// **Clicks need no permission.** `NSEvent.addGlobalMonitorForEvents` for mouse events is
 /// unprivileged, so the base recorder never touches the shared event tap and recording your screen
 /// asks for exactly one grant: the one macOS makes unavoidable.
-@MainActor
-final class EventRecorder {
+///
+/// **Not main-actor, and that is deliberate.** This class used to be, and its monitor callbacks
+/// reached back onto the actor with `MainActor.assumeIsolated` — an assertion, not a hop. A click
+/// arriving while the main thread was blocked inside AVFoundation, which pumps the run loop as it
+/// waits, reached that assertion with a main-actor frame still on the stack. The concurrency
+/// runtime was asked which executor was current and answered `0x1e`; the app died in
+/// `objc_opt_class`. AppKit makes no isolation promise the compiler can see, so the state is
+/// lock-guarded and the callbacks record wherever they land. `RecordingWriter` reached the same
+/// conclusion after the first crash in this feature: the hot path must not touch the main actor.
+final class EventRecorder: @unchecked Sendable {
+
+    private let lock = NSLock()
 
     private var samples: [CursorSample] = []
     private var clicks: [ClickEvent] = []
@@ -20,7 +30,6 @@ final class EventRecorder {
     private var flags: [TimeInterval] = []
 
     private var monitors: [Any] = []
-    private var displayLink: CADisplayLink?
     private var isPaused = false
 
     /// **Absolute `systemUptime`, rebased at `finish`.**
@@ -30,23 +39,52 @@ final class EventRecorder {
     /// have no anchor to subtract and would be thrown away or, worse, timed from zero. Storing
     /// absolute times and rebasing once at the end removes the question.
     /// Maps a global AppKit point into the recording's own pixel space.
-    private var mapPoint: ((CGPoint) -> CGPoint?)?
+    private var mapPoint: (@Sendable (CGPoint) -> CGPoint?)?
 
     /// Whether keystrokes are being recorded. Off unless the user asked, and it needs Accessibility.
-    var recordsKeystrokes = false
+    var recordsKeystrokes: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return _recordsKeystrokes }
+        set { lock.lock(); _recordsKeystrokes = newValue; lock.unlock() }
+    }
+    private var _recordsKeystrokes = false
 
-    func begin(mapping: @escaping (CGPoint) -> CGPoint?) {
+    /// How many global monitors are installed right now.
+    ///
+    /// Observable because leaking them was a real bug twice over: a start that failed part-way left
+    /// them running for the life of the process, and calling `begin` again then installed a second
+    /// set on top, so every click was logged twice.
+    var installedMonitorCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return monitors.count
+    }
+
+    func begin(mapping: @escaping @Sendable (CGPoint) -> CGPoint?) {
+        // Removed first. `begin` used to install unconditionally, so a second recording after a
+        // failed start ran with two monitors and doubled every click and keystroke in the log.
+        removeMonitors()
+
+        lock.lock()
         samples = []; clicks = []; keys = []; flags = []
         mapPoint = mapping
         isPaused = false
+        lock.unlock()
+
         installMonitors()
     }
 
-    func pause() { isPaused = true }
-    func resume() { isPaused = false }
+    deinit {
+        // A monitor outliving its owner keeps firing into a dead closure — the same reason
+        // `ShelfDragMonitor` has one of these.
+        removeMonitors()
+    }
+
+    func pause() { lock.lock(); isPaused = true; lock.unlock() }
+    func resume() { lock.lock(); isPaused = false; lock.unlock() }
 
     func flag() {
-        guard let now = currentTime() else { return }
+        let now = Self.currentTime()
+        lock.lock(); defer { lock.unlock() }
+        guard !isPaused else { return }
         flags.append(now)
     }
 
@@ -57,6 +95,8 @@ final class EventRecorder {
     /// as a bug, and is the single most damaging defect this feature can have.
     func finish(anchoredTo anchor: TimeInterval?) -> EventLog {
         removeMonitors()
+
+        lock.lock(); defer { lock.unlock() }
         guard let anchor else { return EventLog() }
 
         // Anything from before the first frame belongs to no picture, so it is dropped rather than
@@ -86,17 +126,19 @@ final class EventRecorder {
     /// events stop arriving the moment the mouse stops — and a path with no samples during a pause
     /// cannot be interpolated across it.
     func sampleCursor() {
-        guard !isPaused, let now = currentTime() else { return }
+        let now = Self.currentTime()
         let global = NSEvent.mouseLocation
+        let kind = CursorKindReader.current()
+
+        lock.lock(); defer { lock.unlock() }
+        guard !isPaused else { return }
         let mapped = mapPoint?(global)
-        samples.append(CursorSample(t: now,
-                                    point: mapped ?? .zero,
-                                    kind: CursorKindReader.current(),
-                                    isInside: mapped != nil))
+        samples.append(CursorSample(t: now, point: mapped ?? .zero,
+                                    kind: kind, isInside: mapped != nil))
     }
 
     /// Absolute, not relative. See the note on the sample arrays.
-    private func currentTime() -> TimeInterval? {
+    private static func currentTime() -> TimeInterval {
         ProcessInfo.processInfo.systemUptime
     }
 
@@ -108,39 +150,61 @@ final class EventRecorder {
         let mouse = NSEvent.addGlobalMonitorForEvents(
             matching: [.leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp]
         ) { [weak self] event in
-            MainActor.assumeIsolated { self?.record(event) }
+            // Recorded on whichever thread AppKit chose. No assertion, no hop — see the note on
+            // the class.
+            self?.record(event)
         }
-        if let mouse { monitors.append(mouse) }
 
-        guard recordsKeystrokes else { return }
+        lock.lock()
+        if let mouse { monitors.append(mouse) }
+        let wantsKeys = _recordsKeystrokes
+        lock.unlock()
+
+        guard wantsKeys else { return }
         let keyboard = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            MainActor.assumeIsolated { self?.record(key: event) }
+            self?.record(key: event)
         }
+        lock.lock()
         if let keyboard { monitors.append(keyboard) }
+        lock.unlock()
     }
 
     private func removeMonitors() {
-        monitors.forEach { NSEvent.removeMonitor($0) }
+        lock.lock()
+        let doomed = monitors
         monitors = []
+        lock.unlock()
+        doomed.forEach { NSEvent.removeMonitor($0) }
     }
 
     private func record(_ event: NSEvent) {
-        guard !isPaused, let now = currentTime() else { return }
+        let now = Self.currentTime()
         let global = NSEvent.mouseLocation
-        let mapped = mapPoint?(global)
         let isDown = event.type == .leftMouseDown || event.type == .rightMouseDown
         let button: ClickEvent.Button =
             (event.type == .rightMouseDown || event.type == .rightMouseUp) ? .right : .left
+
+        lock.lock(); defer { lock.unlock() }
+        guard !isPaused else { return }
+        let mapped = mapPoint?(global)
         clicks.append(ClickEvent(t: now, point: mapped ?? .zero, button: button,
                                  isDown: isDown, isInside: mapped != nil))
     }
 
     private func record(key event: NSEvent) {
-        guard !isPaused, let now = currentTime() else { return }
+        lock.lock()
+        let paused = isPaused
+        lock.unlock()
+        guard !paused else { return }
+
         // Never what was typed into a secure field. The check is cheap and the alternative is
-        // holding somebody's password in a file on disk.
+        // holding somebody's password in a file on disk. Deliberately outside the lock: it is an
+        // Accessibility round trip, and holding a lock across one would stall every click.
         guard !SecureFieldCheck.isFocusedElementSecure() else { return }
         guard let label = KeyLabel.describe(event) else { return }
+        let now = Self.currentTime()
+
+        lock.lock(); defer { lock.unlock() }
         keys.append(KeyEvent(t: now, label: label,
                              isModifierCombination: KeyLabel.isCombination(event)))
     }

--- a/Sources/Sarvkrit/Features/Studio/EventRecorder.swift
+++ b/Sources/Sarvkrit/Features/Studio/EventRecorder.swift
@@ -1,0 +1,127 @@
+import AppKit
+import Foundation
+
+/// Captures what the mouse and keyboard did, alongside the video.
+///
+/// **This is the half that makes the feature what it is.** The screen is recorded with
+/// `showsCursor = false`, so without this log there is no cursor at all; with it, the pointer can
+/// be redrawn at any size, smoothed, given motion blur, and kept sharp at 2.5× zoom — and the
+/// zooms themselves can be invented afterwards from where the clicks landed.
+///
+/// **Clicks need no permission.** `NSEvent.addGlobalMonitorForEvents` for mouse events is
+/// unprivileged, so the base recorder never touches the shared event tap and recording your screen
+/// asks for exactly one grant: the one macOS makes unavoidable.
+@MainActor
+final class EventRecorder {
+
+    private var samples: [CursorSample] = []
+    private var clicks: [ClickEvent] = []
+    private var keys: [KeyEvent] = []
+    private var flags: [TimeInterval] = []
+
+    private var monitors: [Any] = []
+    private var displayLink: CADisplayLink?
+    private var isPaused = false
+
+    /// Set once the first video frame lands, so events and frames share one clock.
+    private var startedAt: TimeInterval?
+    /// Maps a global AppKit point into the recording's own pixel space.
+    private var mapPoint: ((CGPoint) -> CGPoint?)?
+
+    /// Whether keystrokes are being recorded. Off unless the user asked, and it needs Accessibility.
+    var recordsKeystrokes = false
+
+    func begin(mapping: @escaping (CGPoint) -> CGPoint?) {
+        samples = []; clicks = []; keys = []; flags = []
+        mapPoint = mapping
+        isPaused = false
+        installMonitors()
+    }
+
+    /// Called with the presentation timestamp of the first video frame.
+    ///
+    /// **One clock, and this is where it is set.** Everything else is measured from here, so the
+    /// cursor cannot drift against the picture. Getting this wrong by 80 ms puts the pointer
+    /// visibly behind what it clicked, which reads as "the app is slow" rather than as a bug.
+    func anchor(to hostTime: TimeInterval) {
+        startedAt = hostTime
+    }
+
+    func pause() { isPaused = true }
+    func resume() { isPaused = false }
+
+    func flag() {
+        guard let now = currentTime() else { return }
+        flags.append(now)
+    }
+
+    func finish() -> EventLog {
+        removeMonitors()
+        return EventLog(cursor: samples, clicks: clicks, keys: keys, flags: flags)
+    }
+
+    // MARK: - Sampling
+
+    /// Sampled at the display's refresh rate rather than taken from move events, because move
+    /// events stop arriving the moment the mouse stops — and a path with no samples during a pause
+    /// cannot be interpolated across it.
+    func sampleCursor() {
+        guard !isPaused, let now = currentTime() else { return }
+        let global = NSEvent.mouseLocation
+        let mapped = mapPoint?(global)
+        samples.append(CursorSample(t: now,
+                                    point: mapped ?? .zero,
+                                    kind: CursorKindReader.current(),
+                                    isInside: mapped != nil))
+    }
+
+    private func currentTime() -> TimeInterval? {
+        guard let startedAt else { return nil }
+        return ProcessInfo.processInfo.systemUptime - startedAt
+    }
+
+    // MARK: - Monitors
+
+    private func installMonitors() {
+        // Global monitors observe without consuming, so nothing here can ever swallow a click or a
+        // keystroke from the app being demonstrated.
+        let mouse = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp]
+        ) { [weak self] event in
+            MainActor.assumeIsolated { self?.record(event) }
+        }
+        if let mouse { monitors.append(mouse) }
+
+        guard recordsKeystrokes else { return }
+        let keyboard = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            MainActor.assumeIsolated { self?.record(key: event) }
+        }
+        if let keyboard { monitors.append(keyboard) }
+    }
+
+    private func removeMonitors() {
+        monitors.forEach { NSEvent.removeMonitor($0) }
+        monitors = []
+    }
+
+    private func record(_ event: NSEvent) {
+        guard !isPaused, let now = currentTime() else { return }
+        let global = NSEvent.mouseLocation
+        let mapped = mapPoint?(global)
+        let isDown = event.type == .leftMouseDown || event.type == .rightMouseDown
+        let button: ClickEvent.Button =
+            (event.type == .rightMouseDown || event.type == .rightMouseUp) ? .right : .left
+        clicks.append(ClickEvent(t: now, point: mapped ?? .zero, button: button,
+                                 isDown: isDown, isInside: mapped != nil))
+    }
+
+    private func record(key event: NSEvent) {
+        guard !isPaused, let now = currentTime() else { return }
+        // Never what was typed into a secure field. The check is cheap and the alternative is
+        // holding somebody's password in a file on disk.
+        guard !SecureFieldCheck.isFocusedElementSecure() else { return }
+        guard let label = KeyLabel.describe(event) else { return }
+        keys.append(KeyEvent(t: now, label: label,
+                             isModifierCombination: KeyLabel.isCombination(event)))
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/EventRecorder.swift
+++ b/Sources/Sarvkrit/Features/Studio/EventRecorder.swift
@@ -23,8 +23,12 @@ final class EventRecorder {
     private var displayLink: CADisplayLink?
     private var isPaused = false
 
-    /// Set once the first video frame lands, so events and frames share one clock.
-    private var startedAt: TimeInterval?
+    /// **Absolute `systemUptime`, rebased at `finish`.**
+    ///
+    /// The obvious design — subtract an anchor as each sample is taken — has an ordering hole: the
+    /// display link starts before the first video frame arrives, so the earliest samples would
+    /// have no anchor to subtract and would be thrown away or, worse, timed from zero. Storing
+    /// absolute times and rebasing once at the end removes the question.
     /// Maps a global AppKit point into the recording's own pixel space.
     private var mapPoint: ((CGPoint) -> CGPoint?)?
 
@@ -38,15 +42,6 @@ final class EventRecorder {
         installMonitors()
     }
 
-    /// Called with the presentation timestamp of the first video frame.
-    ///
-    /// **One clock, and this is where it is set.** Everything else is measured from here, so the
-    /// cursor cannot drift against the picture. Getting this wrong by 80 ms puts the pointer
-    /// visibly behind what it clicked, which reads as "the app is slow" rather than as a bug.
-    func anchor(to hostTime: TimeInterval) {
-        startedAt = hostTime
-    }
-
     func pause() { isPaused = true }
     func resume() { isPaused = false }
 
@@ -55,9 +50,34 @@ final class EventRecorder {
         flags.append(now)
     }
 
-    func finish() -> EventLog {
+    /// - Parameter anchor: `systemUptime` at the instant the first video frame landed.
+    ///
+    /// **One clock, and this is where the two halves are joined.** Getting it wrong by 80 ms puts
+    /// the pointer visibly behind what it clicked — which reads as "the app is slow" rather than
+    /// as a bug, and is the single most damaging defect this feature can have.
+    func finish(anchoredTo anchor: TimeInterval?) -> EventLog {
         removeMonitors()
-        return EventLog(cursor: samples, clicks: clicks, keys: keys, flags: flags)
+        guard let anchor else { return EventLog() }
+
+        // Anything from before the first frame belongs to no picture, so it is dropped rather than
+        // given a negative time.
+        let rebased = samples.filter { $0.t >= anchor }.map { sample -> CursorSample in
+            var moved = sample
+            moved.t -= anchor
+            return moved
+        }
+        let movedClicks = clicks.filter { $0.t >= anchor }.map { click -> ClickEvent in
+            var moved = click
+            moved.t -= anchor
+            return moved
+        }
+        let movedKeys = keys.filter { $0.t >= anchor }.map { key -> KeyEvent in
+            var moved = key
+            moved.t -= anchor
+            return moved
+        }
+        return EventLog(cursor: rebased, clicks: movedClicks, keys: movedKeys,
+                        flags: flags.filter { $0 >= anchor }.map { $0 - anchor })
     }
 
     // MARK: - Sampling
@@ -75,9 +95,9 @@ final class EventRecorder {
                                     isInside: mapped != nil))
     }
 
+    /// Absolute, not relative. See the note on the sample arrays.
     private func currentTime() -> TimeInterval? {
-        guard let startedAt else { return nil }
-        return ProcessInfo.processInfo.systemUptime - startedAt
+        ProcessInfo.processInfo.systemUptime
     }
 
     // MARK: - Monitors

--- a/Sources/Sarvkrit/Features/Studio/ExportPreset.swift
+++ b/Sources/Sarvkrit/Features/Studio/ExportPreset.swift
@@ -1,5 +1,7 @@
+import AVFoundation
 import CoreGraphics
 import Foundation
+import UniformTypeIdentifiers
 
 /// A named set of export settings.
 ///
@@ -36,23 +38,79 @@ struct ExportPreset: Identifiable, Equatable {
 
     var id: String
     var name: String
+    /// One line under the name, so a preset is chosen by what it is for rather than by its numbers.
+    var purpose: String
     var codec: Codec
     /// Target height in pixels; nil keeps the canvas as it is.
     var height: Int?
-    var fps: Int
-    /// Social video is watched muted more often than not.
-    var forcesCaptions: Bool = false
-    /// Keeps the microphone and system audio as separate tracks in the container.
-    var separatesAudioTracks: Bool = false
+    /// Nil follows the recording's own rate.
+    ///
+    /// **A 30fps recording exported at 60 is every frame duplicated.** This was a plain `Int` and
+    /// `manifest.fps` was read nowhere, so choosing 30fps when recording produced a 60fps file of
+    /// pairs — twice the bitrate for the same pictures.
+    var fps: Int?
+    /// Whether a chosen height above the canvas is honoured rather than capped.
+    ///
+    /// **Off for a preset, on for a deliberate choice.** A preset must never upscale by accident —
+    /// a 720p recording exported at 4K is a bigger file and not a better video — but somebody who
+    /// picks 4K having been told it will upscale is not to be overridden.
+    var allowsUpscale: Bool = false
 
-    static let web = ExportPreset(id: "web", name: "Web", codec: .h264, height: 1080, fps: 60)
-    static let social = ExportPreset(id: "social", name: "Social", codec: .h264, height: 1080,
-                                     fps: 30, forcesCaptions: true)
-    static let forEditing = ExportPreset(id: "editing", name: "For an editor", codec: .proRes422,
-                                         height: nil, fps: 60, separatesAudioTracks: true)
-    static let small = ExportPreset(id: "small", name: "Small", codec: .h264, height: 720, fps: 30)
+    static let sharpest = ExportPreset(
+        id: "sharpest", name: "Sharpest", purpose: "Every pixel that was recorded",
+        codec: .h264, height: nil, fps: nil)
+    static let web = ExportPreset(
+        id: "web", name: "Web", purpose: "1080p — plays everywhere",
+        codec: .h264, height: 1080, fps: 60)
+    static let small = ExportPreset(
+        id: "small", name: "Small", purpose: "720p — for sending in a message",
+        codec: .h264, height: 720, fps: 30)
+    static let forEditing = ExportPreset(
+        id: "editing", name: "For an editor", purpose: "ProRes at full size — very large",
+        codec: .proRes422, height: nil, fps: nil)
 
-    static let all: [ExportPreset] = [.web, .social, .forEditing, .small]
+    /// Sharpest first: it is the one this app was throwing away for free.
+    static let all: [ExportPreset] = [.sharpest, .web, .small, .forEditing]
+
+    /// The rate to encode at, given what the recording was captured at.
+    func frameRate(forRecording recordingFPS: Int) -> Int {
+        fps ?? max(1, recordingFPS)
+    }
+
+    var fileType: AVFileType { codec == .proRes422 ? .mov : .mp4 }
+    var contentType: UTType { codec == .proRes422 ? .quickTimeMovie : .mpeg4Movie }
+    var fileExtension: String { codec == .proRes422 ? "mov" : "mp4" }
+
+    /// Bits per second for a lossy codec.
+    ///
+    /// **The frame rate is a factor, and it was not.** This was `width × height × 8`, so 60fps and
+    /// 30fps were handed the same budget and 60fps got half the quality per frame. Anchored at
+    /// 30fps so the existing look of a 30fps export does not change.
+    static func videoBitrate(size: CGSize, fps: Int) -> Int {
+        let pixels = Double(size.width * size.height)
+        return Int(pixels * 8 * (Double(max(1, fps)) / 30).squareRoot())
+    }
+
+    /// Roughly how large the file will be, for the dialog to show before committing.
+    ///
+    /// Deliberately rough: the audio is a fixed 128 kbps and ProRes is quoted from its data rate
+    /// per megapixel rather than from a bitrate it does not have. A number within a factor of
+    /// about 1.5 is what makes "will this fit in an email" answerable.
+    func estimatedBytes(forCanvas canvas: CGSize, seconds: TimeInterval,
+                        recordingFPS: Int) -> Int {
+        let size = outputSize(forCanvas: canvas)
+        let rate = frameRate(forRecording: recordingFPS)
+        let videoBitsPerSecond: Double
+        if codec == .proRes422 {
+            // ProRes 422 is about 15 MB/s at 1080p30, and scales with pixels and rate.
+            let megapixels = Double(size.width * size.height) / 2_073_600
+            videoBitsPerSecond = 15_000_000 * 8 * megapixels * Double(rate) / 30
+        } else {
+            videoBitsPerSecond = Double(Self.videoBitrate(size: size, fps: rate))
+        }
+        let audioBitsPerSecond = 128_000.0
+        return Int((videoBitsPerSecond + audioBitsPerSecond) * max(0, seconds) / 8)
+    }
 
     /// The pixel size to encode at, for a given canvas.
     ///
@@ -65,7 +123,7 @@ struct ExportPreset: Identifiable, Equatable {
     ///   closely at the last row of pixels.
     func outputSize(forCanvas canvas: CGSize) -> CGSize {
         guard canvas.width > 0, canvas.height > 0 else { return .zero }
-        guard let height, Double(height) < Double(canvas.height) else {
+        guard let height, allowsUpscale || Double(height) < Double(canvas.height) else {
             return CGSize(width: Self.even(canvas.width), height: Self.even(canvas.height))
         }
         let scale = Double(height) / Double(canvas.height)
@@ -75,5 +133,77 @@ struct ExportPreset: Identifiable, Equatable {
 
     private static func even(_ value: CGFloat) -> CGFloat {
         max(2, (value / 2).rounded() * 2)
+    }
+}
+
+/// One row of the export dialog's resolution list.
+///
+/// **Named against the canvas, not in the abstract.** "1080p" means a different pixel size for
+/// every recording, and whether it is a downscale or an upscale depends entirely on what was
+/// captured — so each row carries the size it will actually produce and whether producing it means
+/// inventing pixels.
+struct ExportResolution: Identifiable, Equatable {
+
+    enum Choice: Equatable, Hashable {
+        case native
+        case height(Int)
+    }
+
+    var id: Choice { resolution }
+    let resolution: Choice
+    let size: CGSize
+    /// The composited canvas this row was measured against — the recording plus its background
+    /// padding. Kept because the ratio between it and `size` is what says how much of the output
+    /// frame the picture itself gets.
+    let canvas: CGSize
+    /// The canvas cannot fill this, so the encoder would be stretching it.
+    let upscales: Bool
+
+    var name: String {
+        switch resolution {
+        case .native: return "Native"
+        case .height(2160): return "4K"
+        case .height(let height): return "\(height)p"
+        }
+    }
+
+    /// `3152 × 2092`, for the row's second line.
+    var pixels: String { "\(Int(size.width)) × \(Int(size.height))" }
+
+    /// How tall the *recording* itself ends up, which is not the frame height whenever the project
+    /// has background padding.
+    ///
+    /// **The height cap measures the padded canvas.** With the default 64pt padding, "1080p" on a
+    /// 3024×1964 capture puts the picture at about 1014 pixels — the number in the menu is not the
+    /// number the content gets, and the dialog should be able to say so.
+    func contentHeight(forRecording recording: CGSize) -> CGFloat {
+        guard canvas.height > 0, recording.height > 0 else { return size.height }
+        // The recording occupies its own share of the canvas, and the whole canvas is scaled to
+        // the output height — so the picture keeps that share of the frame.
+        return (recording.height * (size.height / canvas.height)).rounded()
+    }
+
+    /// The heights worth offering, largest first, each measured against this canvas.
+    ///
+    /// 4K is offered even where it upscales, because it was asked for and because a 4K container is
+    /// sometimes what a downstream tool needs. It is marked rather than hidden.
+    static func offered(forCanvas canvas: CGSize) -> [ExportResolution] {
+        guard canvas.width > 0, canvas.height > 0 else { return [] }
+        let native = ExportResolution(resolution: .native, size: even(canvas),
+                                      canvas: canvas, upscales: false)
+        let heights = [2160, 1440, 1080, 720]
+        return [native] + heights.map { height in
+            let scale = CGFloat(height) / canvas.height
+            return ExportResolution(
+                resolution: .height(height),
+                size: even(CGSize(width: canvas.width * scale, height: CGFloat(height))),
+                canvas: canvas,
+                upscales: CGFloat(height) > canvas.height)
+        }
+    }
+
+    private static func even(_ size: CGSize) -> CGSize {
+        CGSize(width: max(2, (size.width / 2).rounded() * 2),
+               height: max(2, (size.height / 2).rounded() * 2))
     }
 }

--- a/Sources/Sarvkrit/Features/Studio/ExportPreset.swift
+++ b/Sources/Sarvkrit/Features/Studio/ExportPreset.swift
@@ -1,0 +1,79 @@
+import CoreGraphics
+import Foundation
+
+/// A named set of export settings.
+///
+/// **Because "which of these numbers do I want" is not a question most people can answer.** The
+/// individual controls are all still there; these are the four answers that cover almost every
+/// reason somebody exports a screen recording.
+struct ExportPreset: Identifiable, Equatable {
+
+    enum Codec: String, Codable, CaseIterable, Equatable {
+        case h264
+        case hevc
+        case proRes422
+        case gif
+
+        var title: String {
+            switch self {
+            case .h264: return "H.264"
+            case .hevc: return "HEVC"
+            case .proRes422: return "ProRes 422"
+            case .gif: return "GIF"
+            }
+        }
+
+        /// Said in the UI, because "smaller file" and "might not play" are the same choice.
+        var caveat: String? {
+            switch self {
+            case .h264: return nil
+            case .hevc: return "About half the size, but not everything can play it."
+            case .proRes422: return "Very large. For handing to a video editor."
+            case .gif: return "No sound, and large for anything over a few seconds."
+            }
+        }
+    }
+
+    var id: String
+    var name: String
+    var codec: Codec
+    /// Target height in pixels; nil keeps the canvas as it is.
+    var height: Int?
+    var fps: Int
+    /// Social video is watched muted more often than not.
+    var forcesCaptions: Bool = false
+    /// Keeps the microphone and system audio as separate tracks in the container.
+    var separatesAudioTracks: Bool = false
+
+    static let web = ExportPreset(id: "web", name: "Web", codec: .h264, height: 1080, fps: 60)
+    static let social = ExportPreset(id: "social", name: "Social", codec: .h264, height: 1080,
+                                     fps: 30, forcesCaptions: true)
+    static let forEditing = ExportPreset(id: "editing", name: "For an editor", codec: .proRes422,
+                                         height: nil, fps: 60, separatesAudioTracks: true)
+    static let small = ExportPreset(id: "small", name: "Small", codec: .h264, height: 720, fps: 30)
+
+    static let all: [ExportPreset] = [.web, .social, .forEditing, .small]
+
+    /// The pixel size to encode at, for a given canvas.
+    ///
+    /// Two rules that are easy to get wrong and expensive to notice later:
+    ///
+    /// - **Never upscale.** A 720p recording exported at 4K is a bigger file and not a better
+    ///   video, and the only thing it reliably produces is a long wait.
+    /// - **Always even.** H.264 and HEVC work in macroblocks; an odd dimension makes the encoder
+    ///   pad the frame, which costs quality for nothing and is invisible until somebody looks
+    ///   closely at the last row of pixels.
+    func outputSize(forCanvas canvas: CGSize) -> CGSize {
+        guard canvas.width > 0, canvas.height > 0 else { return .zero }
+        guard let height, Double(height) < Double(canvas.height) else {
+            return CGSize(width: Self.even(canvas.width), height: Self.even(canvas.height))
+        }
+        let scale = Double(height) / Double(canvas.height)
+        return CGSize(width: Self.even(canvas.width * CGFloat(scale)),
+                      height: Self.even(CGFloat(height)))
+    }
+
+    private static func even(_ value: CGFloat) -> CGFloat {
+        max(2, (value / 2).rounded() * 2)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/FadeCurtain.swift
+++ b/Sources/Sarvkrit/Features/Studio/FadeCurtain.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// How black the frame should be, at a moment in the finished video.
+///
+/// **One curtain for three features.** A fade up from black at the start, a fade down at the end,
+/// and a dip to black at a cut are all the same wash at different times, so they are one piece of
+/// arithmetic rather than three.
+///
+/// **Dip-to-black rather than crossfade, and that is a deliberate limit.** A crossfade needs the
+/// outgoing *and* incoming frames at once, which means a second decoder in the player and buffering
+/// in the exporter. A dip needs the one frame it already has, and it is honest about being a cut.
+enum FadeCurtain {
+
+    struct Dip: Equatable {
+        /// Output time of the cut this dip is centred on.
+        var at: TimeInterval
+        /// Total length, half either side of the cut.
+        var length: TimeInterval
+    }
+
+    /// 0 for no wash, 1 for solid black.
+    static func alpha(atOutput t: TimeInterval, duration: TimeInterval,
+                      fadeIn: TimeInterval, fadeOut: TimeInterval,
+                      dips: [Dip] = []) -> Double {
+        var darkest: Double = 0
+
+        if fadeIn > 0, t < fadeIn {
+            darkest = max(darkest, 1 - max(0, t) / fadeIn)
+        }
+        if fadeOut > 0, t > duration - fadeOut, duration > 0 {
+            darkest = max(darkest, 1 - max(0, duration - t) / fadeOut)
+        }
+        for dip in dips where dip.length > 0 {
+            let half = dip.length / 2
+            let distance = abs(t - dip.at)
+            guard distance < half else { continue }
+            // Fully black at the cut itself, clear at either end of the dip.
+            darkest = max(darkest, 1 - distance / half)
+        }
+        return min(1, max(0, darkest))
+    }
+
+    /// Where the dips fall, given the running order.
+    ///
+    /// A dip belongs to the clip that *starts* at the cut, which is the same convention
+    /// `Timeline.sourceTime(forOutput:)` uses for the boundary itself. The first clip cannot have
+    /// one: there is no cut before the beginning, and a fade in is the setting for that.
+    static func dips(in timeline: Timeline) -> [Dip] {
+        var result: [Dip] = []
+        var elapsed: TimeInterval = 0
+        for (index, clip) in timeline.clips.enumerated() {
+            if index > 0, clip.dipToBlack > 0 {
+                result.append(Dip(at: elapsed, length: clip.dipToBlack))
+            }
+            elapsed += clip.outputDuration
+        }
+        return result
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/GIFEncoder.swift
+++ b/Sources/Sarvkrit/Features/Studio/GIFEncoder.swift
@@ -1,0 +1,117 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Writing an animated GIF.
+///
+/// **Treated as real work rather than a format flag.** A GIF has 256 colours, and a screen
+/// recording composited onto a mesh gradient has thousands — handing frames straight to
+/// `CGImageDestination` produces the banded, dirty result that gives GIF its reputation. So the
+/// palette is chosen from the footage and the quantisation error is dithered.
+enum GIFEncoder {
+
+    struct Options: Equatable {
+        /// 10–15 is the usable band: below it motion stutters, above it the file doubles for
+        /// something nobody perceives.
+        var fps = 12
+        /// 0 loops forever.
+        var loopCount = 0
+        var maximumColours = 256
+        var dithers = true
+
+        init() {}
+    }
+
+    /// A palette built from the frames themselves.
+    ///
+    /// Median cut rather than a fixed web palette: a recording is mostly one application's colours
+    /// plus one gradient, and spending all 256 entries on *those* is the whole difference between
+    /// a clean GIF and a muddy one.
+    static func palette(from frames: [CGImage], maximumColours: Int) -> [RGBAColour] {
+        var samples: [(r: Int, g: Int, b: Int)] = []
+        for frame in frames {
+            samples.append(contentsOf: sample(frame))
+        }
+        guard !samples.isEmpty else { return [.black, .white] }
+        return medianCut(samples, depth: Int(log2(Double(max(2, maximumColours)))))
+            .map { RGBAColour(r: Double($0.r) / 255, g: Double($0.g) / 255,
+                              b: Double($0.b) / 255, a: 1) }
+    }
+
+    /// A coarse grid rather than every pixel: a 4K frame is eight million samples and the palette
+    /// is indistinguishable from one built on a few thousand.
+    private static func sample(_ image: CGImage, side: Int = 48) -> [(r: Int, g: Int, b: Int)] {
+        var buffer = [UInt8](repeating: 0, count: side * side * 4)
+        guard let context = buffer.withUnsafeMutableBytes({ raw -> CGContext? in
+            CGContext(data: raw.baseAddress, width: side, height: side,
+                      bitsPerComponent: 8, bytesPerRow: side * 4,
+                      space: CGColorSpaceCreateDeviceRGB(),
+                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        }) else { return [] }
+        context.interpolationQuality = .medium
+        context.draw(image, in: CGRect(x: 0, y: 0, width: side, height: side))
+
+        return (0..<(side * side)).map { index in
+            let offset = index * 4
+            return (Int(buffer[offset]), Int(buffer[offset + 1]), Int(buffer[offset + 2]))
+        }
+    }
+
+    /// Splits the colour cube along its longest axis, repeatedly, and averages each bucket.
+    static func medianCut(_ samples: [(r: Int, g: Int, b: Int)],
+                          depth: Int) -> [(r: Int, g: Int, b: Int)] {
+        guard depth > 0, samples.count > 1 else {
+            guard !samples.isEmpty else { return [] }
+            let total = samples.reduce(into: (0, 0, 0)) { sum, sample in
+                sum.0 += sample.r; sum.1 += sample.g; sum.2 += sample.b
+            }
+            let count = samples.count
+            return [(total.0 / count, total.1 / count, total.2 / count)]
+        }
+
+        let ranges = (r: extent(samples.map(\.r)),
+                      g: extent(samples.map(\.g)),
+                      b: extent(samples.map(\.b)))
+        let sorted: [(r: Int, g: Int, b: Int)]
+        if ranges.r >= ranges.g && ranges.r >= ranges.b {
+            sorted = samples.sorted { $0.r < $1.r }
+        } else if ranges.g >= ranges.b {
+            sorted = samples.sorted { $0.g < $1.g }
+        } else {
+            sorted = samples.sorted { $0.b < $1.b }
+        }
+
+        let middle = sorted.count / 2
+        return medianCut(Array(sorted[..<middle]), depth: depth - 1)
+            + medianCut(Array(sorted[middle...]), depth: depth - 1)
+    }
+
+    private static func extent(_ values: [Int]) -> Int {
+        guard let low = values.min(), let high = values.max() else { return 0 }
+        return high - low
+    }
+
+    /// Writes the frames out.
+    static func write(frames: [CGImage], to url: URL, options: Options = Options()) throws {
+        guard !frames.isEmpty else { throw CocoaError(.fileWriteUnknown) }
+        guard let destination = CGImageDestinationCreateWithURL(
+            url as CFURL, UTType.gif.identifier as CFString, frames.count,
+            [kCGImagePropertyGIFDictionary: [
+                kCGImagePropertyGIFLoopCount: options.loopCount,
+            ]] as CFDictionary) else { throw CocoaError(.fileWriteUnknown) }
+
+        let delay = 1.0 / Double(max(1, options.fps))
+        for frame in frames {
+            CGImageDestinationAddImage(destination, frame, [
+                kCGImagePropertyGIFDictionary: [
+                    kCGImagePropertyGIFUnclampedDelayTime: delay,
+                    kCGImagePropertyGIFDelayTime: delay,
+                ],
+            ] as CFDictionary)
+        }
+        guard CGImageDestinationFinalize(destination) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/JSONValue.swift
+++ b/Sources/Sarvkrit/Features/Studio/JSONValue.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Any JSON value, held verbatim.
+///
+/// **This exists to keep somebody else's work.** A project written by a newer build carries fields
+/// this one has never heard of, and the choice is between dropping them on save — quietly deleting
+/// work — and holding them untouched. `CaptureBackground.Fill` already takes the second option for
+/// a single case; a document with dozens of future fields needs a general answer.
+enum JSONValue: Codable, Equatable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    indirect case array([JSONValue])
+    indirect case object([String: JSONValue])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            // Unreachable for well-formed JSON, and null is the one value that cannot mislead.
+            self = .null
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null: try container.encodeNil()
+        case .bool(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .string(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        }
+    }
+}
+
+/// A `CodingKey` built from a string, for reading and writing fields whose names are not known
+/// until runtime.
+struct StudioCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init(stringValue: String) { self.stringValue = stringValue }
+    init?(intValue: Int) { self.intValue = intValue; self.stringValue = String(intValue) }
+    init(_ name: String) { self.stringValue = name }
+}

--- a/Sources/Sarvkrit/Features/Studio/KeystrokeOverlay.swift
+++ b/Sources/Sarvkrit/Features/Studio/KeystrokeOverlay.swift
@@ -1,0 +1,66 @@
+import CoreGraphics
+import Foundation
+
+/// How pressed keys are shown.
+struct KeystrokeSettings: Codable, Equatable {
+    /// Off until asked. Watching the keyboard is a decision, not a discovery.
+    var isEnabled = false
+    /// **The default: combinations only.** ⌘C and ⌃⇧R are what a demo needs to show; putting every
+    /// letter somebody types on screen is a much larger promise about what is being recorded.
+    var showsBareKeys = false
+    var corner: CaptureBackground.Alignment = .bottomTrailing
+    var sizeFraction: Double = 0.035
+    var holdSeconds: TimeInterval = 1.6
+    var fadeSeconds: TimeInterval = 0.25
+    /// A wall of pills is worse than the last few.
+    var maximumPills = 5
+
+    init() {}
+}
+
+/// Turning the keystroke log into the pills on screen at one instant.
+enum KeystrokeOverlay {
+
+    struct Pill: Equatable, Identifiable {
+        var id: String { "\(label)-\(firstPressed)" }
+        var label: String
+        var firstPressed: TimeInterval
+        /// Repeats collapse into a count rather than stacking, which is noise rather than
+        /// information.
+        var repeatCount: Int
+        var opacity: Double
+    }
+
+    static func pills(at t: TimeInterval, keys: [KeyEvent],
+                      settings: KeystrokeSettings) -> [Pill] {
+        let window = settings.holdSeconds + settings.fadeSeconds
+        let live = keys.filter { key in
+            guard key.t <= t, t - key.t <= window else { return false }
+            return settings.showsBareKeys || key.isModifierCombination
+        }
+        guard !live.isEmpty else { return [] }
+
+        var pills: [Pill] = []
+        for key in live {
+            // Collapsed against the previous pill only, so ⌘C ⌘V ⌘C reads as three presses rather
+            // than being merged into two.
+            if var last = pills.last, last.label == key.label {
+                last.repeatCount += 1
+                last.opacity = opacity(at: t, pressed: key.t, settings: settings)
+                pills[pills.count - 1] = last
+            } else {
+                pills.append(Pill(label: key.label, firstPressed: key.t, repeatCount: 1,
+                                  opacity: opacity(at: t, pressed: key.t, settings: settings)))
+            }
+        }
+        return Array(pills.suffix(settings.maximumPills))
+    }
+
+    private static func opacity(at t: TimeInterval, pressed: TimeInterval,
+                                settings: KeystrokeSettings) -> Double {
+        let age = t - pressed
+        guard age > settings.holdSeconds else { return 1 }
+        guard settings.fadeSeconds > 0 else { return 0 }
+        return max(0, 1 - (age - settings.holdSeconds) / settings.fadeSeconds)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/KeystrokeRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/KeystrokeRenderer.swift
@@ -1,0 +1,52 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+/// Drawing the keystroke pills.
+enum KeystrokeRenderer {
+
+    static func draw(_ pills: [KeystrokeOverlay.Pill], settings: KeystrokeSettings,
+                     canvas: CGSize, in context: CGContext) {
+        let size = CGFloat(settings.sizeFraction) * canvas.height
+        let font = NSFont.monospacedSystemFont(ofSize: size, weight: .medium)
+        let padding = size * 0.5
+        let gap = size * 0.32
+        let margin = canvas.height * 0.05
+
+        // Measured first, then placed as a block, so the row grows away from its corner rather
+        // than sliding along the edge as keys are added.
+        let drawn = pills.map { pill -> (text: NSAttributedString, width: CGFloat, alpha: Double) in
+            let label = pill.repeatCount > 1 ? "\(pill.label) ×\(pill.repeatCount)" : pill.label
+            let text = NSAttributedString(
+                string: label,
+                attributes: [.font: font, .foregroundColor: NSColor.white])
+            return (text, text.size().width + padding * 2, pill.opacity)
+        }
+        let totalWidth = drawn.reduce(0) { $0 + $1.width } + gap * CGFloat(max(0, pills.count - 1))
+        let height = size + padding
+
+        let unit = settings.corner.unitPoint
+        let free = CGSize(width: max(0, canvas.width - totalWidth - margin * 2),
+                          height: max(0, canvas.height - height - margin * 2))
+        var x = margin + free.width * unit.x
+        let y = margin + free.height * unit.y
+
+        for pill in drawn {
+            let rect = CGRect(x: x, y: y, width: pill.width, height: height)
+            context.saveGState()
+            context.setAlpha(CGFloat(pill.alpha))
+            context.addPath(CGPath.rounded(rect, cornerRadius: height * 0.28))
+            context.setFillColor(CGColor(red: 0.08, green: 0.08, blue: 0.09, alpha: 0.86))
+            context.fillPath()
+
+            // Core Text draws bottom-up; the surrounding context is top-left, so the label is
+            // flipped back for its own draw and no further.
+            context.translateBy(x: 0, y: rect.midY * 2)
+            context.scaleBy(x: 1, y: -1)
+            pill.text.draw(at: CGPoint(x: rect.minX + padding,
+                                       y: rect.midY - pill.text.size().height / 2))
+            context.restoreGState()
+            x += pill.width + gap
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/LoudnessMeter.swift
+++ b/Sources/Sarvkrit/Features/Studio/LoudnessMeter.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// How loud a track is, and what it would take to fix it.
+enum LoudnessMeter {
+
+    /// The streaming convention, and what a viewer's other tabs are mastered to.
+    static let defaultTarget: Double = -16
+
+    /// Anything quieter than this is silence as far as the meter is concerned. Without a floor,
+    /// an empty envelope measures negative infinity and every number downstream becomes `nan`.
+    static let floor: Double = -120
+
+    /// RMS of an amplitude envelope, in dBFS.
+    static func loudness(of envelope: [Float]) -> Double {
+        guard !envelope.isEmpty else { return floor }
+        let meanSquare = envelope.reduce(0.0) { $0 + Double($1) * Double($1) }
+            / Double(envelope.count)
+        guard meanSquare > 0 else { return floor }
+        return max(floor, 10 * log10(meanSquare))
+    }
+
+    /// The correction, in dB, from a measured level to a target.
+    ///
+    /// **One constant gain for the whole track, not a compressor.** A demo recorded slightly too
+    /// quiet is the actual problem here; dynamic-range compression on speech is a taste decision
+    /// with an audible signature, and the app should not make it on someone's behalf without
+    /// saying so. Anything the gain would push past full scale goes through `SoftClip`, which the
+    /// volume mixer already uses and which leaves everything below the threshold bit-for-bit
+    /// untouched.
+    static func gain(from measured: Double, to target: Double = defaultTarget) -> Double {
+        target - measured
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/MediaOverlay.swift
+++ b/Sources/Sarvkrit/Features/Studio/MediaOverlay.swift
@@ -21,9 +21,10 @@ struct MediaOverlay: Codable, Equatable, Identifiable {
     var rect = CGRect(x: 0.62, y: 0.06, width: 0.32, height: 0.32)
     var opacity: Double = 1
     var cornerRadiusFraction: Double = 0
-    var fadeSeconds: TimeInterval = 0.2
+    var fadeSeconds: TimeInterval = MediaOverlay.defaultFade
 
     static let minimumDuration: TimeInterval = 0.4
+    static let defaultFade: TimeInterval = 0.2
 
     func covers(_ t: TimeInterval) -> Bool { t >= start && t < end }
 

--- a/Sources/Sarvkrit/Features/Studio/MediaOverlay.swift
+++ b/Sources/Sarvkrit/Features/Studio/MediaOverlay.swift
@@ -1,0 +1,106 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+
+/// A picture composited over the recording — a logo, a screenshot, a diagram.
+///
+/// **Stored in the bundle, not referenced from wherever it came from.** A project that points at a
+/// file on somebody's Desktop stops working the moment that file moves, and cannot be opened on
+/// another Mac at all. The `.sarvrec` package already keeps everything else the recording needs;
+/// this is the same rule.
+///
+/// Measured in fractions of the canvas, like the camera and the text, so it keeps its framing at
+/// any export size.
+struct MediaOverlay: Codable, Equatable, Identifiable {
+    var id = UUID()
+    var start: TimeInterval
+    var end: TimeInterval
+    /// The file's name inside the bundle's `media` directory.
+    var asset: String
+    /// Unit canvas coordinates: where it sits and how big it is.
+    var rect = CGRect(x: 0.62, y: 0.06, width: 0.32, height: 0.32)
+    var opacity: Double = 1
+    var cornerRadiusFraction: Double = 0
+    var fadeSeconds: TimeInterval = 0.2
+
+    static let minimumDuration: TimeInterval = 0.4
+
+    func covers(_ t: TimeInterval) -> Bool { t >= start && t < end }
+
+    /// 0 outside, ramping at each end, `opacity` while it holds.
+    func opacity(at t: TimeInterval) -> Double {
+        guard covers(t) else { return 0 }
+        let ramp = max(0.0001, min(fadeSeconds, (end - start) / 2))
+        return opacity * min(1, max(0, min(t - start, end - t) / ramp))
+    }
+
+    /// Hand-written for the reason every other one here is: a field added later must not make an
+    /// older project unreadable, which the model treats as *no* project.
+    private enum Key: String, CodingKey {
+        case id, start, end, asset, rect, opacity, cornerRadiusFraction, fadeSeconds
+    }
+
+    init(start: TimeInterval, end: TimeInterval, asset: String) {
+        self.start = start
+        self.end = end
+        self.asset = asset
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Key.self)
+        func read<T: Decodable>(_ key: Key, _ fallback: T) -> T {
+            (try? container.decode(T.self, forKey: key)) ?? fallback
+        }
+        id = read(.id, UUID())
+        start = read(.start, 0)
+        end = read(.end, 0)
+        asset = read(.asset, "")
+        rect = read(.rect, CGRect(x: 0.62, y: 0.06, width: 0.32, height: 0.32))
+        opacity = read(.opacity, 1)
+        cornerRadiusFraction = read(.cornerRadiusFraction, 0)
+        fadeSeconds = read(.fadeSeconds, 0.2)
+    }
+}
+
+/// Loads the pictures a project's overlays refer to, once each.
+///
+/// **Not main-actor**, because the exporter is an actor and needs the same images the canvas does —
+/// and because loading a file has no business on the main thread. Guarded by a lock for the same
+/// reason `RecordingWriter` is.
+final class MediaStore: @unchecked Sendable {
+    static let shared = MediaStore()
+
+    private let lock = NSLock()
+    private var cache: [URL: CGImage] = [:]
+
+    /// The supported kinds, deliberately narrow: still pictures only for now. A movie overlay wants
+    /// its own decoder slaved to the screen's clock, which is the camera track's pattern and a
+    /// larger piece of work than this.
+    static let allowedExtensions = ["png", "jpg", "jpeg", "heic", "gif", "tiff", "bmp"]
+
+    func image(at url: URL) -> CGImage? {
+        lock.lock()
+        if let cached = cache[url] {
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else { return nil }
+        lock.lock()
+        cache[url] = image
+        lock.unlock()
+        return image
+    }
+
+    /// Every picture a project needs, keyed by its asset name.
+    func images(for project: StudioProject, in recording: RecordingBundle) -> [String: CGImage] {
+        var result: [String: CGImage] = [:]
+        for overlay in project.mediaOverlays where !overlay.asset.isEmpty {
+            let url = recording.mediaDirectory.appendingPathComponent(overlay.asset)
+            if let image = image(at: url) { result[overlay.asset] = image }
+        }
+        return result
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/PlaybackClock.swift
+++ b/Sources/Sarvkrit/Features/Studio/PlaybackClock.swift
@@ -57,15 +57,21 @@ enum PlaybackClock {
     /// Reading the camera at the screen's own time would put the face two and a half seconds ahead
     /// of what it is reacting to.
     ///
-    /// Nil at either end is ordinary, not a failure: `StudioRenderer.drawCamera` already draws
-    /// nothing when it has no image.
+    /// **The lead-in holds the first frame rather than showing nothing.** For the couple of seconds
+    /// before the camera was running there is no true picture, and leaving the bubble out until it
+    /// appears is indistinguishable from the camera being broken — which is exactly how it was
+    /// reported. The earliest frame there is stands in, the way a poster frame does.
+    ///
+    /// After the camera stops there is nothing to hold, so nil, and that is ordinary rather than a
+    /// failure: `StudioRenderer.drawCamera` draws nothing when it has no image.
     ///
     /// - Parameter startOffset: seconds by which the camera started after the screen. Zero for
     ///   bundles recorded before that was measured, which then behave exactly as they used to.
     static func cameraTime(forSource source: TimeInterval, startOffset: TimeInterval,
                            cameraDuration: TimeInterval) -> TimeInterval? {
+        guard cameraDuration > 0 else { return nil }
         let t = source - startOffset
-        guard t >= 0, t < cameraDuration else { return nil }
-        return t
+        guard t < cameraDuration else { return nil }
+        return max(0, t)
     }
 }

--- a/Sources/Sarvkrit/Features/Studio/PlaybackClock.swift
+++ b/Sources/Sarvkrit/Features/Studio/PlaybackClock.swift
@@ -17,6 +17,14 @@ enum PlaybackClock {
     /// and small enough that a cut lands within a couple of frames.
     static let resyncTolerance: TimeInterval = 0.05
 
+    /// The same question for the soundtrack, answered more loosely.
+    ///
+    /// **Correcting audio drift is audible.** A seek on the video player costs a decode nobody
+    /// notices; a seek on the audio player is a click in the middle of a word. So the soundtrack
+    /// rides through the drift a frame would be corrected for, and is only put back when it is far
+    /// enough out to hear as lip-sync error.
+    static let audioResyncTolerance: TimeInterval = 0.25
+
     struct Step: Equatable {
         var playhead: TimeInterval
         /// True at either end: forwards past the duration, or backwards past zero when shuttling.

--- a/Sources/Sarvkrit/Features/Studio/PlaybackClock.swift
+++ b/Sources/Sarvkrit/Features/Studio/PlaybackClock.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// The arithmetic behind playback, separated from AVFoundation so it can be reasoned about.
+///
+/// **Both halves of this were wrong, and together they were most of "the editor does not work".**
+///
+/// The playhead moves in *output* time, which is not source time — a trim makes them diverge — so
+/// playback cannot simply read the player's clock. It has to advance the playhead itself and put
+/// the player where that lands. The previous version did both badly: it assumed every display-link
+/// tick was exactly 1/60 of a second, and it then asked for a keyframe-exact seek on *every* tick,
+/// sixty a second, on top of the real-time playback that setting `rate` had already begun.
+enum PlaybackClock {
+
+    /// How far the player may drift before it is nudged back, in seconds.
+    ///
+    /// Large enough that ordinary real-time playback never triggers it — that is the whole point —
+    /// and small enough that a cut lands within a couple of frames.
+    static let resyncTolerance: TimeInterval = 0.05
+
+    struct Step: Equatable {
+        var playhead: TimeInterval
+        /// True at either end: forwards past the duration, or backwards past zero when shuttling.
+        var reachedEnd: Bool
+    }
+
+    /// - Parameter elapsed: seconds that actually passed, not an assumed frame interval. A display
+    ///   link runs at the screen's refresh rate — 120 Hz is ordinary — and a stalled tick covers
+    ///   more than one frame.
+    static func advance(playhead: TimeInterval, elapsed: TimeInterval, rate: Float,
+                        duration: TimeInterval) -> Step {
+        let span = max(0, duration)
+        let moved = playhead + elapsed * Double(rate)
+        let clamped = min(max(0, moved), span)
+        return Step(playhead: clamped, reachedEnd: moved >= span || moved <= 0)
+    }
+
+    /// Whether the player is far enough from where the project wants it to be worth a seek.
+    ///
+    /// In continuous playback the answer is no, every time: `rate` is already carrying the player
+    /// forward at exactly the speed the playhead is moving. It becomes yes at a cut, where output
+    /// time jumps to a different point in the source, and after a stall.
+    static func needsResync(playerTime: TimeInterval, wanted: TimeInterval,
+                            tolerance: TimeInterval = resyncTolerance) -> Bool {
+        abs(playerTime - wanted) > tolerance
+    }
+
+    /// Where a moment in the recording lands inside `camera.mov`, or nil when there is no camera
+    /// picture for it.
+    ///
+    /// **The two tracks do not start together.** `AVCaptureSession` takes a couple of seconds to
+    /// bring a camera up, so the camera file begins later than the screen and ends sooner. In a
+    /// real take here the screen ran 29.175 s against the camera's 26.747 s — a 2.43 s offset.
+    /// Reading the camera at the screen's own time would put the face two and a half seconds ahead
+    /// of what it is reacting to.
+    ///
+    /// Nil at either end is ordinary, not a failure: `StudioRenderer.drawCamera` already draws
+    /// nothing when it has no image.
+    ///
+    /// - Parameter startOffset: seconds by which the camera started after the screen. Zero for
+    ///   bundles recorded before that was measured, which then behave exactly as they used to.
+    static func cameraTime(forSource source: TimeInterval, startOffset: TimeInterval,
+                           cameraDuration: TimeInterval) -> TimeInterval? {
+        let t = source - startOffset
+        guard t >= 0, t < cameraDuration else { return nil }
+        return t
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/PlaybackClock.swift
+++ b/Sources/Sarvkrit/Features/Studio/PlaybackClock.swift
@@ -31,7 +31,11 @@ enum PlaybackClock {
         let span = max(0, duration)
         let moved = playhead + elapsed * Double(rate)
         let clamped = min(max(0, moved), span)
-        return Step(playhead: clamped, reachedEnd: moved >= span || moved <= 0)
+        // **Which end depends on which way we are going.** Checking both unconditionally meant the
+        // first tick of every playback — elapsed zero, playhead zero — read as having reached the
+        // start, and paused before anything moved.
+        let reachedEnd = rate < 0 ? moved <= 0 : moved >= span
+        return Step(playhead: clamped, reachedEnd: reachedEnd)
     }
 
     /// Whether the player is far enough from where the project wants it to be worth a seek.

--- a/Sources/Sarvkrit/Features/Studio/PlaybackClock.swift
+++ b/Sources/Sarvkrit/Features/Studio/PlaybackClock.swift
@@ -57,13 +57,16 @@ enum PlaybackClock {
     /// Reading the camera at the screen's own time would put the face two and a half seconds ahead
     /// of what it is reacting to.
     ///
-    /// **The lead-in holds the first frame rather than showing nothing.** For the couple of seconds
-    /// before the camera was running there is no true picture, and leaving the bubble out until it
-    /// appears is indistinguishable from the camera being broken — which is exactly how it was
-    /// reported. The earliest frame there is stands in, the way a poster frame does.
+    /// **Nil before the camera was running — not its first frame held.**
     ///
-    /// After the camera stops there is nothing to hold, so nil, and that is ordinary rather than a
-    /// failure: `StudioRenderer.drawCamera` draws nothing when it has no image.
+    /// An earlier version held the first frame through the lead-in, reasoning that an empty bubble
+    /// looks like a broken camera. That was the wrong trade: for those couple of seconds there is
+    /// no narration either, so a motionless face over silence reads as the recording having
+    /// stalled. The camera appears when it actually started, and `CameraLayoutResolver` fades it in
+    /// so it does not pop.
+    ///
+    /// Nil after it stops, too, which is ordinary rather than a failure:
+    /// `StudioRenderer.drawCamera` draws nothing when it has no image.
     ///
     /// - Parameter startOffset: seconds by which the camera started after the screen. Zero for
     ///   bundles recorded before that was measured, which then behave exactly as they used to.
@@ -71,7 +74,7 @@ enum PlaybackClock {
                            cameraDuration: TimeInterval) -> TimeInterval? {
         guard cameraDuration > 0 else { return nil }
         let t = source - startOffset
-        guard t < cameraDuration else { return nil }
-        return max(0, t)
+        guard t >= 0, t < cameraDuration else { return nil }
+        return t
     }
 }

--- a/Sources/Sarvkrit/Features/Studio/PointerHighlight.swift
+++ b/Sources/Sarvkrit/Features/Studio/PointerHighlight.swift
@@ -1,0 +1,63 @@
+import CoreGraphics
+import Foundation
+
+/// A stretch where the pointer's surroundings are dimmed, to say "look here".
+///
+/// **Distinct from `StudioMask.Mode.highlight`, on purpose.** That is a hand-drawn rectangle with a
+/// time range: it does not move, and it has to be placed and sized. This one is centred on the
+/// cursor's own recorded position, so it tracks whatever was being demonstrated without anybody
+/// drawing a box — which is the thing that was missing, since `CursorSettings` is entirely global
+/// and could not express "now" at all.
+struct PointerHighlight: Codable, Equatable, Identifiable {
+    var id = UUID()
+    var start: TimeInterval
+    var end: TimeInterval
+    /// Of the frame's **shorter** side. Taking it from the width would make one setting a very
+    /// different spotlight on a wide recording than on a tall one.
+    var radiusFraction: Double = 0.14
+    /// How far everything outside the circle is dimmed, 0…1.
+    var dimming: Double = 0.55
+    /// Faded in and out over this, at both ends. A spotlight that appears between two frames reads
+    /// as a flash — the same reason the camera's layout changes are blended.
+    var transition: TimeInterval = 0.25
+
+    static let minimumDuration: TimeInterval = 0.4
+}
+
+/// Resolving the pointer highlights into one circle.
+enum PointerSpotlight {
+
+    struct State: Equatable {
+        /// Recording pixel space, like `ClickEvent.point`.
+        var centre: CGPoint
+        var radius: CGFloat
+        var dimming: Double
+    }
+
+    /// - Parameter cursor: the pointer's recorded position at `t`, or nil if it is not known —
+    ///   in which case there is nothing to point at, and inventing a centre would put the
+    ///   spotlight in a corner.
+    static func state(at t: TimeInterval, highlights: [PointerHighlight],
+                      cursor: CGPoint?, frameSize: CGSize) -> State? {
+        guard let cursor,
+              frameSize.width > 0, frameSize.height > 0,
+              // The first that covers this moment wins, so overlapping spotlights never multiply
+              // into darkness.
+              let spot = highlights.first(where: { t >= $0.start && t < $0.end })
+        else { return nil }
+
+        let shorter = min(frameSize.width, frameSize.height)
+        return State(centre: cursor,
+                     radius: shorter * CGFloat(max(0.01, spot.radiusFraction)),
+                     dimming: spot.dimming * Self.fade(at: t, spot: spot))
+    }
+
+    /// 1 while the spotlight holds, ramping from 0 at each edge.
+    private static func fade(at t: TimeInterval, spot: PointerHighlight) -> Double {
+        let ramp = max(0.0001, min(spot.transition, (spot.end - spot.start) / 2))
+        let sinceStart = t - spot.start
+        let untilEnd = spot.end - t
+        let raw = min(sinceStart / ramp, untilEnd / ramp)
+        return ZoomEase.smooth.value(min(1, max(0, raw)))
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/RecordingAction.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingAction.swift
@@ -1,0 +1,57 @@
+import Carbon.HIToolbox
+import Foundation
+
+/// The recording shortcuts.
+///
+/// Raw values are persisted, so renaming one silently unbinds the user's shortcut — the same rule
+/// `Feature.id` and `ScreenshotAction` carry.
+enum RecordingAction: String, CaseIterable, Codable, Identifiable {
+    case startStop
+    case recordArea
+    case pauseResume
+    case flag
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .startStop: return "Start or Stop Recording"
+        case .recordArea: return "Record an Area"
+        case .pauseResume: return "Pause or Resume Recording"
+        case .flag: return "Mark This Moment"
+        }
+    }
+
+    var hotkeyID: UInt32 {
+        switch self {
+        case .startStop: return GlobalHotkey.ID.recordStartStop
+        case .recordArea: return GlobalHotkey.ID.recordArea
+        case .pauseResume: return GlobalHotkey.ID.recordPauseResume
+        case .flag: return GlobalHotkey.ID.recordFlag
+        }
+    }
+
+    /// ⌃⇧ plus a key, joining the family Capture already owns rather than claiming a new one.
+    /// R, E and U are free: `ScreenshotAction` takes A W F 5 S T Z H P Y, and ⌃⇧⎋ dismisses
+    /// everything.
+    var defaultShortcut: WindowShortcut {
+        WindowShortcut(keyCode: Int64(defaultKeyCode), modifiers: [.maskControl, .maskShift])
+    }
+
+    private var defaultKeyCode: Int {
+        switch self {
+        case .startStop: return kVK_ANSI_R
+        case .recordArea: return kVK_ANSI_E
+        case .pauseResume: return kVK_ANSI_U
+        case .flag: return kVK_ANSI_M
+        }
+    }
+
+    static var defaults: [RecordingAction: WindowShortcut] {
+        Dictionary(uniqueKeysWithValues: allCases.map { ($0, $0.defaultShortcut) })
+    }
+}
+
+extension RecordingAction: ShortcutOwner {
+    var shortcutTitle: String { title }
+}

--- a/Sources/Sarvkrit/Features/Studio/RecordingArea.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingArea.swift
@@ -1,0 +1,44 @@
+import CoreGraphics
+import Foundation
+
+/// Which rectangle the aiming overlay opens with when you record an area.
+///
+/// **There is always a rectangle.** Dragging one out of an empty screen is fine for a screenshot,
+/// which happens in a second and is thrown away if it is wrong; a recording is aimed once and then
+/// lived with for ten minutes, so it wants to open as something you adjust rather than something
+/// you draw. Last time's rect is the best guess available, and a centred widescreen box is the
+/// answer when there is no last time.
+enum RecordingArea {
+
+    /// Fraction of the display the default box covers across. Wide enough to be the obvious
+    /// subject of the recording, narrow enough that all eight handles are clear of the edges.
+    private static let defaultWidthFraction: CGFloat = 0.6
+
+    /// The rect to seed the overlay with, in global AppKit points.
+    ///
+    /// `displays` are the frames of the displays being aimed over. A remembered rect that touches
+    /// none of them is discarded rather than passed on: `SelectionView.settle` refuses a rect
+    /// outside its own display, so a rect left behind on an unplugged monitor would open the
+    /// overlay with nothing at all — the exact state this is here to avoid.
+    static func seed(remembered: CGRect?, displays: [CGRect]) -> CGRect? {
+        if let remembered, displays.contains(where: { $0.intersects(remembered) }) {
+            return remembered
+        }
+        guard let display = displays.first else { return nil }
+        return `default`(on: display)
+    }
+
+    /// A centred 16:9 box — the shape everything here is eventually exported into.
+    static func `default`(on display: CGRect) -> CGRect {
+        var width = display.width * defaultWidthFraction
+        var height = width * 9 / 16
+        // A display taller than it is wide, or an unusually short one, would otherwise put two
+        // handles off the edge where they cannot be grabbed.
+        if height > display.height * defaultWidthFraction {
+            height = display.height * defaultWidthFraction
+            width = height * 16 / 9
+        }
+        return CGRect(x: display.midX - width / 2, y: display.midY - height / 2,
+                      width: width, height: height).integral
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
@@ -45,6 +45,16 @@ struct RecordingManifest: Codable, Equatable {
     var hasMicrophone = false
     var hasSystemAudio = false
     var hasCamera = false
+    /// Seconds by which `camera.mov` began after `screen.mov`.
+    ///
+    /// **The two tracks do not start together.** `AVCaptureSession` takes a couple of seconds to
+    /// bring a camera up, so the camera file starts later and, if both are stopped at once, is
+    /// shorter by exactly this much. Composing the camera at the screen's own time puts the face
+    /// that far ahead of what it is reacting to.
+    ///
+    /// Defaults to zero, so a bundle recorded before this was measured behaves exactly as it
+    /// always did. That is what `formatVersion` is for.
+    var cameraStartOffset: TimeInterval = 0
     /// Shown when non-zero. A stuttering file produced silently is the failure to avoid.
     var droppedFrames = 0
     /// The user's Accessibility pointer size at record time.

--- a/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
@@ -76,10 +76,16 @@ struct RecordingManifest: Codable, Equatable {
     /// Hand-written for the same reason `StudioProject`'s is: a missing key takes a default and
     /// never throws. A manifest is the one file that must be readable even when everything else
     /// about the recording went wrong.
+    ///
+    /// **The encoder is synthesized and this is not, so a new property is written and then silently
+    /// dropped on the way back.** That is not hypothetical: `cameraStartOffset` reached disk
+    /// correctly and read back as zero, putting the camera two and a half seconds ahead of the
+    /// action. `RecordingManifestCodingTests` round-trips every field for exactly this reason.
     private enum Key: String, CodingKey {
         case formatVersion, state, source, pixelSize, pointPixelScale, fps
         case sourceRect, displayID, startedAt, duration
-        case hasMicrophone, hasSystemAudio, hasCamera, droppedFrames, accessibilityCursorScale
+        case hasMicrophone, hasSystemAudio, hasCamera, cameraStartOffset
+        case droppedFrames, accessibilityCursorScale
     }
 
     init(from decoder: Decoder) throws {
@@ -100,6 +106,7 @@ struct RecordingManifest: Codable, Equatable {
         hasMicrophone = read(.hasMicrophone, false)
         hasSystemAudio = read(.hasSystemAudio, false)
         hasCamera = read(.hasCamera, false)
+        cameraStartOffset = read(.cameraStartOffset, 0)
         droppedFrames = read(.droppedFrames, 0)
         accessibilityCursorScale = read(.accessibilityCursorScale, 1)
     }

--- a/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
@@ -163,6 +163,17 @@ struct RecordingBundle: Equatable {
         try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
     }
 
+    /// Whether this is a recording the editor can actually open.
+    ///
+    /// A `.sarvrec` with no readable manifest is a failed take: there is nothing to play and no
+    /// canvas size to lay a project out in. Checked before opening so a double-click that cannot
+    /// work says so instead of doing nothing.
+    var canBeOpened: Bool {
+        guard let manifest = try? readManifest() else { return false }
+        return manifest.duration > 0
+            && FileManager.default.fileExists(atPath: screenURL.path)
+    }
+
     func readManifest() throws -> RecordingManifest {
         try JSONDecoder().decode(RecordingManifest.self, from: Data(contentsOf: manifestURL))
     }

--- a/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
@@ -1,0 +1,155 @@
+import CoreGraphics
+import Foundation
+
+/// The buffer size a recording should ask for.
+///
+/// Sibling of `CaptureConfigurationMath`, with one rule a screenshot does not need: **the result
+/// is always even.** H.264 and HEVC work in macroblocks, so an odd dimension makes the encoder pad
+/// the frame — and unlike an export, the recording is the master everything else is derived from,
+/// so the cost is paid by every zoom and every export made from it afterwards.
+enum RecordingGeometry {
+    static func pixelSize(contentRect: CGRect, pointPixelScale: CGFloat) -> (width: Int, height: Int) {
+        let raw = CaptureConfigurationMath.pixelSize(contentRect: contentRect,
+                                                     pointPixelScale: pointPixelScale)
+        return (width: even(raw.width), height: even(raw.height))
+    }
+
+    private static func even(_ value: Int) -> Int { max(2, value - (value % 2)) }
+}
+
+/// What a recording is, written alongside it.
+///
+/// **`state` is written before the first frame arrives.** A bundle still saying `recording` on next
+/// launch is one the app died in the middle of, and that is the only signal there is — a crashed
+/// process leaves no error to catch, exactly as a denied Screen Recording grant leaves none.
+struct RecordingManifest: Codable, Equatable {
+    enum State: String, Codable, Equatable {
+        case recording
+        case complete
+    }
+
+    static let defaultFPS = 60
+
+    var formatVersion = 1
+    var state: State = .recording
+    var source: RecordingSource
+    /// The recording's own coordinate space. Every event is in it.
+    var pixelSize: SizeBox
+    var pointPixelScale: CGFloat = 2
+    var fps: Int = defaultFPS
+    /// Where on screen it came from, in global AppKit points.
+    var sourceRect: RectBox?
+    var displayID: UInt32?
+    var startedAt = Date()
+    var duration: TimeInterval = 0
+    var hasMicrophone = false
+    var hasSystemAudio = false
+    var hasCamera = false
+    /// Shown when non-zero. A stuttering file produced silently is the failure to avoid.
+    var droppedFrames = 0
+    /// The user's Accessibility pointer size at record time.
+    ///
+    /// Stored rather than applied, because our own size multiplier compounds with theirs and the
+    /// result is absurd. Dividing it out needs the number the recording was made under, not the
+    /// one in force whenever the project is next opened.
+    var accessibilityCursorScale: Double = 1
+
+    init(source: RecordingSource, pixelSize: CGSize, pointPixelScale: CGFloat, fps: Int) {
+        self.source = source
+        self.pixelSize = SizeBox(pixelSize)
+        self.pointPixelScale = pointPixelScale
+        self.fps = fps
+    }
+
+    var needsRecovery: Bool { state == .recording }
+
+    /// Hand-written for the same reason `StudioProject`'s is: a missing key takes a default and
+    /// never throws. A manifest is the one file that must be readable even when everything else
+    /// about the recording went wrong.
+    private enum Key: String, CodingKey {
+        case formatVersion, state, source, pixelSize, pointPixelScale, fps
+        case sourceRect, displayID, startedAt, duration
+        case hasMicrophone, hasSystemAudio, hasCamera, droppedFrames, accessibilityCursorScale
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Key.self)
+        func read<T: Decodable>(_ key: Key, _ fallback: T) -> T {
+            (try? container.decode(T.self, forKey: key)) ?? fallback
+        }
+        formatVersion = read(.formatVersion, 1)
+        state = read(.state, State.recording)
+        source = read(.source, RecordingSource.display)
+        pixelSize = read(.pixelSize, SizeBox(.zero))
+        pointPixelScale = read(.pointPixelScale, 2)
+        fps = read(.fps, Self.defaultFPS)
+        sourceRect = try? container.decode(RectBox.self, forKey: .sourceRect)
+        displayID = try? container.decode(UInt32.self, forKey: .displayID)
+        startedAt = read(.startedAt, Date())
+        duration = read(.duration, 0)
+        hasMicrophone = read(.hasMicrophone, false)
+        hasSystemAudio = read(.hasSystemAudio, false)
+        hasCamera = read(.hasCamera, false)
+        droppedFrames = read(.droppedFrames, 0)
+        accessibilityCursorScale = read(.accessibilityCursorScale, 1)
+    }
+}
+
+/// The `.sarvrec` package: a recording and everything captured alongside it.
+///
+/// A directory rather than a single file, because the video is hundreds of megabytes and
+/// re-serialising it on every manifest update would be absurd — and because a directory the user
+/// can open shows them exactly what the app is keeping.
+struct RecordingBundle: Equatable {
+    let root: URL
+
+    /// HEVC, cursor-free. **The cursor is deliberately not in here**, which is the whole reason
+    /// it can be redrawn sharp at any zoom afterwards.
+    var screenURL: URL { root.appendingPathComponent("screen.mov") }
+    var cameraURL: URL { root.appendingPathComponent("camera.mov") }
+    var microphoneURL: URL { root.appendingPathComponent("mic.m4a") }
+    var systemAudioURL: URL { root.appendingPathComponent("system.m4a") }
+    /// Cursor path, clicks, keystrokes, flags.
+    var eventsURL: URL { root.appendingPathComponent("events.json") }
+    /// Per-frame content rect, for window recordings whose window moved.
+    var geometryURL: URL { root.appendingPathComponent("geometry.json") }
+    var manifestURL: URL { root.appendingPathComponent("manifest.json") }
+    /// Bitmaps for pointers we could not recognise, deduplicated by hash.
+    var cursorsDirectory: URL { root.appendingPathComponent("cursors", isDirectory: true) }
+
+    static let fileExtension = "sarvrec"
+
+    @discardableResult
+    static func create(at url: URL) throws -> RecordingBundle {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        let bundle = RecordingBundle(root: url)
+        try FileManager.default.createDirectory(at: bundle.cursorsDirectory,
+                                                withIntermediateDirectories: true)
+        return bundle
+    }
+
+    /// Where a new recording goes: alongside the screenshots, under a name that sorts by time.
+    static func defaultDirectory() -> URL {
+        CaptureHistoryStore.defaultDirectory
+            .deletingLastPathComponent()
+            .appendingPathComponent("Recordings", isDirectory: true)
+    }
+
+    func write(_ manifest: RecordingManifest) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
+    }
+
+    func readManifest() throws -> RecordingManifest {
+        try JSONDecoder().decode(RecordingManifest.self, from: Data(contentsOf: manifestURL))
+    }
+
+    func writeEvents(_ log: EventLog) throws {
+        try JSONEncoder().encode(log).write(to: eventsURL, options: .atomic)
+    }
+
+    func readEvents() throws -> EventLog {
+        try JSONDecoder().decode(EventLog.self, from: Data(contentsOf: eventsURL))
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
@@ -133,6 +133,11 @@ struct RecordingBundle: Equatable {
     var manifestURL: URL { root.appendingPathComponent("manifest.json") }
     /// Bitmaps for pointers we could not recognise, deduplicated by hash.
     var cursorsDirectory: URL { root.appendingPathComponent("cursors", isDirectory: true) }
+    /// Pictures the user brought in, copied so the project stays self-contained.
+    ///
+    /// **Copied rather than referenced.** A project pointing at a file on somebody's Desktop stops
+    /// working the moment that file moves and cannot be opened on another Mac at all.
+    var mediaDirectory: URL { root.appendingPathComponent("media", isDirectory: true) }
 
     static let fileExtension = "sarvrec"
 

--- a/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingBundle.swift
@@ -163,6 +163,18 @@ struct RecordingBundle: Equatable {
         try encoder.encode(manifest).write(to: manifestURL, options: .atomic)
     }
 
+    /// One name for this bundle, whatever spelling of its path arrived.
+    ///
+    /// **`open` hands a package over with a trailing slash**, because it is a directory on disk:
+    /// the Finder's URL is `…/Recording.sarvrec/` where the recorder's is `…/Recording.sarvrec`.
+    /// `URL` equality is string equality, so the two do not match — and the editor's "already
+    /// open" check silently failed, putting a second window over the same bundle. Two editors
+    /// autosaving into one bundle means the last one to close wins.
+    var identity: String {
+        root.standardizedFileURL.resolvingSymlinksInPath()
+            .path(percentEncoded: false)
+    }
+
     /// Whether this is a recording the editor can actually open.
     ///
     /// A `.sarvrec` with no readable manifest is a failed take: there is nothing to play and no

--- a/Sources/Sarvkrit/Features/Studio/RecordingEvents.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingEvents.swift
@@ -94,6 +94,28 @@ struct EventLog: Codable, Equatable {
 
     var isEmpty: Bool { cursor.isEmpty && clicks.isEmpty && keys.isEmpty }
 
+    /// Hand-written so that reading a log back goes through the same sort as building one.
+    ///
+    /// **The synthesised decoder does not call the initialiser above.** It assigns the stored
+    /// properties directly, so every guarantee that initialiser establishes — the one the binary
+    /// search in `indexOfSample` depends on — would hold for a log built in memory and quietly not
+    /// hold for the same log read off disk. That is the worst shape for a bug: it cannot happen in
+    /// a test that builds its own fixture, only in the field, and only on a recording somebody
+    /// cared enough about to reopen.
+    ///
+    /// Points are encoded as `CGPoint`'s own compact array form here, unlike `StudioProject`,
+    /// which spells out `width`/`height`. The difference is deliberate: a project file is short
+    /// and worth reading, and an event log is seventy thousand samples nobody will ever open.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(cursor: (try? container.decode([CursorSample].self, forKey: .cursor)) ?? [],
+                  clicks: (try? container.decode([ClickEvent].self, forKey: .clicks)) ?? [],
+                  keys: (try? container.decode([KeyEvent].self, forKey: .keys)) ?? [],
+                  flags: (try? container.decode([TimeInterval].self, forKey: .flags)) ?? [])
+    }
+
+    private enum CodingKeys: String, CodingKey { case cursor, clicks, keys, flags }
+
     // MARK: - Lookup
 
     /// The pointer's position at `t`, interpolated between the two samples either side.

--- a/Sources/Sarvkrit/Features/Studio/RecordingEvents.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingEvents.swift
@@ -1,0 +1,170 @@
+import CoreGraphics
+import Foundation
+
+/// Which pointer was on screen. Raw values are persisted in the recording bundle.
+///
+/// **A kind, not a bitmap, wherever one can be recognised.** A 16×16 system cursor scaled to 3× is
+/// the blurry mess this whole feature exists to avoid, so a recognised pointer is redrawn from
+/// vector paths at whatever size the canvas wants. `.custom` is the honest admission that an app
+/// shipped its own — Figma, Photoshop, a game — and there the captured bitmap is all there is.
+enum CursorKind: String, Codable, CaseIterable, Equatable {
+    case arrow
+    case iBeam
+    case pointingHand
+    case openHand
+    case closedHand
+    case crosshair
+    case resizeLeftRight
+    case resizeUpDown
+    case resizeDiagonal
+    case notAllowed
+    case contextualMenu
+    /// An application's own pointer. `CursorSample.customCursorHash` names the stored bitmap.
+    case custom
+    /// Written by a newer build. Rendered as an arrow rather than as nothing.
+    case unknown
+}
+
+/// Where the pointer was, sampled at the display's refresh rate.
+///
+/// Sampled rather than taken from move events, because move events stop arriving when the mouse
+/// stops — and a path with no samples during a pause cannot be interpolated across it.
+struct CursorSample: Codable, Equatable {
+    /// Seconds from the first video frame. One clock for the whole bundle.
+    var t: TimeInterval
+    /// Recording space, top-left origin.
+    var point: CGPoint
+    var kind: CursorKind = .arrow
+    /// Set only when `kind == .custom`. Names a file in the bundle's `cursors/`, deduplicated.
+    var customCursorHash: String?
+    /// Whether the pointer was within the recorded region. False happens constantly in area and
+    /// window modes, and drawing a cursor pinned to the frame edge is worse than drawing none.
+    var isInside: Bool = true
+}
+
+/// A press or a release. Both are kept: a drag is a down with a much later up, and the click
+/// effect has to know which.
+struct ClickEvent: Codable, Equatable {
+    enum Button: String, Codable, Equatable { case left, right, other }
+
+    var t: TimeInterval
+    var point: CGPoint
+    var button: Button
+    var isDown: Bool
+    var isInside: Bool = true
+}
+
+/// One keypress, as a *label* rather than a character.
+///
+/// "⌘C" is what a demo needs to show. The character someone typed into a password field is not
+/// something this app should be holding at all, which is why the recorder drops those before they
+/// reach here rather than filtering them later.
+struct KeyEvent: Codable, Equatable {
+    var t: TimeInterval
+    /// Display-ready: "⌘C", "Space", "←".
+    var label: String
+    /// Whether this was a modifier combination rather than a bare character. The default keystroke
+    /// setting shows only these.
+    var isModifierCombination: Bool
+}
+
+/// Everything the recorder captured besides pixels.
+///
+/// **This is the difference between a screen recording and Screen Studio.** The cursor is not in
+/// the video, so it is drawn from `cursor`; the zooms are invented from `clicks` and `keys`; the
+/// keystroke overlay is drawn from `keys`. All of it stays editable afterwards because none of it
+/// was ever baked in.
+struct EventLog: Codable, Equatable {
+    private(set) var cursor: [CursorSample]
+    private(set) var clicks: [ClickEvent]
+    private(set) var keys: [KeyEvent]
+    /// Moments the user marked with ⌃⌥⌘F while recording.
+    private(set) var flags: [TimeInterval]
+
+    /// Sorted here rather than trusted from the file. The log is appended from a serial queue, but
+    /// a recording recovered after a crash is truncated mid-write, and a reader that assumes order
+    /// turns a partially-written tail into a cursor that jumps backwards.
+    init(cursor: [CursorSample] = [], clicks: [ClickEvent] = [],
+         keys: [KeyEvent] = [], flags: [TimeInterval] = []) {
+        self.cursor = cursor.sorted { $0.t < $1.t }
+        self.clicks = clicks.sorted { $0.t < $1.t }
+        self.keys = keys.sorted { $0.t < $1.t }
+        self.flags = flags.sorted()
+    }
+
+    var isEmpty: Bool { cursor.isEmpty && clicks.isEmpty && keys.isEmpty }
+
+    // MARK: - Lookup
+
+    /// The pointer's position at `t`, interpolated between the two samples either side.
+    ///
+    /// Held at the ends rather than extrapolated: past the last sample the recording is over and
+    /// the pointer did not keep moving, so inventing a position would draw a cursor sliding off
+    /// the frame during the final second.
+    func cursorPoint(at t: TimeInterval) -> CGPoint? {
+        guard let first = cursor.first, let last = cursor.last else { return nil }
+        if t <= first.t { return first.point }
+        if t >= last.t { return last.point }
+
+        let index = indexOfSample(at: t)
+        let before = cursor[index]
+        guard index + 1 < cursor.count else { return before.point }
+        let after = cursor[index + 1]
+
+        let span = after.t - before.t
+        guard span > 0 else { return before.point }
+        let fraction = CGFloat((t - before.t) / span)
+        return CGPoint(x: before.point.x + (after.point.x - before.point.x) * fraction,
+                       y: before.point.y + (after.point.y - before.point.y) * fraction)
+    }
+
+    /// Whether the pointer was over the recorded region. A step, not a blend — it is a fact about
+    /// one sample, and interpolating a boolean means inventing a half-visible cursor.
+    func isCursorInside(at t: TimeInterval) -> Bool {
+        guard !cursor.isEmpty else { return false }
+        return cursor[indexOfSample(at: t)].isInside
+    }
+
+    /// The kind holds until the next sample changes it: it is a state, not an event.
+    func cursorKind(at t: TimeInterval) -> CursorKind {
+        guard !cursor.isEmpty else { return .arrow }
+        return cursor[indexOfSample(at: t)].kind
+    }
+
+    func customCursorHash(at t: TimeInterval) -> String? {
+        guard !cursor.isEmpty else { return nil }
+        return cursor[indexOfSample(at: t)].customCursorHash
+    }
+
+    /// Presses only, which is what the zoom planner and the click effect both want.
+    var pressDowns: [ClickEvent] { clicks.filter { $0.isDown } }
+
+    /// The last sample at or before `t`, by binary search — a ten-minute recording at 120 Hz is
+    /// seventy thousand samples and this is called for every layer of every frame.
+    private func indexOfSample(at t: TimeInterval) -> Int {
+        var low = 0, high = cursor.count - 1, best = 0
+        while low <= high {
+            let mid = (low + high) / 2
+            if cursor[mid].t <= t {
+                best = mid
+                low = mid + 1
+            } else {
+                high = mid - 1
+            }
+        }
+        return best
+    }
+
+    // MARK: - Recovery
+
+    /// Cuts the log back to what the video actually contains.
+    ///
+    /// A recording recovered after a crash keeps whole fragments only, so the sidecars are longer
+    /// than the picture. Without this the cursor carries on moving over a frozen final frame.
+    func truncated(to t: TimeInterval) -> EventLog {
+        EventLog(cursor: cursor.filter { $0.t <= t },
+                 clicks: clicks.filter { $0.t <= t },
+                 keys: keys.filter { $0.t <= t },
+                 flags: flags.filter { $0 <= t })
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/RecordingFailureMessage.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingFailureMessage.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// What to put in the toast when a recording will not start.
+///
+/// Separate and pure so the wording is testable, and because "Couldn't start recording" — which is
+/// all this used to say, for every cause — is the least useful sentence the app can produce. A
+/// recording that fails silently or generically is indistinguishable from a shortcut that does
+/// nothing, and both were reported as the same bug.
+enum RecordingFailureMessage {
+
+    /// - Returns: a sentence naming what went wrong, and the symbol to show beside it.
+    static func describe(_ error: Error) -> (text: String, symbolName: String) {
+        guard let recording = error as? RecordingError else {
+            // Anything from AVFoundation or ScreenCaptureKit that we have no case for. Its own
+            // description is still better than a generic line, and the log carries the rest.
+            let described = (error as NSError).localizedDescription
+            return (described.isEmpty ? "Couldn't start recording" : described,
+                    "exclamationmark.triangle")
+        }
+
+        switch recording {
+        case .noDisplays:
+            return ("Sarvkrit can't see the screen yet", "display.trianglebadge.exclamationmark")
+        case .displayGone:
+            return ("That display has gone", "display.trianglebadge.exclamationmark")
+        case .windowGone:
+            return ("That window has gone", "macwindow.badge.plus")
+        case .cannotWrite:
+            return ("Couldn't write the recording", "externaldrive.badge.exclamationmark")
+        case .alreadyRecording:
+            return ("A recording is already starting", "record.circle")
+        case .outOfSpace(let free):
+            let gigabytes = Double(free) / 1_000_000_000
+            return (String(format: "Only %.1f GB free", gigabytes),
+                    "externaldrive.badge.exclamationmark")
+        case .cancelled:
+            return ("Recording cancelled", "xmark.circle")
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/RecordingLibrary.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingLibrary.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// The recordings already on disk.
+///
+/// **A recording was saved correctly and then unreachable.** `project.json` is written into the
+/// bundle on every edit and flushed again as the window closes, so nothing was ever lost — but the
+/// only caller of `StudioEditorController.open` was `stopRecording`, so the only way back into a
+/// take was to have never closed it.
+///
+/// No index, no database. The bundles all live in one directory and each carries its own manifest,
+/// so the directory *is* the list — which also means a recording moved, renamed or deleted in the
+/// Finder needs nothing kept in step.
+enum RecordingLibrary {
+
+    struct Entry: Identifiable, Equatable {
+        var id: URL { url }
+        let url: URL
+        /// The file's name without its extension, which is what the Finder shows.
+        let name: String
+        let modified: Date
+        /// Nil when the manifest could not be read — there is nothing to open, but there is still
+        /// something taking up disk space.
+        let duration: TimeInterval?
+        let hasCamera: Bool
+        /// The app died inside this recording. Written faithfully all along and read by nothing.
+        let needsRecovery: Bool
+
+        var canOpen: Bool { duration != nil }
+
+        var bundle: RecordingBundle { RecordingBundle(root: url) }
+
+        var lengthDescription: String { Self.lengthDescription(for: duration) }
+
+        /// `0:09`, `1:15`, `1:00:01`. Hours only when there are some.
+        static func lengthDescription(for duration: TimeInterval?) -> String {
+            guard let duration, duration.isFinite, duration >= 0 else { return "—" }
+            let total = Int(duration.rounded())
+            let (hours, minutes, seconds) = (total / 3600, (total % 3600) / 60, total % 60)
+            return hours > 0
+                ? String(format: "%d:%02d:%02d", hours, minutes, seconds)
+                : String(format: "%d:%02d", minutes, seconds)
+        }
+    }
+
+    static func entries(in directory: URL = RecordingBundle.defaultDirectory()) -> [Entry] {
+        // A directory that has never held a recording is a new install, not an error.
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles])) ?? []
+
+        return contents
+            .filter { $0.pathExtension == RecordingBundle.fileExtension }
+            .map(entry(for:))
+            // Newest first: the recording somebody wants back is almost always the last one.
+            .sorted { $0.modified > $1.modified }
+    }
+
+    static func entry(for url: URL) -> Entry {
+        let manifest = try? RecordingBundle(root: url).readManifest()
+        let modified = (try? url.resourceValues(forKeys: [.contentModificationDateKey])
+            .contentModificationDate) ?? .distantPast
+        return Entry(url: url,
+                     name: url.deletingPathExtension().lastPathComponent,
+                     modified: modified,
+                     duration: manifest?.duration,
+                     hasCamera: manifest?.hasCamera ?? false,
+                     needsRecovery: manifest?.needsRecovery ?? false)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/RecordingSetup.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingSetup.swift
@@ -1,0 +1,97 @@
+import AVFoundation
+import Foundation
+
+/// What the user chose before pressing Record.
+///
+/// **Remembered between launches on purpose.** The costliest failure this feature has is finishing
+/// a ten-minute take and discovering the camera was off, or the microphone was the wrong one. The
+/// pre-record bar's live preview is the main defence; remembering last time's choice is the rest,
+/// because the setting somebody deliberately chose yesterday is almost always the one they want
+/// today.
+///
+/// Hand-rolled over an injected `UserDefaults` with a same-value guard, like every other settings
+/// object in the app — never `@Published`, for the reason `AppState` records at length.
+final class RecordingSetup: ObservableObject {
+
+    /// Long enough to reach the window you are about to demonstrate, and short enough that nobody
+    /// has to think about which to pick.
+    static let countdownChoices = [0, 3, 5, 10]
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var source: RecordingSource {
+        get {
+            (defaults.string(forKey: "recording.source")
+                .flatMap(RecordingSource.init(rawValue:))) ?? .display
+        }
+        set {
+            guard newValue != source else { return }
+            defaults.set(newValue.rawValue, forKey: "recording.source")
+            objectWillChange.send()
+        }
+    }
+
+    /// Nil means no camera. **Nothing is switched on for you** — a recorder that films somebody by
+    /// default is a recorder that has filmed them without their deciding to be filmed.
+    var cameraID: String? {
+        get { defaults.string(forKey: "recording.camera") }
+        set {
+            guard newValue != cameraID else { return }
+            defaults.set(newValue, forKey: "recording.camera")
+            objectWillChange.send()
+        }
+    }
+
+    var microphoneID: String? {
+        get { defaults.string(forKey: "recording.microphone") }
+        set {
+            guard newValue != microphoneID else { return }
+            defaults.set(newValue, forKey: "recording.microphone")
+            objectWillChange.send()
+        }
+    }
+
+    var capturesSystemAudio: Bool {
+        get { defaults.object(forKey: "recording.systemAudio") as? Bool ?? false }
+        set {
+            guard newValue != capturesSystemAudio else { return }
+            defaults.set(newValue, forKey: "recording.systemAudio")
+            objectWillChange.send()
+        }
+    }
+
+    var countdownSeconds: Int {
+        get {
+            let stored = defaults.object(forKey: "recording.countdown") as? Int ?? 0
+            // A value this build does not offer falls back rather than showing a countdown nobody
+            // chose — the same forward-compatibility rule the documents follow.
+            return Self.countdownChoices.contains(stored) ? stored : 0
+        }
+        set {
+            guard newValue != countdownSeconds else { return }
+            defaults.set(newValue, forKey: "recording.countdown")
+            objectWillChange.send()
+        }
+    }
+
+    /// Forgets devices that are no longer attached.
+    ///
+    /// Without this the bar offers a camera that was unplugged last week, and Record produces a
+    /// recording with no camera track and no explanation.
+    func reconcile(cameraIDs: [String], microphoneIDs: [String]) {
+        if let cameraID, !cameraIDs.contains(cameraID) { self.cameraID = nil }
+        if let microphoneID, !microphoneIDs.contains(microphoneID) { self.microphoneID = nil }
+    }
+
+    func request(fps: Int, hidesDesktopIcons: Bool, destination: URL) -> RecordingRequest {
+        var request = RecordingRequest(source: source, destination: destination)
+        request.fps = fps
+        request.capturesSystemAudio = capturesSystemAudio
+        request.hidesDesktopIcons = hidesDesktopIcons
+        return request
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/RecordingSetup.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingSetup.swift
@@ -78,6 +78,30 @@ final class RecordingSetup: ObservableObject {
         }
     }
 
+    /// The rectangle the last area recording used, in global AppKit points.
+    ///
+    /// Seeds the aiming overlay so the second area recording opens with the first one's rectangle
+    /// already drawn and grabbable, instead of an empty screen to drag on. Four numbers rather
+    /// than an archived rect, for the reason `ScreenshotFeature.lastSelection` gives: a change to
+    /// how rects are persisted must not let an old value decode as something plausible but wrong,
+    /// because the failure mode is recording the wrong part of the screen.
+    var lastArea: CGRect? {
+        get {
+            guard let values = defaults.array(forKey: "recording.lastArea") as? [Double],
+                  values.count == 4, values[2] > 0, values[3] > 0
+            else { return nil }
+            return CGRect(x: values[0], y: values[1], width: values[2], height: values[3])
+        }
+        set {
+            guard let newValue, newValue.width > 0, newValue.height > 0 else {
+                defaults.removeObject(forKey: "recording.lastArea")
+                return
+            }
+            defaults.set([newValue.minX, newValue.minY, newValue.width, newValue.height],
+                         forKey: "recording.lastArea")
+        }
+    }
+
     /// Forgets devices that are no longer attached.
     ///
     /// Without this the bar offers a camera that was unplugged last week, and Record produces a

--- a/Sources/Sarvkrit/Features/Studio/RecordingSource.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingSource.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// What a recording is a recording *of*.
+///
+/// **Deliberately not a case on `CaptureMode`.** That enum's raw values are persisted in the
+/// screenshot history index and it drives four exhaustive switches plus the history shelf's mode
+/// filter; a recording is not a screenshot mode and pretending otherwise would put video concepts
+/// into every one of those. Raw values here are persisted in the recording bundle, so they are
+/// equally permanent.
+enum RecordingSource: String, Codable, CaseIterable, Equatable, Identifiable {
+    case display
+    case window
+    case area
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .display: return "Display"
+        case .window: return "Window"
+        case .area: return "Area"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .display: return "display"
+        case .window: return "macwindow"
+        case .area: return "selection.pin.in.out"
+        }
+    }
+
+    /// Whether the frozen-screen overlay is used to aim this. The other two are chosen by pointing
+    /// at something that already has edges, so there is nothing to drag.
+    var aimsByDragging: Bool {
+        switch self {
+        case .area: return true
+        case .display, .window: return false
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/RecordingWriter.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingWriter.swift
@@ -1,0 +1,143 @@
+import AVFoundation
+import CoreMedia
+import Foundation
+
+/// Everything the sample-buffer callback touches.
+///
+/// **Deliberately not main-actor, and that is the whole point of this type existing.** `SCStream`
+/// delivers frames on its own serial queue. The first version of the recorder wrapped the handler
+/// in `MainActor.assumeIsolated` — which is an *assertion*, not a hop — so the first frame of the
+/// first recording trapped with `EXC_BREAKPOINT` and recording looked impossible to switch on.
+///
+/// Hopping to the main actor per frame would have been the wrong fix as well as a slow one: at 60
+/// fps that is sixty context switches a second to call one `append`. So the writing state lives
+/// here, is mutated only from the stream's own queue, and is guarded by a lock for the two
+/// counters the HUD reads while frames are still arriving.
+final class RecordingWriter: @unchecked Sendable {
+
+    private let writer: AVAssetWriter
+    private let input: AVAssetWriterInput
+    private let lock = NSLock()
+
+    /// The presentation time of the first frame. Everything is measured from it, so the events and
+    /// the picture cannot drift apart.
+    private var firstFrame: CMTime?
+    private var lastFrame: CMTime = .zero
+    /// Accumulated across pauses, so elapsed means *recorded* time.
+    private var pausedFor: CMTime = .zero
+    private var pausedAt: CMTime?
+    private var paused = false
+    private var dropped = 0
+
+    /// `systemUptime` at the instant the first frame landed.
+    ///
+    /// The event log is rebased against this rather than against a time taken when capture was
+    /// asked for: the gap between `startCapture()` returning and the first frame arriving is tens
+    /// of milliseconds, and that is enough to put the cursor visibly behind what it clicked.
+    private var anchorHostTime: TimeInterval?
+
+    init(url: URL, size: CGSize, fps: Int) throws {
+        try? FileManager.default.removeItem(at: url)
+        guard let writer = try? AVAssetWriter(outputURL: url, fileType: .mov) else {
+            throw RecordingError.cannotWrite
+        }
+        // **Fragments are what make a crash survivable.** The writer flushes a self-contained
+        // fragment every two seconds, so a file whose `finishWriting` never ran is still playable
+        // up to the last one rather than a header-less block nothing can open.
+        writer.movieFragmentInterval = CMTime(seconds: 2, preferredTimescale: 600)
+
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: [
+            AVVideoCodecKey: AVVideoCodecType.hevc,
+            AVVideoWidthKey: Int(size.width),
+            AVVideoHeightKey: Int(size.height),
+            AVVideoCompressionPropertiesKey: [
+                AVVideoQualityKey: 0.9,
+                AVVideoExpectedSourceFrameRateKey: fps,
+            ],
+        ])
+        input.expectsMediaDataInRealTime = true
+        guard writer.canAdd(input) else { throw RecordingError.cannotWrite }
+        writer.add(input)
+        guard writer.startWriting() else { throw RecordingError.cannotWrite }
+
+        self.writer = writer
+        self.input = input
+    }
+
+    // MARK: - Reading, from anywhere
+
+    var elapsed: TimeInterval {
+        lock.lock(); defer { lock.unlock() }
+        guard let firstFrame else { return 0 }
+        return CMTimeGetSeconds(CMTimeSubtract(CMTimeSubtract(lastFrame, firstFrame), pausedFor))
+    }
+
+    var droppedFrames: Int {
+        lock.lock(); defer { lock.unlock() }
+        return dropped
+    }
+
+    var firstFrameHostTime: TimeInterval? {
+        lock.lock(); defer { lock.unlock() }
+        return anchorHostTime
+    }
+
+    var isPaused: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return paused
+    }
+
+    // MARK: - Writing, from the stream queue only
+
+    func append(_ buffer: CMSampleBuffer?) {
+        guard let buffer, buffer.isValid else { return }
+
+        lock.lock()
+        if firstFrame == nil {
+            let timestamp = CMSampleBufferGetPresentationTimeStamp(buffer)
+            firstFrame = timestamp
+            anchorHostTime = ProcessInfo.processInfo.systemUptime
+            lock.unlock()
+            writer.startSession(atSourceTime: timestamp)
+            lock.lock()
+        }
+        let isPaused = paused
+        lastFrame = CMSampleBufferGetPresentationTimeStamp(buffer)
+        lock.unlock()
+
+        guard !isPaused else { return }
+        guard input.isReadyForMoreMediaData else {
+            // Dropped at the tail rather than blocking the stream, counted, and reported when the
+            // recording stops. Producing a stuttering file in silence is the failure to avoid.
+            countDrop()
+            return
+        }
+        if !input.append(buffer) { countDrop() }
+    }
+
+    private func countDrop() {
+        lock.lock(); dropped += 1; lock.unlock()
+    }
+
+    func pause() {
+        lock.lock(); defer { lock.unlock() }
+        guard !paused else { return }
+        paused = true
+        pausedAt = lastFrame
+    }
+
+    func resume() {
+        lock.lock(); defer { lock.unlock() }
+        guard paused, let pausedAt else { return }
+        paused = false
+        // Rebased rather than left as a gap: a gap means every downstream time — zoom segments,
+        // captions, the timeline — would have to know about it, and none of them should.
+        pausedFor = CMTimeAdd(pausedFor, CMTimeSubtract(lastFrame, pausedAt))
+        self.pausedAt = nil
+    }
+
+    func finish() async {
+        input.markAsFinished()
+        await writer.finishWriting()
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/RecordingWriter.swift
+++ b/Sources/Sarvkrit/Features/Studio/RecordingWriter.swift
@@ -17,6 +17,12 @@ final class RecordingWriter: @unchecked Sendable {
 
     private let writer: AVAssetWriter
     private let input: AVAssetWriterInput
+    /// System audio, when the recording asked for it.
+    ///
+    /// **In the same file as the picture, deliberately.** One writer means one fragment interval
+    /// and therefore the same crash survivability for both tracks, and it makes the raw recording
+    /// directly playable with sound rather than something only this app can assemble.
+    private let audioInput: AVAssetWriterInput?
     private let lock = NSLock()
 
     /// The presentation time of the first frame. Everything is measured from it, so the events and
@@ -36,7 +42,10 @@ final class RecordingWriter: @unchecked Sendable {
     /// of milliseconds, and that is enough to put the cursor visibly behind what it clicked.
     private var anchorHostTime: TimeInterval?
 
-    init(url: URL, size: CGSize, fps: Int) throws {
+    /// - Parameter capturesAudio: whether to make room for system audio. `SCStream` will not
+    ///   deliver any unless an `.audio` output is added, which is why this was silently absent:
+    ///   `capturesAudio` was set on the configuration and nothing ever asked for the buffers.
+    init(url: URL, size: CGSize, fps: Int, capturesAudio: Bool = false) throws {
         try? FileManager.default.removeItem(at: url)
         guard let writer = try? AVAssetWriter(outputURL: url, fileType: .mov) else {
             throw RecordingError.cannotWrite
@@ -58,10 +67,26 @@ final class RecordingWriter: @unchecked Sendable {
         input.expectsMediaDataInRealTime = true
         guard writer.canAdd(input) else { throw RecordingError.cannotWrite }
         writer.add(input)
+        var audio: AVAssetWriterInput?
+        if capturesAudio {
+            let track = AVAssetWriterInput(mediaType: .audio, outputSettings: [
+                AVFormatIDKey: kAudioFormatMPEG4AAC,
+                AVSampleRateKey: 48_000,
+                AVNumberOfChannelsKey: 2,
+                AVEncoderBitRateKey: 128_000,
+            ])
+            track.expectsMediaDataInRealTime = true
+            if writer.canAdd(track) {
+                writer.add(track)
+                audio = track
+            }
+        }
+
         guard writer.startWriting() else { throw RecordingError.cannotWrite }
 
         self.writer = writer
         self.input = input
+        self.audioInput = audio
     }
 
     // MARK: - Reading, from anywhere
@@ -88,6 +113,22 @@ final class RecordingWriter: @unchecked Sendable {
     }
 
     // MARK: - Writing, from the stream queue only
+
+    /// System audio, from `SCStream`'s own queue.
+    ///
+    /// **Dropped until the first video frame has landed.** The session is anchored on that frame,
+    /// so audio arriving before it has no timeline to sit on — and appending it would either fail
+    /// or, worse, shift the whole soundtrack earlier than the picture.
+    func appendAudio(_ buffer: CMSampleBuffer?) {
+        guard let buffer, buffer.isValid, let audioInput else { return }
+        lock.lock()
+        let started = firstFrame != nil
+        let isPaused = paused
+        lock.unlock()
+
+        guard started, !isPaused, audioInput.isReadyForMoreMediaData else { return }
+        audioInput.append(buffer)
+    }
 
     func append(_ buffer: CMSampleBuffer?) {
         guard let buffer, buffer.isValid else { return }
@@ -138,6 +179,8 @@ final class RecordingWriter: @unchecked Sendable {
 
     func finish() async {
         input.markAsFinished()
+        // The writer will not finish while an input it was given is still open.
+        audioInput?.markAsFinished()
         await writer.finishWriting()
     }
 }

--- a/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
+++ b/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
@@ -35,9 +35,13 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
     private var displayLink: CADisplayLink?
 
     private(set) var isRecording = false
+    /// True from the moment `start` is entered until it has either succeeded or cleaned up.
+    /// `isRecording` is only set once the stream is live, and there are two `await`s before that,
+    /// so without this a second ⌃⇧R during a start walked straight past the guard.
+    private var isStarting = false
 
     /// Maps a global AppKit point into the recording's pixel space. Nil means outside.
-    private var mapPoint: ((CGPoint) -> CGPoint?)?
+    private var mapPoint: (@Sendable (CGPoint) -> CGPoint?)?
 
     var elapsed: TimeInterval { writer?.elapsed ?? 0 }
     var droppedFrames: Int { writer?.droppedFrames ?? 0 }
@@ -52,7 +56,9 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
 
     /// - Parameter setup: the camera and microphone the user chose, if any.
     func start(_ request: RecordingRequest, setup: RecordingSetup? = nil) async throws {
-        guard !isRecording else { throw RecordingError.alreadyRecording }
+        guard !isRecording, !isStarting else { throw RecordingError.alreadyRecording }
+        isStarting = true
+        defer { isStarting = false }
 
         let content = try await SCShareableContent.excludingDesktopWindows(
             true, onScreenWindowsOnly: true)
@@ -67,55 +73,81 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
         try checkSpace(for: pixels, fps: request.fps)
 
         let bundle = try RecordingBundle.create(at: request.destination)
-        var manifest = RecordingManifest(source: request.source,
-                                         pixelSize: pixels,
-                                         pointPixelScale: CGFloat(filter.pointPixelScale),
-                                         fps: request.fps)
-        manifest.sourceRect = sourceRect.map(RectBox.init)
-        manifest.displayID = geometry?.displayID
-        manifest.hasSystemAudio = request.capturesSystemAudio
-        manifest.accessibilityCursorScale = Self.accessibilityCursorScale()
-        // Written before the first frame: a bundle still saying `recording` on next launch is one
-        // the app died in the middle of, and that is the only signal a crash leaves.
-        try bundle.write(manifest)
+        do {
+            var manifest = RecordingManifest(source: request.source,
+                                             pixelSize: pixels,
+                                             pointPixelScale: CGFloat(filter.pointPixelScale),
+                                             fps: request.fps)
+            manifest.sourceRect = sourceRect.map(RectBox.init)
+            manifest.displayID = geometry?.displayID
+            manifest.hasSystemAudio = request.capturesSystemAudio
+            manifest.accessibilityCursorScale = Self.accessibilityCursorScale()
+            // Written before the first frame: a bundle still saying `recording` on next launch
+            // is one the app died in the middle of, the only signal a crash leaves.
+            try bundle.write(manifest)
 
-        writer = try RecordingWriter(url: bundle.screenURL, size: pixels, fps: request.fps)
+            writer = try RecordingWriter(url: bundle.screenURL, size: pixels, fps: request.fps)
 
-        self.bundle = bundle
-        self.manifest = manifest
-        self.mapPoint = Self.mapper(sourceRect: sourceRect, geometry: geometry,
-                                    scale: CGFloat(filter.pointPixelScale), pixels: pixels)
-        events.begin(mapping: { [weak self] point in self?.mapPoint?(point) })
+            self.bundle = bundle
+            // Handed to the recorder by value. It used to reach back through `self?.mapPoint`,
+            // meaning a nonisolated monitor callback read a main-actor property; the mapper is a
+            // pure function of the geometry, so there is nothing to reach back for.
+            let mapper = Self.mapper(sourceRect: sourceRect, geometry: geometry,
+                                     scale: CGFloat(filter.pointPixelScale), pixels: pixels)
+            self.mapPoint = mapper
 
-        // Started before the stream, so the camera is already rolling when the first screen frame
-        // lands rather than a second behind it.
-        if let setup {
-            let device = setup.cameraID.flatMap { id in
-                CameraRecorder.devices().first { $0.uniqueID == id }
+            // Started before the stream, so the camera is already rolling when the first screen
+            // frame lands rather than a second behind it.
+            if let setup {
+                let device = setup.cameraID.flatMap { id in
+                    CameraRecorder.devices().first { $0.uniqueID == id }
+                }
+                let microphone = setup.microphoneID.flatMap { id in
+                    CameraRecorder.microphones().first { $0.uniqueID == id }
+                }
+                // **A microphone with no camera still has to be recorded.** Gating this on the
+                // camera meant choosing a mic alone captured nothing at all, silently — the worst
+                // possible way for narration to go missing.
+                if device != nil || microphone != nil {
+                    try? camera.start(device: device, microphone: microphone,
+                                      to: device != nil ? bundle.cameraURL : bundle.microphoneURL)
+                    manifest.hasCamera = device != nil
+                    manifest.hasMicrophone = microphone != nil
+                    try? bundle.write(manifest)
+                }
             }
-            let microphone = setup.microphoneID.flatMap { id in
-                CameraRecorder.microphones().first { $0.uniqueID == id }
-            }
-            // **A microphone with no camera still has to be recorded.** Gating this on the camera
-            // meant choosing a mic alone captured nothing at all, silently — which is the worst
-            // possible way for narration to go missing.
-            if device != nil || microphone != nil {
-                try? camera.start(device: device, microphone: microphone,
-                                  to: device != nil ? bundle.cameraURL : bundle.microphoneURL)
-                manifest.hasCamera = device != nil
-                manifest.hasMicrophone = microphone != nil
-                try? bundle.write(manifest)
-            }
+            // Assigned after the camera block, not before: the block mutates a local copy, so the
+            // old order wrote `hasCamera` to disk and kept a stale value in memory.
+            self.manifest = manifest
+
+            let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
+            let frames = DispatchQueue(label: "ai.psylief.sarvkrit.recording")
+            try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: frames)
+            try await stream.startCapture()
+            self.stream = stream
+            isRecording = true
+            // Monitors last. Nothing before this point produces an event worth recording, and a
+            // start that failed part-way used to leave them installed for the life of the process
+            // — the app then watched every click on the Mac with no recording running.
+            events.begin(mapping: mapper)
+            startCursorSampling()
+            let size = "\(configuration.width)x\(configuration.height)"
+            log.info("recording started \(size, privacy: .public)")
+        } catch {
+            // A start that fails leaves nothing behind. It used to leave the camera running, the
+            // event monitors installed for the rest of the process, and a bundle still saying
+            // `state: "recording"` that the next launch offered to recover as a crashed take.
+            log.error("recording failed to start: \(error.localizedDescription, privacy: .public)")
+            camera.finish()
+            _ = events.finish(anchoredTo: nil)
+            writer = nil
+            stream = nil
+            self.bundle = nil
+            self.manifest = nil
+            mapPoint = nil
+            try? FileManager.default.removeItem(at: bundle.root)
+            throw error
         }
-
-        let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
-        try stream.addStreamOutput(self, type: .screen,
-                                   sampleHandlerQueue: DispatchQueue(label: "ai.psylief.sarvkrit.recording"))
-        try await stream.startCapture()
-        self.stream = stream
-        isRecording = true
-        startCursorSampling()
-        log.info("recording started \(configuration.width, privacy: .public)x\(configuration.height, privacy: .public)")
     }
 
     // MARK: - Filter and configuration
@@ -300,7 +332,7 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
     /// Nil is the answer that matters: in area and window modes the pointer spends much of its time
     /// outside the frame, and a cursor pinned to the edge looks like a bug.
     private static func mapper(sourceRect: CGRect?, geometry: DisplaySnapshotGeometry?,
-                               scale: CGFloat, pixels: CGSize) -> (CGPoint) -> CGPoint? {
+                               scale: CGFloat, pixels: CGSize) -> @Sendable (CGPoint) -> CGPoint? {
         return { global in
             guard let geometry else {
                 // Window mode: the per-frame geometry sidecar is what resolves this properly, and

--- a/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
+++ b/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
@@ -43,6 +43,9 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
     /// Maps a global AppKit point into the recording's pixel space. Nil means outside.
     private var mapPoint: (@Sendable (CGPoint) -> CGPoint?)?
 
+    /// Nil when this recording has no camera, which is what the preview window checks.
+    func cameraPreviewLayer() -> AVCaptureVideoPreviewLayer? { camera.previewLayer }
+
     var elapsed: TimeInterval { writer?.elapsed ?? 0 }
     var droppedFrames: Int { writer?.droppedFrames ?? 0 }
     var isPaused: Bool { writer?.isPaused ?? false }

--- a/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
+++ b/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
@@ -38,7 +38,7 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
     /// True from the moment `start` is entered until it has either succeeded or cleaned up.
     /// `isRecording` is only set once the stream is live, and there are two `await`s before that,
     /// so without this a second ⌃⇧R during a start walked straight past the guard.
-    private var isStarting = false
+    private(set) var isStarting = false
 
     /// Maps a global AppKit point into the recording's pixel space. Nil means outside.
     private var mapPoint: (@Sendable (CGPoint) -> CGPoint?)?

--- a/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
+++ b/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
@@ -15,7 +15,10 @@ import os
 @MainActor
 final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput, SCStreamDelegate {
 
-    private let log = Logger(subsystem: AppIdentity.logSubsystem, category: "Recording")
+    /// Nonisolated: ScreenCaptureKit's delegate callbacks arrive on its own queue, and
+    /// `os.Logger` is Sendable.
+    private nonisolated let log = Logger(subsystem: AppIdentity.logSubsystem,
+                                         category: "Recording")
 
     /// Nonisolated so `FeatureRegistry.makeAll()` — which is not on the main actor — can build the
     /// feature that owns it. Nothing here touches the main actor until a recording starts.
@@ -204,9 +207,9 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
     }
 
     nonisolated func stream(_ stream: SCStream, didStopWithError error: Error) {
-        MainActor.assumeIsolated {
-            log.error("stream stopped: \(error.localizedDescription, privacy: .public)")
-        }
+        // Same trap as the frame handler had, on the path that runs when a display is unplugged
+        // mid-recording — so the error that should have ended the take cleanly ended the app.
+        log.error("stream stopped: \(error.localizedDescription, privacy: .public)")
     }
 
     // MARK: - Cursor sampling

--- a/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
+++ b/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
@@ -1,0 +1,353 @@
+import AVFoundation
+import AppKit
+import CoreMedia
+import Foundation
+import ScreenCaptureKit
+import os
+
+/// The only file in the app that streams from ScreenCaptureKit.
+///
+/// **`SCRecordingOutput` is macOS 15 and the deployment target is 14.4**, which `project.yml`
+/// explains cannot move — Core Audio process taps, which the volume mixer needs, do not exist
+/// before 14.4. So frames are pumped by hand into an `AVAssetWriter`. That is not a hardship: the
+/// one-line API writes a single muxed file, and separate tracks are wanted anyway so audio can be
+/// edited without touching the picture.
+@MainActor
+final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput, SCStreamDelegate {
+
+    private let log = Logger(subsystem: AppIdentity.logSubsystem, category: "Recording")
+
+    /// Nonisolated so `FeatureRegistry.makeAll()` — which is not on the main actor — can build the
+    /// feature that owns it. Nothing here touches the main actor until a recording starts.
+    override nonisolated init() { super.init() }
+
+    private var stream: SCStream?
+    private var writer: AVAssetWriter?
+    private var videoInput: AVAssetWriterInput?
+    private var bundle: RecordingBundle?
+    private var manifest: RecordingManifest?
+    private let events = EventRecorder()
+    private var displayLink: CADisplayLink?
+
+    /// The presentation timestamp of the first frame. Everything is measured from it, so the
+    /// events and the picture cannot drift apart.
+    private var firstFrame: CMTime?
+    /// Accumulated across pauses, so the output has no gap and elapsed time means recorded time.
+    private var pausedFor: CMTime = .zero
+    private var pausedAt: CMTime?
+    private var lastFrame: CMTime = .zero
+
+    private(set) var isRecording = false
+    private(set) var droppedFrames = 0
+    private(set) var isPaused = false
+
+    /// Maps a global AppKit point into the recording's pixel space. Nil means outside.
+    private var mapPoint: ((CGPoint) -> CGPoint?)?
+
+    var elapsed: TimeInterval {
+        guard let firstFrame else { return 0 }
+        return CMTimeGetSeconds(CMTimeSubtract(CMTimeSubtract(lastFrame, firstFrame), pausedFor))
+    }
+
+    var recordsKeystrokes: Bool {
+        get { events.recordsKeystrokes }
+        set { events.recordsKeystrokes = newValue }
+    }
+
+    // MARK: - Start
+
+    func start(_ request: RecordingRequest) async throws {
+        guard !isRecording else { throw RecordingError.alreadyRecording }
+
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            true, onScreenWindowsOnly: true)
+        // Denial has no error to catch — ScreenCaptureKit simply reports nothing. This is the same
+        // signal `CaptureError.noDisplays` carries, and `ScreenRecordingRelaunch` reads it.
+        guard !content.displays.isEmpty else { throw RecordingError.noDisplays }
+
+        let (filter, sourceRect, geometry) = try makeFilter(request, content: content)
+        let configuration = makeConfiguration(request, filter: filter, sourceRect: sourceRect)
+
+        let pixels = CGSize(width: configuration.width, height: configuration.height)
+        try checkSpace(for: pixels, fps: request.fps)
+
+        let bundle = try RecordingBundle.create(at: request.destination)
+        var manifest = RecordingManifest(source: request.source,
+                                         pixelSize: pixels,
+                                         pointPixelScale: CGFloat(filter.pointPixelScale),
+                                         fps: request.fps)
+        manifest.sourceRect = sourceRect.map(RectBox.init)
+        manifest.displayID = geometry?.displayID
+        manifest.hasSystemAudio = request.capturesSystemAudio
+        manifest.accessibilityCursorScale = Self.accessibilityCursorScale()
+        // Written before the first frame: a bundle still saying `recording` on next launch is one
+        // the app died in the middle of, and that is the only signal a crash leaves.
+        try bundle.write(manifest)
+
+        try makeWriter(bundle: bundle, size: pixels)
+
+        self.bundle = bundle
+        self.manifest = manifest
+        self.mapPoint = Self.mapper(sourceRect: sourceRect, geometry: geometry,
+                                    scale: CGFloat(filter.pointPixelScale), pixels: pixels)
+        events.begin(mapping: { [weak self] point in self?.mapPoint?(point) })
+
+        let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
+        try stream.addStreamOutput(self, type: .screen,
+                                   sampleHandlerQueue: DispatchQueue(label: "ai.psylief.sarvkrit.recording"))
+        try await stream.startCapture()
+        self.stream = stream
+        isRecording = true
+        droppedFrames = 0
+        startCursorSampling()
+        log.info("recording started \(configuration.width, privacy: .public)x\(configuration.height, privacy: .public)")
+    }
+
+    // MARK: - Filter and configuration
+
+    private func makeFilter(_ request: RecordingRequest, content: SCShareableContent)
+        throws -> (SCContentFilter, CGRect?, DisplaySnapshotGeometry?) {
+        switch request.source {
+        case .window:
+            guard let wanted = request.window,
+                  let window = content.windows.first(where: { $0.windowID == wanted.id }) else {
+                throw RecordingError.windowGone
+            }
+            return (SCContentFilter(desktopIndependentWindow: window), nil, nil)
+
+        case .display, .area:
+            guard let geometry = request.display
+                ?? content.displays.first.map({ DisplaySnapshotGeometry(
+                    displayID: $0.displayID,
+                    frame: CGRect(x: 0, y: 0, width: CGFloat($0.width), height: CGFloat($0.height)),
+                    scale: 2,
+                    pixelSize: CGSize(width: $0.width * 2, height: $0.height * 2)) }),
+                let display = content.displays.first(where: { $0.displayID == geometry.displayID })
+            else { throw RecordingError.displayGone }
+
+            // Our own windows never appear in a recording. The same one line that keeps the
+            // capture overlay out of every screenshot.
+            let excluded = content.applications.filter {
+                $0.bundleIdentifier == AppIdentity.bundleID
+            }
+            let iconLayer = Int(CGWindowLevelForKey(.desktopIconWindow))
+            let exceptions = request.hidesDesktopIcons
+                ? content.windows.filter { $0.windowLayer == iconLayer } : []
+            let filter = SCContentFilter(display: display, excludingApplications: excluded,
+                                         exceptingWindows: exceptions)
+            return (filter, request.source == .area ? request.areaRect : nil, geometry)
+        }
+    }
+
+    private func makeConfiguration(_ request: RecordingRequest, filter: SCContentFilter,
+                                   sourceRect: CGRect?) -> SCStreamConfiguration {
+        let configuration = SCStreamConfiguration()
+        let scale = CGFloat(filter.pointPixelScale)
+        let rect = sourceRect ?? filter.contentRect
+        let size = RecordingGeometry.pixelSize(contentRect: rect, pointPixelScale: scale)
+        configuration.width = size.width
+        configuration.height = size.height
+
+        if let sourceRect {
+            // Points, relative to the display's own origin.
+            configuration.sourceRect = sourceRect
+        }
+
+        // **False, and this is the feature.** The pointer is logged instead and redrawn at
+        // composite time, which is what lets it stay sharp at 2.5x and carry motion blur.
+        configuration.showsCursor = false
+        configuration.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(request.fps))
+        // 5 is the floor SCK documents for smooth capture; 8 leaves headroom on a busy machine.
+        configuration.queueDepth = 8
+        configuration.pixelFormat = kCVPixelFormatType_32BGRA
+        // Same forced sRGB as the screenshot path, for the same reason: an extended-range buffer
+        // written out without conversion comes back visibly washed out.
+        configuration.colorSpaceName = CGColorSpace.sRGB
+        configuration.capturesAudio = request.capturesSystemAudio
+        configuration.excludesCurrentProcessAudio = true
+        if #available(macOS 14.2, *) { configuration.includeChildWindows = true }
+        return configuration
+    }
+
+    // MARK: - Writing
+
+    private func makeWriter(bundle: RecordingBundle, size: CGSize) throws {
+        guard let writer = try? AVAssetWriter(outputURL: bundle.screenURL, fileType: .mov) else {
+            throw RecordingError.cannotWrite
+        }
+        // **Fragments, and this is what makes a crash survivable.** The writer flushes a
+        // self-contained fragment every two seconds, so a file whose `finishWriting` never ran is
+        // still playable up to the last one — rather than a header-less block nothing can open.
+        writer.movieFragmentInterval = CMTime(seconds: 2, preferredTimescale: 600)
+
+        let settings: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.hevc,
+            AVVideoWidthKey: Int(size.width),
+            AVVideoHeightKey: Int(size.height),
+            AVVideoCompressionPropertiesKey: [
+                AVVideoQualityKey: 0.9,
+                AVVideoExpectedSourceFrameRateKey: 60,
+            ],
+        ]
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
+        input.expectsMediaDataInRealTime = true
+        guard writer.canAdd(input) else { throw RecordingError.cannotWrite }
+        writer.add(input)
+        guard writer.startWriting() else { throw RecordingError.cannotWrite }
+
+        self.writer = writer
+        self.videoInput = input
+    }
+
+    nonisolated func stream(_ stream: SCStream, didOutputSampleBuffer buffer: CMSampleBuffer,
+                            of type: SCStreamOutputType) {
+        guard type == .screen, buffer.isValid else { return }
+        // Idle frames say nothing changed. Not writing them is most of the difference between a
+        // recording of a still screen being enormous and being small; the next real frame simply
+        // carries a longer duration.
+        guard Self.isComplete(buffer) else { return }
+        MainActor.assumeIsolated { append(buffer) }
+    }
+
+    private nonisolated static func isComplete(_ buffer: CMSampleBuffer) -> Bool {
+        guard let attachments = CMSampleBufferGetSampleAttachmentsArray(
+            buffer, createIfNecessary: false) as? [[SCStreamFrameInfo: Any]],
+              let raw = attachments.first?[.status] as? Int,
+              let status = SCFrameStatus(rawValue: raw) else { return false }
+        return status == .complete
+    }
+
+    private func append(_ buffer: CMSampleBuffer) {
+        guard let writer, let videoInput, !isPaused else { return }
+        let timestamp = CMSampleBufferGetPresentationTimeStamp(buffer)
+
+        if firstFrame == nil {
+            firstFrame = timestamp
+            writer.startSession(atSourceTime: timestamp)
+            // One clock. The events are anchored to the same instant the picture starts, which is
+            // the whole reason the cursor lands on what it clicked.
+            events.anchor(to: ProcessInfo.processInfo.systemUptime)
+        }
+        lastFrame = timestamp
+
+        guard videoInput.isReadyForMoreMediaData else {
+            // Dropped at the tail rather than blocking the stream. Counted, and reported when the
+            // recording stops — a stuttering file produced silently is the failure to avoid.
+            droppedFrames += 1
+            return
+        }
+        if !videoInput.append(buffer) { droppedFrames += 1 }
+    }
+
+    nonisolated func stream(_ stream: SCStream, didStopWithError error: Error) {
+        MainActor.assumeIsolated {
+            log.error("stream stopped: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Cursor sampling
+
+    private func startCursorSampling() {
+        // The display's own refresh rate, via NSScreen (macOS 14+). CVDisplayLink is deprecated
+        // from 15 and this is the supported replacement at our target.
+        let screen = ScreenPlacement.screenUnderPointer() ?? NSScreen.main
+        displayLink = screen?.displayLink(target: self, selector: #selector(tick))
+        displayLink?.add(to: .main, forMode: .common)
+    }
+
+    @objc private func tick() { events.sampleCursor() }
+
+    // MARK: - Pause, finish, discard
+
+    func pause() {
+        guard isRecording, !isPaused else { return }
+        isPaused = true
+        pausedAt = lastFrame
+        events.pause()
+    }
+
+    func resume() {
+        guard isRecording, isPaused, let pausedAt else { return }
+        isPaused = false
+        // Rebased rather than left as a gap. A gap means every downstream time — zoom segments,
+        // captions, the timeline — would have to know about it, and none of them should.
+        pausedFor = CMTimeAdd(pausedFor, CMTimeSubtract(lastFrame, pausedAt))
+        self.pausedAt = nil
+        events.resume()
+    }
+
+    func flag() { events.flag() }
+
+    func finish() async throws -> RecordingBundle? {
+        guard isRecording, let bundle else { return nil }
+        isRecording = false
+        displayLink?.invalidate()
+        displayLink = nil
+        try? await stream?.stopCapture()
+        stream = nil
+
+        videoInput?.markAsFinished()
+        await writer?.finishWriting()
+
+        try? bundle.writeEvents(events.finish())
+        if var manifest {
+            manifest.state = .complete
+            manifest.duration = elapsed
+            manifest.droppedFrames = droppedFrames
+            try? bundle.write(manifest)
+        }
+
+        writer = nil; videoInput = nil; self.bundle = nil; manifest = nil
+        firstFrame = nil; pausedFor = .zero; pausedAt = nil; lastFrame = .zero
+        return bundle
+    }
+
+    func discard() async {
+        let doomed = bundle
+        _ = try? await finish()
+        if let doomed { try? FileManager.default.removeItem(at: doomed.root) }
+    }
+
+    // MARK: - Space and scale
+
+    /// Refuses to start with under two minutes of room, and says the number.
+    private func checkSpace(for size: CGSize, fps: Int) throws {
+        let values = try? RecordingBundle.defaultDirectory()
+            .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        let free = values?.volumeAvailableCapacityForImportantUsage ?? Int64.max
+        let perSecond = Int64(size.width * size.height) / 8
+        guard free > perSecond * Int64(fps > 30 ? 120 : 90) else {
+            throw RecordingError.outOfSpace(freeBytes: free)
+        }
+    }
+
+    /// The user's Accessibility pointer size. Stored, not applied — see `RecordingManifest`.
+    private static func accessibilityCursorScale() -> Double {
+        UserDefaults(suiteName: "com.apple.universalaccess")?
+            .object(forKey: "mouseDriverCursorSize") as? Double ?? 1
+    }
+
+    // MARK: - Mapping
+
+    /// Global AppKit points to the recording's own pixel space, or nil when outside it.
+    ///
+    /// Nil is the answer that matters: in area and window modes the pointer spends much of its time
+    /// outside the frame, and a cursor pinned to the edge looks like a bug.
+    private static func mapper(sourceRect: CGRect?, geometry: DisplaySnapshotGeometry?,
+                               scale: CGFloat, pixels: CGSize) -> (CGPoint) -> CGPoint? {
+        return { global in
+            guard let geometry else {
+                // Window mode: the per-frame geometry sidecar is what resolves this properly, and
+                // until that lands a window recording simply has no cursor rather than a wrong one.
+                return nil
+            }
+            let local = CGPoint(x: global.x - geometry.frame.minX,
+                                y: geometry.frame.maxY - global.y)
+            let origin = sourceRect.map { CGPoint(x: $0.minX, y: $0.minY) } ?? .zero
+            let point = CGPoint(x: (local.x - origin.x) * scale, y: (local.y - origin.y) * scale)
+            guard point.x >= 0, point.y >= 0,
+                  point.x < pixels.width, point.y < pixels.height else { return nil }
+            return point
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
+++ b/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
@@ -89,7 +89,8 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
             // is one the app died in the middle of, the only signal a crash leaves.
             try bundle.write(manifest)
 
-            writer = try RecordingWriter(url: bundle.screenURL, size: pixels, fps: request.fps)
+            writer = try RecordingWriter(url: bundle.screenURL, size: pixels, fps: request.fps,
+                                         capturesAudio: request.capturesSystemAudio)
 
             self.bundle = bundle
             // Handed to the recorder by value. It used to reach back through `self?.mapPoint`,
@@ -126,6 +127,13 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
             let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
             let frames = DispatchQueue(label: "ai.psylief.sarvkrit.recording")
             try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: frames)
+            // **Without this, `capturesAudio` on the configuration does nothing.** It was set, and
+            // `hasSystemAudio` was written into the manifest, and no audio output was ever added —
+            // so ScreenCaptureKit never delivered a single buffer and the claim was false.
+            if request.capturesSystemAudio {
+                let sound = DispatchQueue(label: "ai.psylief.sarvkrit.recording.audio")
+                try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: sound)
+            }
             try await stream.startCapture()
             self.stream = stream
             isRecording = true
@@ -223,7 +231,12 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
 
     nonisolated func stream(_ stream: SCStream, didOutputSampleBuffer buffer: CMSampleBuffer,
                             of type: SCStreamOutputType) {
-        guard type == .screen, buffer.isValid else { return }
+        guard buffer.isValid else { return }
+        if type == .audio {
+            writer?.appendAudio(buffer)
+            return
+        }
+        guard type == .screen else { return }
         // Idle frames say nothing changed. Not writing them is most of the difference between a
         // recording of a still screen being enormous and being small; the next real frame simply
         // carries a longer duration.

--- a/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
+++ b/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
@@ -28,6 +28,7 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
     private var bundle: RecordingBundle?
     private var manifest: RecordingManifest?
     private let events = EventRecorder()
+    private let camera = CameraRecorder()
     private var displayLink: CADisplayLink?
 
     private(set) var isRecording = false
@@ -46,7 +47,8 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
 
     // MARK: - Start
 
-    func start(_ request: RecordingRequest) async throws {
+    /// - Parameter setup: the camera and microphone the user chose, if any.
+    func start(_ request: RecordingRequest, setup: RecordingSetup? = nil) async throws {
         guard !isRecording else { throw RecordingError.alreadyRecording }
 
         let content = try await SCShareableContent.excludingDesktopWindows(
@@ -81,6 +83,27 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
         self.mapPoint = Self.mapper(sourceRect: sourceRect, geometry: geometry,
                                     scale: CGFloat(filter.pointPixelScale), pixels: pixels)
         events.begin(mapping: { [weak self] point in self?.mapPoint?(point) })
+
+        // Started before the stream, so the camera is already rolling when the first screen frame
+        // lands rather than a second behind it.
+        if let setup {
+            let device = setup.cameraID.flatMap { id in
+                CameraRecorder.devices().first { $0.uniqueID == id }
+            }
+            let microphone = setup.microphoneID.flatMap { id in
+                CameraRecorder.microphones().first { $0.uniqueID == id }
+            }
+            // **A microphone with no camera still has to be recorded.** Gating this on the camera
+            // meant choosing a mic alone captured nothing at all, silently — which is the worst
+            // possible way for narration to go missing.
+            if device != nil || microphone != nil {
+                try? camera.start(device: device, microphone: microphone,
+                                  to: device != nil ? bundle.cameraURL : bundle.microphoneURL)
+                manifest.hasCamera = device != nil
+                manifest.hasMicrophone = microphone != nil
+                try? bundle.write(manifest)
+            }
+        }
 
         let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
         try stream.addStreamOutput(self, type: .screen,
@@ -221,6 +244,7 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
         displayLink = nil
         try? await stream?.stopCapture()
         stream = nil
+        camera.finish()
 
         let anchor = writer?.firstFrameHostTime
         let duration = elapsed

--- a/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
+++ b/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
@@ -22,32 +22,22 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
     override nonisolated init() { super.init() }
 
     private var stream: SCStream?
-    private var writer: AVAssetWriter?
-    private var videoInput: AVAssetWriterInput?
+    /// Not main-actor: `SCStream` hands frames to its own queue and this is written from there.
+    /// See `RecordingWriter` for the crash that made this explicit.
+    private nonisolated(unsafe) var writer: RecordingWriter?
     private var bundle: RecordingBundle?
     private var manifest: RecordingManifest?
     private let events = EventRecorder()
     private var displayLink: CADisplayLink?
 
-    /// The presentation timestamp of the first frame. Everything is measured from it, so the
-    /// events and the picture cannot drift apart.
-    private var firstFrame: CMTime?
-    /// Accumulated across pauses, so the output has no gap and elapsed time means recorded time.
-    private var pausedFor: CMTime = .zero
-    private var pausedAt: CMTime?
-    private var lastFrame: CMTime = .zero
-
     private(set) var isRecording = false
-    private(set) var droppedFrames = 0
-    private(set) var isPaused = false
 
     /// Maps a global AppKit point into the recording's pixel space. Nil means outside.
     private var mapPoint: ((CGPoint) -> CGPoint?)?
 
-    var elapsed: TimeInterval {
-        guard let firstFrame else { return 0 }
-        return CMTimeGetSeconds(CMTimeSubtract(CMTimeSubtract(lastFrame, firstFrame), pausedFor))
-    }
+    var elapsed: TimeInterval { writer?.elapsed ?? 0 }
+    var droppedFrames: Int { writer?.droppedFrames ?? 0 }
+    var isPaused: Bool { writer?.isPaused ?? false }
 
     var recordsKeystrokes: Bool {
         get { events.recordsKeystrokes }
@@ -84,7 +74,7 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
         // the app died in the middle of, and that is the only signal a crash leaves.
         try bundle.write(manifest)
 
-        try makeWriter(bundle: bundle, size: pixels)
+        writer = try RecordingWriter(url: bundle.screenURL, size: pixels, fps: request.fps)
 
         self.bundle = bundle
         self.manifest = manifest
@@ -98,7 +88,6 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
         try await stream.startCapture()
         self.stream = stream
         isRecording = true
-        droppedFrames = 0
         startCursorSampling()
         log.info("recording started \(configuration.width, privacy: .public)x\(configuration.height, privacy: .public)")
     }
@@ -171,34 +160,6 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
 
     // MARK: - Writing
 
-    private func makeWriter(bundle: RecordingBundle, size: CGSize) throws {
-        guard let writer = try? AVAssetWriter(outputURL: bundle.screenURL, fileType: .mov) else {
-            throw RecordingError.cannotWrite
-        }
-        // **Fragments, and this is what makes a crash survivable.** The writer flushes a
-        // self-contained fragment every two seconds, so a file whose `finishWriting` never ran is
-        // still playable up to the last one — rather than a header-less block nothing can open.
-        writer.movieFragmentInterval = CMTime(seconds: 2, preferredTimescale: 600)
-
-        let settings: [String: Any] = [
-            AVVideoCodecKey: AVVideoCodecType.hevc,
-            AVVideoWidthKey: Int(size.width),
-            AVVideoHeightKey: Int(size.height),
-            AVVideoCompressionPropertiesKey: [
-                AVVideoQualityKey: 0.9,
-                AVVideoExpectedSourceFrameRateKey: 60,
-            ],
-        ]
-        let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
-        input.expectsMediaDataInRealTime = true
-        guard writer.canAdd(input) else { throw RecordingError.cannotWrite }
-        writer.add(input)
-        guard writer.startWriting() else { throw RecordingError.cannotWrite }
-
-        self.writer = writer
-        self.videoInput = input
-    }
-
     nonisolated func stream(_ stream: SCStream, didOutputSampleBuffer buffer: CMSampleBuffer,
                             of type: SCStreamOutputType) {
         guard type == .screen, buffer.isValid else { return }
@@ -206,7 +167,9 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
         // recording of a still screen being enormous and being small; the next real frame simply
         // carries a longer duration.
         guard Self.isComplete(buffer) else { return }
-        MainActor.assumeIsolated { append(buffer) }
+        // Straight to the writer, on this queue. **No hop to the main actor**: the previous version
+        // asserted its way onto it with `MainActor.assumeIsolated` and trapped on the first frame.
+        writer?.append(buffer)
     }
 
     private nonisolated static func isComplete(_ buffer: CMSampleBuffer) -> Bool {
@@ -215,28 +178,6 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
               let raw = attachments.first?[.status] as? Int,
               let status = SCFrameStatus(rawValue: raw) else { return false }
         return status == .complete
-    }
-
-    private func append(_ buffer: CMSampleBuffer) {
-        guard let writer, let videoInput, !isPaused else { return }
-        let timestamp = CMSampleBufferGetPresentationTimeStamp(buffer)
-
-        if firstFrame == nil {
-            firstFrame = timestamp
-            writer.startSession(atSourceTime: timestamp)
-            // One clock. The events are anchored to the same instant the picture starts, which is
-            // the whole reason the cursor lands on what it clicked.
-            events.anchor(to: ProcessInfo.processInfo.systemUptime)
-        }
-        lastFrame = timestamp
-
-        guard videoInput.isReadyForMoreMediaData else {
-            // Dropped at the tail rather than blocking the stream. Counted, and reported when the
-            // recording stops — a stuttering file produced silently is the failure to avoid.
-            droppedFrames += 1
-            return
-        }
-        if !videoInput.append(buffer) { droppedFrames += 1 }
     }
 
     nonisolated func stream(_ stream: SCStream, didStopWithError error: Error) {
@@ -260,19 +201,14 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
     // MARK: - Pause, finish, discard
 
     func pause() {
-        guard isRecording, !isPaused else { return }
-        isPaused = true
-        pausedAt = lastFrame
+        guard isRecording else { return }
+        writer?.pause()
         events.pause()
     }
 
     func resume() {
-        guard isRecording, isPaused, let pausedAt else { return }
-        isPaused = false
-        // Rebased rather than left as a gap. A gap means every downstream time — zoom segments,
-        // captions, the timeline — would have to know about it, and none of them should.
-        pausedFor = CMTimeAdd(pausedFor, CMTimeSubtract(lastFrame, pausedAt))
-        self.pausedAt = nil
+        guard isRecording else { return }
+        writer?.resume()
         events.resume()
     }
 
@@ -286,19 +222,22 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
         try? await stream?.stopCapture()
         stream = nil
 
-        videoInput?.markAsFinished()
-        await writer?.finishWriting()
+        let anchor = writer?.firstFrameHostTime
+        let duration = elapsed
+        let dropped = droppedFrames
+        await writer?.finish()
 
-        try? bundle.writeEvents(events.finish())
+        try? bundle.writeEvents(events.finish(anchoredTo: anchor))
         if var manifest {
             manifest.state = .complete
-            manifest.duration = elapsed
-            manifest.droppedFrames = droppedFrames
+            manifest.duration = duration
+            manifest.droppedFrames = dropped
             try? bundle.write(manifest)
         }
 
-        writer = nil; videoInput = nil; self.bundle = nil; manifest = nil
-        firstFrame = nil; pausedFor = .zero; pausedAt = nil; lastFrame = .zero
+        writer = nil
+        self.bundle = nil
+        manifest = nil
         return bundle
     }
 

--- a/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
+++ b/Sources/Sarvkrit/Features/Studio/SCKScreenRecordingService.swift
@@ -285,6 +285,10 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
         camera.finish()
 
         let anchor = writer?.firstFrameHostTime
+        // Both are `systemUptime` taken at a first frame, so the gap between the tracks is the
+        // difference. Clamped at zero: a camera that somehow beat the screen is not a negative
+        // offset, it is no offset.
+        let cameraStart = camera.startedAtHostTime
         let duration = elapsed
         let dropped = droppedFrames
         await writer?.finish()
@@ -294,6 +298,11 @@ final class SCKScreenRecordingService: NSObject, ScreenRecording, SCStreamOutput
             manifest.state = .complete
             manifest.duration = duration
             manifest.droppedFrames = dropped
+            if let anchor, let cameraStart {
+                manifest.cameraStartOffset = max(0, cameraStart - anchor)
+                let offset = manifest.cameraStartOffset
+                log.info("camera started \(offset, format: .fixed(precision: 3), privacy: .public)s after the screen")
+            }
             try? bundle.write(manifest)
         }
 

--- a/Sources/Sarvkrit/Features/Studio/ScreenRecording.swift
+++ b/Sources/Sarvkrit/Features/Studio/ScreenRecording.swift
@@ -1,0 +1,59 @@
+import CoreGraphics
+import Foundation
+
+/// What a recording was asked for.
+struct RecordingRequest: Equatable {
+    var source: RecordingSource
+    /// Area mode: the chosen rectangle in global AppKit points.
+    var areaRect: CGRect?
+    var display: DisplaySnapshotGeometry?
+    var window: CapturableWindow?
+    var fps: Int = 60
+    var capturesSystemAudio = false
+    var hidesDesktopIcons = true
+    var destination: URL
+
+    init(source: RecordingSource, destination: URL) {
+        self.source = source
+        self.destination = destination
+    }
+}
+
+/// Why a recording did not happen, or stopped.
+///
+/// `noDisplays` is the same signal `CaptureError` carries and means the same thing: **that is what
+/// a denied Screen Recording grant looks like.** There is no error to catch — ScreenCaptureKit
+/// simply reports nothing to record — so `ScreenRecordingRelaunch` reads it here too.
+enum RecordingError: Error, Equatable {
+    case noDisplays
+    case displayGone
+    case windowGone
+    case cannotWrite
+    case alreadyRecording
+    case outOfSpace(freeBytes: Int64)
+    case cancelled
+}
+
+/// Everything that streams from ScreenCaptureKit, behind one protocol.
+///
+/// **Sibling of `ScreenCapturing`, and for exactly the same reason.** `SarvkritTests` is hosted
+/// inside `Sarvkrit.app`, so a live `SCStream` in a test either prompts for TCC — hanging the run
+/// — or returns denied results that make every assertion vacuous. Kept separate from
+/// `ScreenCapturing` rather than bolted onto it because every method there returns a finished
+/// `CGImage`, and a frame pump is a different shape: adding one would also break
+/// `StubScreenCaptureService` at compile time for no gain.
+@MainActor
+protocol ScreenRecording: AnyObject {
+    var isRecording: Bool { get }
+    /// Reports elapsed *recorded* time — which is not wall-clock once a recording has been paused.
+    var elapsed: TimeInterval { get }
+    var droppedFrames: Int { get }
+
+    func start(_ request: RecordingRequest) async throws
+    func pause()
+    func resume()
+    /// - Returns: the finished bundle, or nil if nothing usable was written.
+    func finish() async throws -> RecordingBundle?
+    /// Stops and deletes. For "that take was rubbish, go again".
+    func discard() async
+}

--- a/Sources/Sarvkrit/Features/Studio/ScreenRecording.swift
+++ b/Sources/Sarvkrit/Features/Studio/ScreenRecording.swift
@@ -49,7 +49,8 @@ protocol ScreenRecording: AnyObject {
     var elapsed: TimeInterval { get }
     var droppedFrames: Int { get }
 
-    func start(_ request: RecordingRequest) async throws
+    /// - Parameter setup: the camera and microphone the user chose in the pre-record bar, if any.
+    func start(_ request: RecordingRequest, setup: RecordingSetup?) async throws
     func pause()
     func resume()
     /// - Returns: the finished bundle, or nil if nothing usable was written.

--- a/Sources/Sarvkrit/Features/Studio/ScreenRecordingFeature.swift
+++ b/Sources/Sarvkrit/Features/Studio/ScreenRecordingFeature.swift
@@ -137,6 +137,11 @@ final class ScreenRecordingFeature: Feature, ObservableObject {
             }
             if status == noErr {
                 hotkeys.append(hotkey)
+                // The successes are logged too, not only the refusals, matching `ScreenshotFeature`
+                // — "did this combination actually get claimed on this Mac" is otherwise
+                // unanswerable without a debugger, and when these shortcuts went missing the launch
+                // log could not say so.
+                log.info("registered \(action.rawValue, privacy: .public) keyCode \(shortcut.keyCode, privacy: .public)")
             } else {
                 // Another app holding a combination is ordinary. Recorded so settings can say so,
                 // rather than offering a shortcut that quietly does nothing.
@@ -147,12 +152,20 @@ final class ScreenRecordingFeature: Feature, ObservableObject {
         objectWillChange.send()
     }
 
-    private func handler(for action: RecordingAction) -> (() -> Void)? {
+    /// Internal rather than private so `ScreenRecordingHotkeyBindingTests` can pin the late
+    /// binding this returns — the launch-order bug it documents had no other observable surface.
+    func handler(for action: RecordingAction) -> (() -> Void)? {
+        // **Read at fire time, not here.** `rebindHotkeys()` runs from `AppState.sync()`, which
+        // happens during `AppState.shared`'s initialiser — four lines before `wireRecording()`
+        // assigns any of these. Returning the stored closure meant returning nil four times, and
+        // `guard let handler … else { continue }` then registered nothing at all. Worse, it never
+        // recovered: `sync()` skips features already in `activeFeatureIDs`, so the only cure was
+        // toggling the feature off and on. `ScreenshotFeature` has done it this way all along.
         switch action {
-        case .startStop: return startStop
-        case .recordArea: return recordArea
-        case .pauseResume: return pauseResume
-        case .flag: return markMoment
+        case .startStop: return { [weak self] in self?.startStop?() }
+        case .recordArea: return { [weak self] in self?.recordArea?() }
+        case .pauseResume: return { [weak self] in self?.pauseResume?() }
+        case .flag: return { [weak self] in self?.markMoment?() }
         }
     }
 }

--- a/Sources/Sarvkrit/Features/Studio/ScreenRecordingFeature.swift
+++ b/Sources/Sarvkrit/Features/Studio/ScreenRecordingFeature.swift
@@ -27,6 +27,8 @@ final class ScreenRecordingFeature: Feature, ObservableObject {
     let requirements: Set<Requirement> = [.screenRecording]
 
     let recorder: SCKScreenRecordingService
+    /// What the pre-record bar last had chosen. Shared with it rather than copied.
+    let setup: RecordingSetup
     private let defaults: UserDefaults
     private var hotkeys: [GlobalHotkey] = []
 
@@ -43,6 +45,7 @@ final class ScreenRecordingFeature: Feature, ObservableObject {
          defaults: UserDefaults = .standard) {
         self.recorder = recorder
         self.defaults = defaults
+        self.setup = RecordingSetup(defaults: defaults)
     }
 
     // MARK: - Settings

--- a/Sources/Sarvkrit/Features/Studio/ScreenRecordingFeature.swift
+++ b/Sources/Sarvkrit/Features/Studio/ScreenRecordingFeature.swift
@@ -1,0 +1,155 @@
+import Foundation
+import SwiftUI
+import os
+
+/// Recording the screen, and editing it afterwards.
+final class ScreenRecordingFeature: Feature, ObservableObject {
+    private let log = Logger(subsystem: AppIdentity.logSubsystem, category: "Recording")
+
+    let id = "screen-recording"
+    let category = FeatureCategory.capture
+    let title = "Screen Recording"
+    let summary = "Record your screen; it edits itself"
+    let details = """
+        Records your screen — an area, a window, or the whole display — and captures what the \
+        mouse and keyboard did alongside it.
+
+        The pointer is not recorded into the video. Its path is logged instead and drawn back in \
+        afterwards, which is why it can be resized, smoothed and kept sharp when the frame is \
+        zoomed, and why none of those are decisions you have to get right while recording.
+        """
+    let symbolName = "record.circle"
+    var shortcutHint: String? { "⌃⇧R" }
+
+    /// **Screen Recording only.** Not Accessibility: the base recorder watches clicks through a
+    /// global monitor, which needs no grant, and `FeatureCategoryTests` asserts that only
+    /// `EventTapFeature`s declare it. Keystroke capture asks for Accessibility at the point of use.
+    let requirements: Set<Requirement> = [.screenRecording]
+
+    let recorder: SCKScreenRecordingService
+    private let defaults: UserDefaults
+    private var hotkeys: [GlobalHotkey] = []
+
+    /// Set by `AppDelegate`. Nothing under `Features/` imports the UI layer.
+    var startStop: (() -> Void)?
+    var recordArea: (() -> Void)?
+    var pauseResume: (() -> Void)?
+    var markMoment: (() -> Void)?
+
+    @Published private(set) var isRecording = false
+    @Published private(set) var failedRegistrations: Set<RecordingAction> = []
+
+    init(recorder: SCKScreenRecordingService = SCKScreenRecordingService(),
+         defaults: UserDefaults = .standard) {
+        self.recorder = recorder
+        self.defaults = defaults
+    }
+
+    // MARK: - Settings
+
+    /// Hand-rolled over an injected `UserDefaults`, with a same-value guard in the setter. Never
+    /// `@Published`: a same-value write through a SwiftUI binding once became notify → invalidate
+    /// → write back → notify, and pinned a core until the app was killed. See `AppState`.
+    var framesPerSecond: Int {
+        get { defaults.object(forKey: "recording.fps") as? Int ?? 60 }
+        set {
+            guard newValue != framesPerSecond else { return }
+            defaults.set(newValue, forKey: "recording.fps")
+            objectWillChange.send()
+        }
+    }
+
+    var capturesSystemAudio: Bool {
+        get { defaults.object(forKey: "recording.systemAudio") as? Bool ?? false }
+        set {
+            guard newValue != capturesSystemAudio else { return }
+            defaults.set(newValue, forKey: "recording.systemAudio")
+            objectWillChange.send()
+        }
+    }
+
+    var hidesDesktopIcons: Bool {
+        get { defaults.object(forKey: "recording.hidesDesktopIcons") as? Bool ?? true }
+        set {
+            guard newValue != hidesDesktopIcons else { return }
+            defaults.set(newValue, forKey: "recording.hidesDesktopIcons")
+            objectWillChange.send()
+        }
+    }
+
+    /// Off until asked, like Snap Areas. Watching the keyboard is exactly the thing a
+    /// privacy-minded person wants to opt into rather than discover, and it needs Accessibility.
+    var showsKeystrokes: Bool {
+        get { defaults.object(forKey: "recording.keystrokes") as? Bool ?? false }
+        set {
+            guard newValue != showsKeystrokes else { return }
+            defaults.set(newValue, forKey: "recording.keystrokes")
+            MainActor.assumeIsolated { recorder.recordsKeystrokes = newValue }
+            objectWillChange.send()
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    func activate() {
+        MainActor.assumeIsolated {
+            recorder.recordsKeystrokes = showsKeystrokes
+            rebindHotkeys()
+        }
+    }
+
+    func deactivate() {
+        hotkeys.forEach { $0.unregister() }
+        hotkeys = []
+    }
+
+    @MainActor
+    func noteRecording(_ recording: Bool) {
+        guard recording != isRecording else { return }
+        isRecording = recording
+    }
+
+    @MainActor
+    func makeDetailView() -> AnyView? {
+        AnyView(ScreenRecordingDetailView(feature: self))
+    }
+
+    /// Registered again after a rebind, because Carbon hot keys are registered rather than matched
+    /// — there is no table to update, only a registration to replace.
+    @MainActor
+    func rebindHotkeys() {
+        hotkeys.forEach { $0.unregister() }
+        hotkeys = []
+        failedRegistrations = []
+
+        for action in RecordingAction.allCases {
+            guard let handler = handler(for: action) else { continue }
+            let shortcut = action.defaultShortcut
+            let hotkey = GlobalHotkey(id: action.hotkeyID)
+            let status = hotkey.register(keyCode: UInt32(shortcut.keyCode),
+                                         // Carbon masks, not CGEventFlags. Handing over the wrong
+                                         // one compiles and registers a different combination.
+                                         modifiers: CarbonModifiers.from(shortcut.flags)) {
+                MainActor.assumeIsolated { handler() }
+            }
+            if status == noErr {
+                hotkeys.append(hotkey)
+            } else {
+                // Another app holding a combination is ordinary. Recorded so settings can say so,
+                // rather than offering a shortcut that quietly does nothing.
+                failedRegistrations.insert(action)
+                log.error("couldn't register \(action.rawValue, privacy: .public): \(status, privacy: .public)")
+            }
+        }
+        objectWillChange.send()
+    }
+
+    private func handler(for action: RecordingAction) -> (() -> Void)? {
+        switch action {
+        case .startStop: return startStop
+        case .recordArea: return recordArea
+        case .pauseResume: return pauseResume
+        case .flag: return markMoment
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/SilenceDetector.swift
+++ b/Sources/Sarvkrit/Features/Studio/SilenceDetector.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Finding the dead air in a narration track.
+///
+/// Pure over an amplitude envelope — an array of per-slice peak levels — rather than over an
+/// `AVAudioFile`, so the judgement can be tuned and tested without decoding anything. Reading the
+/// envelope out of the audio is somebody else's job.
+///
+/// **The result is a set of suggested cuts, not a filter.** Applying this live would mean the
+/// timeline no longer shows what will be exported, which breaks the promise the whole editor rests
+/// on: what you see is what comes out.
+enum SilenceDetector {
+
+    struct Tuning: Equatable {
+        /// dBFS. Below this counts as quiet. Room tone sits well under it; a whisper does not.
+        var threshold: Double = -45
+        /// A gap shorter than this is a breath between sentences, not dead air. Cutting breaths
+        /// makes speech sound hurried in a way listeners notice without being able to say why.
+        var minimumDuration: TimeInterval = 0.6
+        /// Left at each edge of a cut.
+        ///
+        /// Cutting exactly where the level crosses the threshold clips the attack of the next
+        /// word — speech begins quietly and gets loud — and the result sounds gasped.
+        var pad: TimeInterval = 0.15
+
+        init() {}
+
+        var thresholdAmplitude: Float { Float(pow(10, threshold / 20)) }
+    }
+
+    /// Ranges of the envelope, in seconds, that are quiet enough and long enough to cut.
+    static func silences(in envelope: [Float], sampleRate: Double,
+                         tuning: Tuning = Tuning()) -> [Range<TimeInterval>] {
+        guard !envelope.isEmpty, sampleRate > 0 else { return [] }
+        let limit = tuning.thresholdAmplitude
+
+        var found: [Range<TimeInterval>] = []
+        var runStart: Int?
+
+        func close(at index: Int) {
+            guard let start = runStart else { return }
+            runStart = nil
+            let from = Double(start) / sampleRate
+            let to = Double(index) / sampleRate
+            guard to - from >= tuning.minimumDuration else { return }
+            // Padded inwards, and dropped if the padding consumes it — a cut with a negative
+            // length is not a cut.
+            let padded = (from + tuning.pad)..<(to - tuning.pad)
+            if padded.lowerBound < padded.upperBound { found.append(padded) }
+        }
+
+        for (index, level) in envelope.enumerated() {
+            if abs(level) < limit {
+                if runStart == nil { runStart = index }
+            } else {
+                close(at: index)
+            }
+        }
+        close(at: envelope.count)
+        return found
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/StudioAudio.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioAudio.swift
@@ -107,6 +107,23 @@ enum StudioAudio {
                 gain.setVolume(Float(max(0, min(1, level))), at: cursor)
                 cursor = cursor + CMTime(seconds: clip.outputDuration, preferredTimescale: 600)
             }
+            // **The audio fades with the picture.** Set after the per-clip levels so the ramps win
+            // at the two ends, which is what "fade in" means.
+            let total = CMTime(seconds: project.duration, preferredTimescale: 600)
+            if project.fadeIn > 0 {
+                gain.setVolumeRamp(fromStartVolume: 0, toEndVolume: 1,
+                                   timeRange: CMTimeRange(
+                                       start: .zero,
+                                       duration: CMTime(seconds: project.fadeIn,
+                                                        preferredTimescale: 600)))
+            }
+            if project.fadeOut > 0, project.duration > project.fadeOut {
+                gain.setVolumeRamp(fromStartVolume: 1, toEndVolume: 0,
+                                   timeRange: CMTimeRange(
+                                       start: CMTime(seconds: project.duration - project.fadeOut,
+                                                     preferredTimescale: 600),
+                                       end: total))
+            }
             parameters.append(gain)
         }
 

--- a/Sources/Sarvkrit/Features/Studio/StudioAudio.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioAudio.swift
@@ -31,11 +31,15 @@ enum StudioAudio {
         return nil
     }
 
+    /// System audio rides in `screen.mov` alongside the picture — one writer, one fragment
+    /// interval, and a raw recording that plays with sound.
     static func systemAudioURL(in recording: RecordingBundle) async -> URL? {
-        let url = recording.systemAudioURL
-        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
-        let tracks = try? await AVURLAsset(url: url).loadTracks(withMediaType: .audio)
-        return tracks?.isEmpty == false ? url : nil
+        for url in [recording.screenURL, recording.systemAudioURL] where
+            FileManager.default.fileExists(atPath: url.path) {
+            let tracks = try? await AVURLAsset(url: url).loadTracks(withMediaType: .audio)
+            if tracks?.isEmpty == false { return url }
+        }
+        return nil
     }
 
     /// The project's audio, cut and gain-staged to match the timeline.

--- a/Sources/Sarvkrit/Features/Studio/StudioAudio.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioAudio.swift
@@ -53,6 +53,16 @@ enum StudioAudio {
         let system = await systemAudioURL(in: recording)
         guard narration != nil || system != nil else { return nil }
 
+        // **The microphone starts late, and the picture does not.** An `AVCaptureSession` takes a
+        // couple of seconds to come up, so the narration file begins that much after the screen.
+        // `cameraStartOffset` records it — despite the name it is the capture session's offset,
+        // whichever file the sound landed in. Reading the file as if its time were the screen's
+        // put every word seconds *before* it was said, and left the tail silent.
+        //
+        // System audio has no such offset: it rides in `screen.mov`, anchored to the first video
+        // frame like the picture itself.
+        let narrationOffset = (try? recording.readManifest())?.cameraStartOffset ?? 0
+
         let composition = AVMutableComposition()
         var parameters: [AVMutableAudioMixInputParameters] = []
         // **The assets are held, not just their tracks.** `AVAssetTrack.asset` is a weak reference,
@@ -61,14 +71,20 @@ enum StudioAudio {
         // the bug this file exists to fix.
         var retained: [AVURLAsset] = []
 
-        for source in [(narration, false), (system, true)] {
+        for source in [(narration, narrationOffset, false), (system, 0.0, true)] {
             guard let url = source.0 else { continue }
             let asset = AVURLAsset(url: url)
             retained.append(asset)
             guard let sourceTrack = try? await asset.loadTracks(withMediaType: .audio).first,
-                  let track = composition.addMutableTrack(withMediaType: .audio,
-                                                          preferredTrackID: kCMPersistentTrackID_Invalid)
+                  let track = composition.addMutableTrack(
+                      withMediaType: .audio,
+                      preferredTrackID: kCMPersistentTrackID_Invalid)
             else { continue }
+
+            let offset = source.1
+            let available = ((try? await asset.load(.duration))?.seconds).map {
+                $0.isFinite ? $0 : 0
+            } ?? 0
 
             let gain = AVMutableAudioMixInputParameters(track: track)
             // A tape-style pitch shift on a sped-up clip is what a speed change is expected to
@@ -77,36 +93,44 @@ enum StudioAudio {
 
             var cursor = CMTime.zero
             for clip in project.timeline.clips {
-                let range = CMTimeRange(
-                    start: CMTime(seconds: clip.sourceStart, preferredTimescale: 600),
-                    duration: CMTime(seconds: clip.sourceDuration, preferredTimescale: 600))
-                guard range.duration.seconds > 0 else { continue }
+                // Where this clip's material sits inside *this* file.
+                let wantedStart = clip.sourceStart - offset
+                let wantedEnd = clip.sourceEnd - offset
+                let from = max(0, wantedStart)
+                let to = min(wantedEnd, available)
 
-                do {
-                    try track.insertTimeRange(range, of: sourceTrack, at: cursor)
-                } catch {
-                    // A clip whose source range runs past the end of the audio is ordinary: the
-                    // microphone can stop before the screen does. Silence is the right answer —
-                    // but it is logged, because "the export is silent" was the bug this whole
-                    // file exists to fix and a swallowed insert would recreate it exactly.
-                    let why = String(describing: error)
-                    log.error("audio: could not insert a clip's range: \(why, privacy: .public)")
-                    cursor = cursor + CMTime(seconds: clip.outputDuration, preferredTimescale: 600)
-                    continue
-                }
-
-                let inserted = CMTimeRange(start: cursor, duration: range.duration)
-                if clip.speed != 1 {
-                    track.scaleTimeRange(inserted,
-                                         toDuration: CMTime(seconds: clip.outputDuration,
-                                                            preferredTimescale: 600))
+                if to > from {
+                    // Output seconds this file has nothing for — before the microphone existed.
+                    // Left as silence rather than filled, which is the honest answer.
+                    let lead = (from - wantedStart) / max(clip.speed, 0.0001)
+                    let insertAt = cursor + CMTime(seconds: lead, preferredTimescale: 600)
+                    let range = CMTimeRange(
+                        start: CMTime(seconds: from, preferredTimescale: 600),
+                        duration: CMTime(seconds: to - from, preferredTimescale: 600))
+                    do {
+                        try track.insertTimeRange(range, of: sourceTrack, at: insertAt)
+                        if clip.speed != 1 {
+                            track.scaleTimeRange(
+                                CMTimeRange(start: insertAt, duration: range.duration),
+                                toDuration: CMTime(seconds: (to - from) / clip.speed,
+                                                   preferredTimescale: 600))
+                        }
+                    } catch {
+                        // Logged, because "the export is silent" was the bug this whole file
+                        // exists to fix and a swallowed insert would recreate it exactly.
+                        let why = String(describing: error)
+                        log.error("audio: could not insert a clip's range: \(why, privacy: .public)")
+                    }
                 }
 
                 // Set at the clip's own start, so each clip's gain holds until the next changes it.
-                let level = clip.isMuted ? 0 : (source.1 ? clip.systemAudioVolume : clip.volume)
+                let level = clip.isMuted ? 0 : (source.2 ? clip.systemAudioVolume : clip.volume)
                 gain.setVolume(Float(max(0, min(1, level))), at: cursor)
+                // The whole clip, including any held last frame — which is silence, since nothing
+                // was inserted for it.
                 cursor = cursor + CMTime(seconds: clip.outputDuration, preferredTimescale: 600)
             }
+
             // **The audio fades with the picture.** Set after the per-clip levels so the ramps win
             // at the two ends, which is what "fade in" means.
             let total = CMTime(seconds: project.duration, preferredTimescale: 600)

--- a/Sources/Sarvkrit/Features/Studio/StudioAudio.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioAudio.swift
@@ -1,0 +1,120 @@
+import AVFoundation
+import Foundation
+import os
+
+/// The edited soundtrack, as something the exporter can read.
+///
+/// **Every export was silent.** `StudioExporter` wrote a single video input and read only the
+/// screen's video track — while the recorder captured narration, the manifest recorded
+/// `hasMicrophone` and `hasSystemAudio`, and every `Clip` carried `volume`, `systemAudioVolume` and
+/// `isMuted`. All of those controls were editing a track that never reached a file.
+///
+/// **Built as an `AVComposition` rather than by hand.** The hard parts here are time-scaling a
+/// speed-changed clip and mixing two sources with per-clip gain, and AVFoundation already does both
+/// correctly. Re-timing PCM by hand would mean owning a resampler, and getting that subtly wrong
+/// sounds like a broken app rather than an off-by-one.
+enum StudioAudio {
+
+    private static let log = Logger(subsystem: AppIdentity.logSubsystem, category: "Studio")
+
+    /// The narration and system tracks a bundle actually has.
+    ///
+    /// Narration lands in `camera.mov` when a camera was recording — one `AVCaptureSession` with
+    /// both inputs writes one file — and in `mic.m4a` when it was the microphone alone. Rather than
+    /// infer that from the manifest, both are asked whether they have an audio track.
+    static func narrationURL(in recording: RecordingBundle) async -> URL? {
+        for url in [recording.microphoneURL, recording.cameraURL] where
+            FileManager.default.fileExists(atPath: url.path) {
+            let tracks = try? await AVURLAsset(url: url).loadTracks(withMediaType: .audio)
+            if tracks?.isEmpty == false { return url }
+        }
+        return nil
+    }
+
+    static func systemAudioURL(in recording: RecordingBundle) async -> URL? {
+        let url = recording.systemAudioURL
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        let tracks = try? await AVURLAsset(url: url).loadTracks(withMediaType: .audio)
+        return tracks?.isEmpty == false ? url : nil
+    }
+
+    /// The project's audio, cut and gain-staged to match the timeline.
+    ///
+    /// Nil when the recording has no sound at all, which is an ordinary answer — a screen-only take
+    /// should not gain an empty audio track.
+    static func composition(project: StudioProject,
+                            recording: RecordingBundle) async -> (asset: AVAsset,
+                                                                  mix: AVAudioMix)? {
+        let narration = await narrationURL(in: recording)
+        let system = await systemAudioURL(in: recording)
+        guard narration != nil || system != nil else { return nil }
+
+        let composition = AVMutableComposition()
+        var parameters: [AVMutableAudioMixInputParameters] = []
+        // **The assets are held, not just their tracks.** `AVAssetTrack.asset` is a weak reference,
+        // so building one inline and keeping only the track lets the asset go — and then
+        // `insertTimeRange` fails with `-12780` and the export comes out silent, which is exactly
+        // the bug this file exists to fix.
+        var retained: [AVURLAsset] = []
+
+        for source in [(narration, false), (system, true)] {
+            guard let url = source.0 else { continue }
+            let asset = AVURLAsset(url: url)
+            retained.append(asset)
+            guard let sourceTrack = try? await asset.loadTracks(withMediaType: .audio).first,
+                  let track = composition.addMutableTrack(withMediaType: .audio,
+                                                          preferredTrackID: kCMPersistentTrackID_Invalid)
+            else { continue }
+
+            let gain = AVMutableAudioMixInputParameters(track: track)
+            // A tape-style pitch shift on a sped-up clip is what a speed change is expected to
+            // sound like; the alternative is owning a time-stretcher.
+            gain.audioTimePitchAlgorithm = .varispeed
+
+            var cursor = CMTime.zero
+            for clip in project.timeline.clips {
+                let range = CMTimeRange(
+                    start: CMTime(seconds: clip.sourceStart, preferredTimescale: 600),
+                    duration: CMTime(seconds: clip.sourceDuration, preferredTimescale: 600))
+                guard range.duration.seconds > 0 else { continue }
+
+                do {
+                    try track.insertTimeRange(range, of: sourceTrack, at: cursor)
+                } catch {
+                    // A clip whose source range runs past the end of the audio is ordinary: the
+                    // microphone can stop before the screen does. Silence is the right answer —
+                    // but it is logged, because "the export is silent" was the bug this whole
+                    // file exists to fix and a swallowed insert would recreate it exactly.
+                    let why = String(describing: error)
+                    log.error("audio: could not insert a clip's range: \(why, privacy: .public)")
+                    cursor = cursor + CMTime(seconds: clip.outputDuration, preferredTimescale: 600)
+                    continue
+                }
+
+                let inserted = CMTimeRange(start: cursor, duration: range.duration)
+                if clip.speed != 1 {
+                    track.scaleTimeRange(inserted,
+                                         toDuration: CMTime(seconds: clip.outputDuration,
+                                                            preferredTimescale: 600))
+                }
+
+                // Set at the clip's own start, so each clip's gain holds until the next changes it.
+                let level = clip.isMuted ? 0 : (source.1 ? clip.systemAudioVolume : clip.volume)
+                gain.setVolume(Float(max(0, min(1, level))), at: cursor)
+                cursor = cursor + CMTime(seconds: clip.outputDuration, preferredTimescale: 600)
+            }
+            parameters.append(gain)
+        }
+
+        // An `AVMutableCompositionTrack` exists the moment it is added, empty or not, so the
+        // presence of a track says nothing. Duration is what says whether anything went in.
+        guard composition.duration.seconds > 0 else {
+            log.error("audio: the composition came out empty, so the export would be silent")
+            return nil
+        }
+        let mix = AVMutableAudioMix()
+        mix.inputParameters = parameters
+        _ = retained
+        return (composition, mix)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -54,6 +54,11 @@ final class StudioDocumentModel: ObservableObject {
     let recordingDuration: TimeInterval
     /// When the camera track begins, in source time. Recording metadata, not a project edit.
     let cameraStartOffset: TimeInterval
+    /// Seconds hidden at the head of this take when the editor created the project, or nil.
+    ///
+    /// Set only on first creation, so the editor can *say* what it did — a trim nobody is told
+    /// about is another silent decision, which is the complaint that started all of this.
+    let trimmedLeadIn: TimeInterval?
 
     @Published private(set) var project: StudioProject
     @Published var inspector: Inspector = .canvas
@@ -110,6 +115,11 @@ final class StudioDocumentModel: ObservableObject {
     /// Whether the shortcuts sheet is up. Set from the window's ⌘/ and cleared by the sheet.
     @Published var isShowingShortcuts = false
     @Published var exportProgress: Double?
+    /// The banner offering the trimmed start-up seconds back, or nil once it has been acted on.
+    ///
+    /// Separate from `trimmedLeadIn`, which is a fact about how the project was created and never
+    /// changes. This is what is on screen.
+    @Published private(set) var leadInNotice: TimeInterval?
 
     private var undoStack: UndoStack<StudioProject>
     /// The project exactly as it opened, for "undo every edit".
@@ -133,9 +143,22 @@ final class StudioDocumentModel: ObservableObject {
             StudioProject.self,
             from: Data(contentsOf: bundle.root.appendingPathComponent("project.json")))
 
+        // **The take starts when everything is running.** A capture session needs two to three
+        // seconds to come up, so a recording with a camera or a microphone opens with a frozen
+        // face and silence — the "first three seconds" report. Trimming rather than cutting means
+        // the material is still there, one context-menu item away.
+        //
+        // Only on first creation. Re-trimming on every open would eat the same seconds again each
+        // time the editor was reopened, and would undo a deliberate "put it back".
+        let leadIn = Self.leadInWorthTrimming(offset: manifest.cameraStartOffset,
+                                              duration: manifest.duration)
+        self.trimmedLeadIn = existing == nil ? leadIn : nil
+        self.leadInNotice = self.trimmedLeadIn
+
         var project = existing ?? StudioProject(
             canvasSize: manifest.pixelSize.size,
-            timeline: Timeline(clips: [Clip(sourceStart: 0, sourceEnd: manifest.duration)]))
+            timeline: Timeline(clips: [Clip(sourceStart: leadIn ?? 0,
+                                            sourceEnd: manifest.duration)]))
 
         if existing == nil {
             // **The moment that makes this feel like magic.** Stopping a recording should open an
@@ -166,6 +189,18 @@ final class StudioDocumentModel: ObservableObject {
         player.sourceTime = { [weak self] output in
             self?.project.timeline.sourceTime(forOutput: output)?.sourceTime ?? 0
         }
+    }
+
+    /// Whether a capture offset is worth hiding.
+    ///
+    /// Under 0.15 s is not worth mentioning to anybody, and is below the threshold the timeline
+    /// already uses to decide a clip has hidden material — trimming less would offer a "put it
+    /// back" for something invisible. An offset that swallows most of the take is refused
+    /// outright: an empty timeline has nothing to play and no clip wide enough to right-click.
+    static func leadInWorthTrimming(offset: TimeInterval,
+                                    duration: TimeInterval) -> TimeInterval? {
+        guard offset > 0.15, duration - offset > 1 else { return nil }
+        return offset
     }
 
     var playhead: TimeInterval {
@@ -464,6 +499,19 @@ final class StudioDocumentModel: ObservableObject {
                                                           upper)
         }
     }
+
+    /// Puts the trimmed start-up seconds back, from the banner.
+    ///
+    /// The same `untrimClip` the timeline's context menu uses, so it is one undo step and reaches
+    /// the recording's real first frame.
+    func putBackLeadIn() {
+        leadInNotice = nil
+        guard let first = project.timeline.clips.first else { return }
+        untrimClip(first.id)
+    }
+
+    /// Agrees with the trim and wants the banner gone. Does not touch the project.
+    func dismissLeadInNotice() { leadInNotice = nil }
 
     func addZoomAtPlayhead() {
         let start = sourceTime

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -43,6 +43,8 @@ final class StudioDocumentModel: ObservableObject {
 
     let bundle: RecordingBundle
     let events: EventLog
+    /// How long the recording itself runs, which is the furthest a trim can ever be undone to.
+    let recordingDuration: TimeInterval
 
     @Published private(set) var project: StudioProject
     @Published var inspector: Inspector = .canvas
@@ -70,6 +72,7 @@ final class StudioDocumentModel: ObservableObject {
     init(bundle: RecordingBundle, manifest: RecordingManifest, events: EventLog) {
         self.bundle = bundle
         self.events = events
+        self.recordingDuration = manifest.duration
 
         let existing = try? JSONDecoder().decode(
             StudioProject.self,
@@ -215,6 +218,41 @@ final class StudioDocumentModel: ObservableObject {
         guard let selectedClip else { return }
         edit { $0.timeline = $0.timeline.delete(id: selectedClip) }
         self.selectedClip = nil
+    }
+
+    /// Moves a clip in the running order.
+    func moveClip(from index: Int, to destination: Int) {
+        edit { $0.timeline = $0.timeline.move(from: index, to: destination) }
+    }
+
+    func duplicateSelectedClip() {
+        guard let selectedClip else { return }
+        edit { $0.timeline = $0.timeline.duplicate(id: selectedClip) }
+    }
+
+    /// Live, because this is a drag: one undo step for the whole gesture.
+    func rollCut(after id: Clip.ID, by seconds: TimeInterval) {
+        editLive { $0.timeline = $0.timeline.roll(after: id, by: seconds) }
+    }
+
+    /// Puts back everything a clip's trim is hiding, both ends.
+    ///
+    /// The payoff the non-destructive model was built for: `sourceStart`/`sourceEnd` are a window,
+    /// never a cut, so the material was always still there.
+    func untrimClip(_ id: Clip.ID) {
+        edit { project in
+            guard let index = project.timeline.clips.firstIndex(where: { $0.id == id }) else {
+                return
+            }
+            // Only as far as the neighbours allow, so un-trimming cannot overlap the next shot.
+            let lower = index > 0 ? project.timeline.clips[index - 1].sourceEnd : 0
+            let upper = index + 1 < project.timeline.clips.count
+                ? project.timeline.clips[index + 1].sourceStart : self.recordingDuration
+            project.timeline.clips[index].sourceStart = min(project.timeline.clips[index].sourceStart,
+                                                            max(0, lower))
+            project.timeline.clips[index].sourceEnd = max(project.timeline.clips[index].sourceEnd,
+                                                          upper)
+        }
     }
 
     func addZoomAtPlayhead() {

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -46,8 +46,8 @@ final class StudioDocumentModel: ObservableObject {
 
     @Published private(set) var project: StudioProject
     @Published var inspector: Inspector = .canvas
-    @Published var playhead: TimeInterval = 0
-    @Published var isPlaying = false
+    /// Playback lives here rather than in a view, so nothing has to go looking for it.
+    let player: StudioPlayer
     @Published var selectedZoom: ZoomSegment.ID?
     @Published var selectedClip: Clip.ID?
     @Published private(set) var isDirty = false
@@ -85,7 +85,23 @@ final class StudioDocumentModel: ObservableObject {
 
         self.project = project
         self.undoStack = UndoStack(initial: project, depth: 200)
+        self.player = StudioPlayer(url: bundle.screenURL)
+
+        // The player needs to know how long the edit is and how to turn an output moment into a
+        // recording moment. Both change as the timeline is edited, so they are closures rather
+        // than copies.
+        player.duration = project.duration
+        player.sourceTime = { [weak self] output in
+            self?.project.timeline.sourceTime(forOutput: output)?.sourceTime ?? 0
+        }
     }
+
+    var playhead: TimeInterval {
+        get { player.playhead }
+        set { player.scrub(to: newValue) }
+    }
+
+    var isPlaying: Bool { player.isPlaying }
 
     var duration: TimeInterval { project.duration }
 
@@ -103,6 +119,7 @@ final class StudioDocumentModel: ObservableObject {
         guard updated != project else { return }
         undoStack.commit(updated)
         project = updated
+        player.duration = updated.duration
         isDirty = true
         saver.schedule(updated)
     }
@@ -196,11 +213,11 @@ final class StudioDocumentModel: ObservableObject {
     }
 
     func step(frames: Int, fps: Int = 60) {
-        playhead = min(max(0, playhead + Double(frames) / Double(fps)), max(0, duration - 0.001))
+        player.step(seconds: Double(frames) / Double(fps))
     }
 
     func step(seconds: Double) {
-        playhead = min(max(0, playhead + seconds), max(0, duration - 0.001))
+        player.step(seconds: seconds)
     }
 
     // MARK: - Trimming

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -331,6 +331,53 @@ final class StudioDocumentModel: ObservableObject {
 
     // MARK: - Masks
 
+    /// Places a click at the playhead, on the pointer.
+    ///
+    /// **The pointer's own position is the point**, because "add a click here" means the thing under
+    /// the cursor at that moment; asking the user to place it as well would be asking twice.
+    func addClickAtPlayhead() {
+        let start = sourceTime
+        guard let point = events.cursorPoint(at: start) else { return }
+        edit { $0.clickEdits.added.append(ManualClick(t: start, point: point)) }
+    }
+
+    /// Takes out the recorded click nearest the playhead, if there is one close by.
+    ///
+    /// Suppressed rather than deleted — the recording is never modified, so undo brings it back.
+    @discardableResult
+    func suppressClickNearPlayhead() -> Bool {
+        let t = sourceTime
+        let nearest = ClickTrack.effective(recorded: events.clicks, edits: project.clickEdits)
+            .filter { abs($0.t - t) <= ClickEffect.duration }
+            .min { abs($0.t - t) < abs($1.t - t) }
+        guard let nearest else { return false }
+
+        edit { edited in
+            // A hand-placed one is removed outright; there is nothing in the recording to remember.
+            if let index = edited.clickEdits.added.firstIndex(where: {
+                abs($0.t - nearest.t) <= ClickTrack.sameClickTolerance
+            }) {
+                edited.clickEdits.added.remove(at: index)
+            } else {
+                edited.clickEdits.suppressed.append(nearest.t)
+            }
+        }
+        return true
+    }
+
+    /// Dims everything around the pointer for a few seconds from the playhead.
+    func addPointerHighlightAtPlayhead() {
+        let start = sourceTime
+        edit {
+            $0.pointerHighlights.append(PointerHighlight(start: start, end: start + 3))
+            $0.pointerHighlights.sort { $0.start < $1.start }
+        }
+    }
+
+    func removePointerHighlight(_ id: PointerHighlight.ID) {
+        edit { $0.pointerHighlights.removeAll { $0.id == id } }
+    }
+
     func addMaskAtPlayhead() {
         let start = sourceTime
         let size = project.canvasSize

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -55,6 +55,14 @@ final class StudioDocumentModel: ObservableObject {
     @Published var selectedZoom: ZoomSegment.ID?
     @Published var selectedClip: Clip.ID?
     @Published var selectedText: TextOverlay.ID?
+    /// Bumped on every edit.
+    ///
+    /// **The canvas and the timeline poll this.** Both are `NSView`s that read the project inside
+    /// `draw(_:)`, and both relied on SwiftUI re-running the enclosing body and calling
+    /// `updateNSView` — which does not happen reliably, as the playhead already taught us. So an
+    /// edit made while paused did not repaint anything: adding text put nothing on screen until
+    /// playback or a scrub happened to nudge it.
+    @Published private(set) var revision = 0
     @Published private(set) var isDirty = false
     /// Whether the shortcuts sheet is up. Set from the window's ⌘/ and cleared by the sheet.
     @Published var isShowingShortcuts = false
@@ -149,6 +157,7 @@ final class StudioDocumentModel: ObservableObject {
         guard updated != project else { return }
         undoStack.commit(updated)
         project = updated
+        revision &+= 1
         player.duration = updated.duration
         isDirty = true
         saver.schedule(updated)
@@ -159,6 +168,7 @@ final class StudioDocumentModel: ObservableObject {
         var updated = project
         change(&updated)
         project = updated
+        revision &+= 1
         isDirty = true
     }
 
@@ -447,8 +457,12 @@ final class StudioDocumentModel: ObservableObject {
 
     /// Puts a line of text on the video from the playhead, and selects it for editing.
     func addTextAtPlayhead() {
-        let start = sourceTime
-        let overlay = TextOverlay(start: start, end: start + 3)
+        // **Starts a fade-length early, on purpose.** A line whose range begins exactly at the
+        // playhead is fully transparent there — the first frame of its own fade in — so asking for
+        // text "here" and seeing nothing appear is the obvious reading of a bug. Beginning slightly
+        // before means it is at full strength at the moment you asked for it.
+        let overlay = TextOverlay(start: max(0, sourceTime - TextOverlay.defaultFade),
+                                  end: sourceTime + 3)
         edit {
             $0.textOverlays.append(overlay)
             $0.textOverlays.sort { $0.start < $1.start }

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -353,4 +353,18 @@ final class StudioDocumentModel: ObservableObject {
             await MainActor.run { self?.removeSilences(envelope: envelope, sampleRate: 100) }
         }
     }
+
+    // MARK: - Camera
+
+    func addCameraSegment(_ layout: CameraSegment.Layout) {
+        let start = sourceTime
+        edit {
+            $0.cameraSegments.append(CameraSegment(start: start, end: start + 4, layout: layout))
+            $0.cameraSegments.sort { $0.start < $1.start }
+        }
+    }
+
+    func removeCameraSegment(_ id: CameraSegment.ID) {
+        edit { $0.cameraSegments.removeAll { $0.id == id } }
+    }
 }

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -388,6 +388,20 @@ final class StudioDocumentModel: ObservableObject {
         }
     }
 
+    /// Per-clip timing: speed, a held last frame, and a dip to black at its cut.
+    func updateClip(_ id: Clip.ID, live: Bool = false, _ change: (inout Clip) -> Void) {
+        let apply: ((inout StudioProject) -> Void) -> Void = live ? editLive : edit
+        apply { project in
+            guard let index = project.timeline.clips.firstIndex(where: { $0.id == id }) else {
+                return
+            }
+            change(&project.timeline.clips[index])
+            // Speed is clamped where it is defined, so going through `setSpeed` keeps one rule.
+            let speed = project.timeline.clips[index].speed
+            project.timeline = project.timeline.setSpeed(id: id, speed)
+        }
+    }
+
     /// Moves a clip in the running order.
     func moveClip(from index: Int, to destination: Int) {
         edit { $0.timeline = $0.timeline.move(from: index, to: destination) }

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -51,10 +51,16 @@ final class StudioDocumentModel: ObservableObject {
     @Published var selectedZoom: ZoomSegment.ID?
     @Published var selectedClip: Clip.ID?
     @Published private(set) var isDirty = false
-    @Published var timelineZoom: Double = 1
+    /// Whether the shortcuts sheet is up. Set from the window's ⌘/ and cleared by the sheet.
+    @Published var isShowingShortcuts = false
     @Published var exportProgress: Double?
 
     private var undoStack: UndoStack<StudioProject>
+    /// The project exactly as it opened, for "undo every edit".
+    ///
+    /// Kept here rather than read back off the undo stack, whose history is trimmed at its depth —
+    /// after two hundred edits the first state is genuinely gone from it.
+    private let originalProject: StudioProject
     private lazy var saver = CoalescingSaver<StudioProject>(
         label: "\(AppIdentity.bundleID).studio-save") { [bundle] project in
             try? JSONEncoder().encode(project)
@@ -85,6 +91,7 @@ final class StudioDocumentModel: ObservableObject {
 
         self.project = project
         self.undoStack = UndoStack(initial: project, depth: 200)
+        self.originalProject = project
         // Opened only when the recording actually has one, so a screen-only take pays for no
         // decoder. Nothing read `manifest.hasCamera` before this — which is why the camera was
         // recorded faithfully and then never shown.
@@ -148,6 +155,28 @@ final class StudioDocumentModel: ObservableObject {
 
     var canUndo: Bool { undoStack.canUndo }
     var canRedo: Bool { undoStack.canRedo }
+
+    /// What a rendered frame needs from outside the project.
+    ///
+    /// **One place, used by the live canvas and by "copy this frame".** The screenshot editor states
+    /// why next to its own equivalent: the two disagreeing about a background is a failure it has
+    /// already had once. Studio managed worse — three of these four fields were never filled at all,
+    /// so the camera and any wallpaper simply did not render.
+    var frameSources: FrameSources {
+        FrameSources(screen: player.decoded,
+                     camera: player.decodedCamera,
+                     wallpaper: FrameSources.wallpaper(for: project))
+    }
+
+    /// Puts the project back to how it opened, and leaves that on the undo stack.
+    ///
+    /// **Restores the first state rather than re-planning.** Those differ the moment somebody has
+    /// edited and then re-detected zooms, and "reset" honestly means "back to how I found it".
+    func resetEdits() {
+        guard originalProject != project else { return }
+        let original = originalProject
+        edit { $0 = original }
+    }
 
     func undo() {
         undoStack.undo()

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -12,13 +12,14 @@ import Foundation
 final class StudioDocumentModel: ObservableObject {
 
     enum Inspector: String, CaseIterable, Identifiable {
-        case canvas, cursor, camera, captions, audio, keystrokes
+        case canvas, cursor, masks, camera, captions, audio, keystrokes
 
         var id: String { rawValue }
 
         var title: String {
             switch self {
             case .canvas: return "Canvas"
+            case .masks: return "Masks"
             case .cursor: return "Cursor"
             case .camera: return "Camera"
             case .captions: return "Captions"
@@ -30,6 +31,7 @@ final class StudioDocumentModel: ObservableObject {
         var symbolName: String {
             switch self {
             case .canvas: return "rectangle.inset.filled"
+            case .masks: return "eye.slash"
             case .cursor: return "cursorarrow"
             case .camera: return "video"
             case .captions: return "captions.bubble"
@@ -199,5 +201,139 @@ final class StudioDocumentModel: ObservableObject {
 
     func step(seconds: Double) {
         playhead = min(max(0, playhead + seconds), max(0, duration - 0.001))
+    }
+
+    // MARK: - Trimming
+
+    /// Cuts the dead air out, as one undoable step.
+    ///
+    /// **A one-shot, not a live filter.** A filter would mean the timeline no longer shows what
+    /// will be exported, which breaks the promise the whole editor rests on. This inserts real
+    /// cuts the user can then adjust or undo like any other.
+    ///
+    /// - Returns: how many stretches were removed, so the caller can say so rather than appearing
+    ///   to do nothing when a recording has no silence in it.
+    @discardableResult
+    func removeSilences(envelope: [Float], sampleRate: Double) -> Int {
+        let found = SilenceDetector.silences(in: envelope, sampleRate: sampleRate)
+        guard !found.isEmpty else { return 0 }
+        edit { project in
+            // Applied back to front, so removing one stretch does not shift the next one's
+            // coordinates out from under it.
+            for range in found.reversed() {
+                project.timeline = Self.cutting(project.timeline, source: range)
+            }
+        }
+        return found.count
+    }
+
+    /// The typing runs worth offering to speed up.
+    var typingSuggestions: [TypingDetector.Suggestion] {
+        TypingDetector.runs(in: events.keys)
+    }
+
+    /// Accepts one suggestion: splits around the run and speeds the middle up.
+    func applyTypingSuggestion(_ suggestion: TypingDetector.Suggestion) {
+        edit { project in
+            project.timeline = Self.speedingUp(project.timeline,
+                                               source: suggestion.start..<suggestion.end,
+                                               speed: suggestion.suggestedSpeed)
+        }
+    }
+
+    func applyAllTypingSuggestions() {
+        let runs = typingSuggestions
+        guard !runs.isEmpty else { return }
+        edit { project in
+            for run in runs.reversed() {
+                project.timeline = Self.speedingUp(project.timeline,
+                                                   source: run.start..<run.end,
+                                                   speed: run.suggestedSpeed)
+            }
+        }
+    }
+
+    /// Removes a span of *source* time from the edit by splitting around it and deleting the middle.
+    private static func cutting(_ timeline: Timeline,
+                                source range: Range<TimeInterval>) -> Timeline {
+        guard let leading = timeline.outputTime(forSource: range.lowerBound),
+              let trailing = timeline.outputTime(forSource: range.upperBound) else {
+            return timeline
+        }
+        let afterFirst = timeline.split(at: leading)
+        guard let secondCut = afterFirst.outputTime(forSource: range.upperBound) else {
+            return afterFirst
+        }
+        let afterSecond = afterFirst.split(at: secondCut)
+        guard let middle = afterSecond.sourceTime(forOutput: (leading + trailing) / 2)?.clip else {
+            return afterSecond
+        }
+        return afterSecond.delete(id: middle.id)
+    }
+
+    /// Splits around a span of source time and sets the middle clip's speed.
+    private static func speedingUp(_ timeline: Timeline, source range: Range<TimeInterval>,
+                                   speed: Double) -> Timeline {
+        guard let leading = timeline.outputTime(forSource: range.lowerBound),
+              let trailing = timeline.outputTime(forSource: range.upperBound) else {
+            return timeline
+        }
+        let afterFirst = timeline.split(at: leading)
+        guard let secondCut = afterFirst.outputTime(forSource: range.upperBound) else {
+            return afterFirst
+        }
+        let afterSecond = afterFirst.split(at: secondCut)
+        guard let middle = afterSecond.sourceTime(forOutput: (leading + trailing) / 2)?.clip else {
+            return afterSecond
+        }
+        return afterSecond.setSpeed(id: middle.id, speed)
+    }
+
+    // MARK: - Captions
+
+    /// Runs transcription over the microphone track.
+    func transcribe(locale: Locale = .current, vocabulary: [String] = []) async throws {
+        let captions = try await Transcriber.transcribe(url: bundle.microphoneURL,
+                                                        locale: locale,
+                                                        vocabulary: vocabulary)
+        edit { $0.captions = captions }
+    }
+
+    // MARK: - Presets
+
+    func apply(_ preset: StudioPreset) {
+        edit { preset.apply(to: &$0) }
+    }
+
+    // MARK: - Masks
+
+    func addMaskAtPlayhead() {
+        let start = sourceTime
+        let size = project.canvasSize
+        edit {
+            let box = CGRect(x: size.width * 0.3, y: size.height * 0.4,
+                             width: size.width * 0.4, height: size.height * 0.15)
+            $0.masks.append(StudioMask(rects: [box], start: start, end: start + 3))
+        }
+    }
+
+    func setMaskMode(_ id: StudioMask.ID, _ mode: StudioMask.Mode) {
+        edit {
+            guard let index = $0.masks.firstIndex(where: { $0.id == id }) else { return }
+            $0.masks[index].mode = mode
+        }
+    }
+
+    func removeMask(_ id: StudioMask.ID) {
+        edit { $0.masks.removeAll { $0.id == id } }
+    }
+
+    /// Reads the microphone envelope, then cuts the dead air.
+    func removeSilencesFromMicrophone() {
+        let url = bundle.microphoneURL
+        Task { [weak self] in
+            guard let envelope = try? await AudioEnvelope.read(url: url) else { return }
+            await MainActor.run { self?.removeSilences(envelope: envelope, sampleRate: 100) }
+        }
     }
 }

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -12,7 +12,7 @@ import Foundation
 final class StudioDocumentModel: ObservableObject {
 
     enum Inspector: String, CaseIterable, Identifiable {
-        case canvas, cursor, masks, camera, captions, audio, keystrokes
+        case canvas, cursor, masks, camera, text, captions, audio, keystrokes
 
         var id: String { rawValue }
 
@@ -22,6 +22,7 @@ final class StudioDocumentModel: ObservableObject {
             case .masks: return "Masks"
             case .cursor: return "Cursor"
             case .camera: return "Camera"
+            case .text: return "Text"
             case .captions: return "Captions"
             case .audio: return "Audio"
             case .keystrokes: return "Keystrokes"
@@ -34,6 +35,7 @@ final class StudioDocumentModel: ObservableObject {
             case .masks: return "eye.slash"
             case .cursor: return "cursorarrow"
             case .camera: return "video"
+            case .text: return "textformat"
             case .captions: return "captions.bubble"
             case .audio: return "speaker.wave.2"
             case .keystrokes: return "command"
@@ -52,6 +54,7 @@ final class StudioDocumentModel: ObservableObject {
     let player: StudioPlayer
     @Published var selectedZoom: ZoomSegment.ID?
     @Published var selectedClip: Clip.ID?
+    @Published var selectedText: TextOverlay.ID?
     @Published private(set) var isDirty = false
     /// Whether the shortcuts sheet is up. Set from the window's ⌘/ and cleared by the sheet.
     @Published var isShowingShortcuts = false
@@ -440,6 +443,38 @@ final class StudioDocumentModel: ObservableObject {
             }
         }
         return true
+    }
+
+    /// Puts a line of text on the video from the playhead, and selects it for editing.
+    func addTextAtPlayhead() {
+        let start = sourceTime
+        let overlay = TextOverlay(start: start, end: start + 3)
+        edit {
+            $0.textOverlays.append(overlay)
+            $0.textOverlays.sort { $0.start < $1.start }
+        }
+        selectedText = overlay.id
+        inspector = .text
+    }
+
+    func updateText(_ id: TextOverlay.ID, _ change: (inout TextOverlay) -> Void) {
+        edit { project in
+            guard let index = project.textOverlays.firstIndex(where: { $0.id == id }) else { return }
+            change(&project.textOverlays[index])
+        }
+    }
+
+    /// Live, for a drag or a slider: one undo step for the whole gesture.
+    func updateTextLive(_ id: TextOverlay.ID, _ change: (inout TextOverlay) -> Void) {
+        editLive { project in
+            guard let index = project.textOverlays.firstIndex(where: { $0.id == id }) else { return }
+            change(&project.textOverlays[index])
+        }
+    }
+
+    func removeText(_ id: TextOverlay.ID) {
+        edit { $0.textOverlays.removeAll { $0.id == id } }
+        if selectedText == id { selectedText = nil }
     }
 
     /// Dims everything around the pointer for a few seconds from the playhead.

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -124,6 +124,16 @@ final class StudioDocumentModel: ObservableObject {
         project.timeline.sourceTime(forOutput: playhead)?.sourceTime ?? 0
     }
 
+    /// The source range of the clip the playhead is inside.
+    ///
+    /// Passed to the renderer so a zoom or a camera move that straddles a cut eases out at the cut
+    /// rather than being caught mid-ramp when the picture jumps to different material.
+    var currentClipSource: Range<TimeInterval>? {
+        guard let clip = project.timeline.sourceTime(forOutput: playhead)?.clip,
+              clip.sourceEnd > clip.sourceStart else { return nil }
+        return clip.sourceStart..<clip.sourceEnd
+    }
+
     // MARK: - Editing
 
     /// One committed change: an undo step, a redraw and a save.

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -85,7 +85,14 @@ final class StudioDocumentModel: ObservableObject {
 
         self.project = project
         self.undoStack = UndoStack(initial: project, depth: 200)
-        self.player = StudioPlayer(url: bundle.screenURL)
+        // Opened only when the recording actually has one, so a screen-only take pays for no
+        // decoder. Nothing read `manifest.hasCamera` before this — which is why the camera was
+        // recorded faithfully and then never shown.
+        let camera = manifest.hasCamera
+            && FileManager.default.fileExists(atPath: bundle.cameraURL.path)
+            ? bundle.cameraURL : nil
+        self.player = StudioPlayer(url: bundle.screenURL, cameraURL: camera,
+                                   cameraStartOffset: manifest.cameraStartOffset)
 
         // The player needs to know how long the edit is and how to turn an output moment into a
         // recording moment. Both change as the timeline is edited, so they are closures rather

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -55,6 +55,39 @@ final class StudioDocumentModel: ObservableObject {
     @Published var selectedZoom: ZoomSegment.ID?
     @Published var selectedClip: Clip.ID?
     @Published var selectedText: TextOverlay.ID?
+    @Published var selectedCamera: CameraSegment.ID?
+    @Published var selectedMask: StudioMask.ID?
+    @Published var selectedPointer: PointerHighlight.ID?
+    /// Clears every timeline selection.
+    ///
+    /// **One call rather than nilling five properties by hand at each site.** Selection used to be
+    /// two properties kept mutually exclusive by every writer remembering to nil the other, which
+    /// does not scale to the six kinds the timeline now shows.
+    func clearTimelineSelection() {
+        selectedClip = nil
+        selectedZoom = nil
+        selectedText = nil
+        selectedCamera = nil
+        selectedMask = nil
+        selectedPointer = nil
+    }
+
+    /// How many rows the timeline has, so the view can be tall enough for them.
+    var timelineRowCount: Int {
+        TimelineLayout.rows(project: project, events: events).count
+    }
+
+    /// Whatever is selected on the timeline, if anything.
+    var timelineSelection: (kind: TimelineLayout.RowKind, id: UUID)? {
+        if let selectedClip { return (.video, selectedClip) }
+        if let selectedZoom { return (.zoom, selectedZoom) }
+        if let selectedText { return (.text, selectedText) }
+        if let selectedCamera { return (.camera, selectedCamera) }
+        if let selectedMask { return (.mask, selectedMask) }
+        if let selectedPointer { return (.pointer, selectedPointer) }
+        return nil
+    }
+
     /// Bumped on every edit.
     ///
     /// **The canvas and the timeline poll this.** Both are `NSView`s that read the project inside
@@ -231,6 +264,128 @@ final class StudioDocumentModel: ObservableObject {
         guard let selectedClip else { return }
         edit { $0.timeline = $0.timeline.delete(id: selectedClip) }
         self.selectedClip = nil
+    }
+
+    // MARK: - Editing any track from the timeline
+
+    /// Moves a timeline item so it begins at `sourceStart`, keeping its length.
+    ///
+    /// **One entry point for every track**, so the timeline needs one drag handler rather than one
+    /// per kind — which is what kept masks, camera segments and pointer highlights off it
+    /// altogether. Live, because this is a drag: one undo step for the whole gesture.
+    func moveTimelineItem(_ kind: TimelineLayout.RowKind, id: UUID,
+                          toSourceStart sourceStart: TimeInterval) {
+        editLive { project in
+            let start = max(0, sourceStart)
+            switch kind {
+            case .text:
+                guard let index = project.textOverlays.firstIndex(where: { $0.id == id }) else {
+                    return
+                }
+                let length = project.textOverlays[index].end - project.textOverlays[index].start
+                project.textOverlays[index].start = start
+                project.textOverlays[index].end = start + length
+            case .zoom:
+                guard let index = project.zooms.firstIndex(where: { $0.id == id }) else { return }
+                let length = project.zooms[index].end - project.zooms[index].start
+                project.zooms[index].start = start
+                project.zooms[index].end = start + length
+                project.zooms[index].isAutomatic = false
+            case .camera:
+                guard let index = project.cameraSegments.firstIndex(where: { $0.id == id }) else {
+                    return
+                }
+                let length = project.cameraSegments[index].end
+                    - project.cameraSegments[index].start
+                project.cameraSegments[index].start = start
+                project.cameraSegments[index].end = start + length
+            case .mask:
+                guard let index = project.masks.firstIndex(where: { $0.id == id }) else { return }
+                let length = project.masks[index].end - project.masks[index].start
+                project.masks[index].start = start
+                project.masks[index].end = start + length
+            case .pointer:
+                guard let index = project.pointerHighlights
+                    .firstIndex(where: { $0.id == id }) else { return }
+                let length = project.pointerHighlights[index].end
+                    - project.pointerHighlights[index].start
+                project.pointerHighlights[index].start = start
+                project.pointerHighlights[index].end = start + length
+            case .video, .caption:
+                // A clip's place is its order, not a time; captions come from the transcript.
+                break
+            }
+        }
+    }
+
+    /// Drags one edge of a timeline item to a source moment.
+    func trimTimelineItem(_ kind: TimelineLayout.RowKind, id: UUID, leading: Bool,
+                          toSource source: TimeInterval) {
+        /// Where the edge lands, keeping the item long enough to still be grabbable afterwards.
+        /// Returns a pair rather than taking two `inout`s into the same array, which Swift refuses
+        /// as overlapping access — and rightly.
+        func moved(_ start: TimeInterval, _ end: TimeInterval,
+                   minimum: TimeInterval) -> (TimeInterval, TimeInterval) {
+            let t = max(0, source)
+            return leading ? (min(t, end - minimum), end) : (start, max(t, start + minimum))
+        }
+
+        editLive { project in
+            switch kind {
+            case .text:
+                guard let index = project.textOverlays.firstIndex(where: { $0.id == id }) else {
+                    return
+                }
+                let item = project.textOverlays[index]
+                let range = moved(item.start, item.end, minimum: TextOverlay.minimumDuration)
+                project.textOverlays[index].start = range.0
+                project.textOverlays[index].end = range.1
+            case .zoom:
+                guard let index = project.zooms.firstIndex(where: { $0.id == id }) else { return }
+                let item = project.zooms[index]
+                let range = moved(item.start, item.end, minimum: ZoomSegment.minimumDuration)
+                project.zooms[index].start = range.0
+                project.zooms[index].end = range.1
+                project.zooms[index].isAutomatic = false
+            case .camera:
+                guard let index = project.cameraSegments.firstIndex(where: { $0.id == id }) else {
+                    return
+                }
+                let item = project.cameraSegments[index]
+                let range = moved(item.start, item.end, minimum: 0.4)
+                project.cameraSegments[index].start = range.0
+                project.cameraSegments[index].end = range.1
+            case .mask:
+                guard let index = project.masks.firstIndex(where: { $0.id == id }) else { return }
+                let item = project.masks[index]
+                let range = moved(item.start, item.end, minimum: 0.4)
+                project.masks[index].start = range.0
+                project.masks[index].end = range.1
+            case .pointer:
+                guard let index = project.pointerHighlights
+                    .firstIndex(where: { $0.id == id }) else { return }
+                let item = project.pointerHighlights[index]
+                let range = moved(item.start, item.end,
+                                  minimum: PointerHighlight.minimumDuration)
+                project.pointerHighlights[index].start = range.0
+                project.pointerHighlights[index].end = range.1
+            case .video, .caption:
+                break
+            }
+        }
+    }
+
+    /// Removes whatever is selected on the timeline, whichever track it is on.
+    func deleteTimelineItem(_ kind: TimelineLayout.RowKind, id: UUID) {
+        switch kind {
+        case .text: removeText(id)
+        case .zoom: edit { $0.zooms.removeAll { $0.id == id } }
+        case .camera: removeCameraSegment(id)
+        case .mask: removeMask(id)
+        case .pointer: removePointerHighlight(id)
+        case .video: edit { $0.timeline = $0.timeline.delete(id: id) }
+        case .caption: break
+        }
     }
 
     /// Moves a clip in the running order.

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -52,6 +52,8 @@ final class StudioDocumentModel: ObservableObject {
     let events: EventLog
     /// How long the recording itself runs, which is the furthest a trim can ever be undone to.
     let recordingDuration: TimeInterval
+    /// When the camera track begins, in source time. Recording metadata, not a project edit.
+    let cameraStartOffset: TimeInterval
 
     @Published private(set) var project: StudioProject
     @Published var inspector: Inspector = .canvas
@@ -125,6 +127,7 @@ final class StudioDocumentModel: ObservableObject {
         self.bundle = bundle
         self.events = events
         self.recordingDuration = manifest.duration
+        self.cameraStartOffset = manifest.cameraStartOffset
 
         let existing = try? JSONDecoder().decode(
             StudioProject.self,

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -502,12 +502,13 @@ final class StudioDocumentModel: ObservableObject {
 
     /// Puts the trimmed start-up seconds back, from the banner.
     ///
-    /// The same `untrimClip` the timeline's context menu uses, so it is one undo step and reaches
-    /// the recording's real first frame.
+    /// **The head only.** `untrimClip` restores both ends, which is right for its context menu and
+    /// wrong here: a user who had trimmed the tail deliberately would lose the end of their edit
+    /// to a button that promised to fix the start.
     func putBackLeadIn() {
         leadInNotice = nil
-        guard let first = project.timeline.clips.first else { return }
-        untrimClip(first.id)
+        guard !project.timeline.clips.isEmpty else { return }
+        edit { $0.timeline.clips[0].sourceStart = 0 }
     }
 
     /// Agrees with the trim and wants the banner gone. Does not touch the project.

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -817,6 +817,21 @@ final class StudioDocumentModel: ObservableObject {
                              width: size.width * 0.4, height: size.height * 0.15)
             $0.masks.append(StudioMask(rects: [box], start: start, end: start + 3))
         }
+        // Selected as it appears, so its handles are on the canvas straight away. Without this a
+        // new blur arrives in the middle of the picture looking like something you cannot touch,
+        // which is precisely what was reported.
+        selectedMask = project.masks.last?.id
+        inspector = .masks
+    }
+
+    /// Mid-drag. One undo step for the whole gesture, between `beginGesture` and `endGesture`.
+    func updateMaskRectLive(_ id: StudioMask.ID, index: Int, to rect: CGRect) {
+        editLive { StudioProject.setMaskRect(&$0, id: id, index: index, to: rect) }
+    }
+
+    /// A committed change — the inspector's number fields, where there is no drag to bracket.
+    func updateMaskRect(_ id: StudioMask.ID, index: Int, to rect: CGRect) {
+        edit { StudioProject.setMaskRect(&$0, id: id, index: index, to: rect) }
     }
 
     func setMaskMode(_ id: StudioMask.ID, _ mode: StudioMask.Mode) {

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -122,6 +122,8 @@ final class StudioDocumentModel: ObservableObject {
     @Published private(set) var leadInNotice: TimeInterval?
 
     private var undoStack: UndoStack<StudioProject>
+    /// The pending soundtrack rebuild, so a burst of edits produces one.
+    private var soundtrackRebuild: Task<Void, Never>?
     /// The project exactly as it opened, for "undo every edit".
     ///
     /// Kept here rather than read back off the undo stack, whose history is trimmed at its depth —
@@ -234,12 +236,51 @@ final class StudioDocumentModel: ObservableObject {
         var updated = project
         change(&updated)
         guard updated != project else { return }
+        // Asked before the assignment, since the soundtrack is cut to the timeline and a trim, a
+        // speed change or a volume slider all make the loaded one play the previous edit.
+        let soundChanged = updated.timeline != project.timeline
         undoStack.commit(updated)
         project = updated
         revision &+= 1
         player.duration = updated.duration
         isDirty = true
         saver.schedule(updated)
+        if soundChanged { scheduleSoundtrackRebuild() }
+    }
+
+    /// Builds the project's soundtrack and hands it to the player.
+    ///
+    /// **The composition the exporter uses, so the editor cannot sound different from the file.**
+    /// `StudioAudio.composition` already cuts, gain-stages and speed-scales the audio to match the
+    /// timeline, in output time — building anything simpler for preview is how an editor starts
+    /// lying about what it will produce.
+    ///
+    /// Nil is an ordinary answer: a screen-only take gets no soundtrack and pays for nothing.
+    func prepareSoundtrack() async {
+        let snapshot = project
+        guard let (asset, mix) = await StudioAudio.composition(project: snapshot,
+                                                               recording: bundle) else {
+            player.setSoundtrack(asset: nil, mix: nil)
+            return
+        }
+        // The edit may have moved on while the composition was being read off disk. Rebuilding is
+        // cheaper than playing the wrong one, and `scheduleSoundtrackRebuild` will come back.
+        guard snapshot.timeline == project.timeline else { return }
+        player.setSoundtrack(asset: asset, mix: mix)
+    }
+
+    /// Rebuilds the soundtrack after the edit settles.
+    ///
+    /// Debounced because composing reads the source assets, and because a volume slider being
+    /// dragged would otherwise ask for a hundred of them.
+    func scheduleSoundtrackRebuild() {
+        soundtrackRebuild?.cancel()
+        let work = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            guard !Task.isCancelled else { return }
+            await self?.prepareSoundtrack()
+        }
+        soundtrackRebuild = work
     }
 
     /// A change mid-gesture. Not an undo step — dragging a slider should cost one, not fifty.
@@ -256,6 +297,9 @@ final class StudioDocumentModel: ObservableObject {
     func endGesture() {
         undoStack.endTransaction(project)
         saver.schedule(project)
+        // A gesture goes through `editLive`, which deliberately skips the rebuild so dragging a
+        // clip edge does not recompose the audio sixty times a second. It happens once, here.
+        scheduleSoundtrackRebuild()
     }
 
     var canUndo: Bool { undoStack.canUndo }

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -677,8 +677,11 @@ final class StudioDocumentModel: ObservableObject {
             return false
         }
 
-        let start = sourceTime
-        let overlay = MediaOverlay(start: start, end: start + 4, asset: name)
+        // A fade-length early, for the same reason text is: an overlay whose range begins exactly
+        // at the playhead is fully transparent there, so asking for a picture "here" and seeing
+        // nothing appear reads as a bug.
+        let overlay = MediaOverlay(start: max(0, sourceTime - MediaOverlay.defaultFade),
+                                   end: sourceTime + 4, asset: name)
         edit {
             $0.mediaOverlays.append(overlay)
             $0.mediaOverlays.sort { $0.start < $1.start }

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -1,0 +1,203 @@
+import AVFoundation
+import Combine
+import CoreGraphics
+import Foundation
+
+/// The editor's state for one project.
+///
+/// Modelled on `EditorDocumentModel`: a value-type document under an `UndoStack`, with the live
+/// interaction state alongside it. The project is geometry and numbers — never bitmaps — so
+/// snapshot undo stays cheap at any depth.
+@MainActor
+final class StudioDocumentModel: ObservableObject {
+
+    enum Inspector: String, CaseIterable, Identifiable {
+        case canvas, cursor, camera, captions, audio, keystrokes
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .canvas: return "Canvas"
+            case .cursor: return "Cursor"
+            case .camera: return "Camera"
+            case .captions: return "Captions"
+            case .audio: return "Audio"
+            case .keystrokes: return "Keystrokes"
+            }
+        }
+
+        var symbolName: String {
+            switch self {
+            case .canvas: return "rectangle.inset.filled"
+            case .cursor: return "cursorarrow"
+            case .camera: return "video"
+            case .captions: return "captions.bubble"
+            case .audio: return "speaker.wave.2"
+            case .keystrokes: return "command"
+            }
+        }
+    }
+
+    let bundle: RecordingBundle
+    let events: EventLog
+
+    @Published private(set) var project: StudioProject
+    @Published var inspector: Inspector = .canvas
+    @Published var playhead: TimeInterval = 0
+    @Published var isPlaying = false
+    @Published var selectedZoom: ZoomSegment.ID?
+    @Published var selectedClip: Clip.ID?
+    @Published private(set) var isDirty = false
+    @Published var timelineZoom: Double = 1
+    @Published var exportProgress: Double?
+
+    private var undoStack: UndoStack<StudioProject>
+    private lazy var saver = CoalescingSaver<StudioProject>(
+        label: "\(AppIdentity.bundleID).studio-save") { [bundle] project in
+            try? JSONEncoder().encode(project)
+                .write(to: bundle.root.appendingPathComponent("project.json"), options: .atomic)
+        }
+
+    init(bundle: RecordingBundle, manifest: RecordingManifest, events: EventLog) {
+        self.bundle = bundle
+        self.events = events
+
+        let existing = try? JSONDecoder().decode(
+            StudioProject.self,
+            from: Data(contentsOf: bundle.root.appendingPathComponent("project.json")))
+
+        var project = existing ?? StudioProject(
+            canvasSize: manifest.pixelSize.size,
+            timeline: Timeline(clips: [Clip(sourceStart: 0, sourceEnd: manifest.duration)]))
+
+        if existing == nil {
+            // **The moment that makes this feel like magic.** Stopping a recording should open an
+            // editor whose answer is already good: the zooms found, a background chosen from the
+            // recording's own colours, padding set. Anything else asks the user to do work before
+            // they can see whether the recording was any use.
+            project.zooms = ZoomPlanner.plan(events: events,
+                                             frameSize: manifest.pixelSize.size,
+                                             duration: manifest.duration)
+        }
+
+        self.project = project
+        self.undoStack = UndoStack(initial: project, depth: 200)
+    }
+
+    var duration: TimeInterval { project.duration }
+
+    /// The recording moment currently under the playhead.
+    var sourceTime: TimeInterval {
+        project.timeline.sourceTime(forOutput: playhead)?.sourceTime ?? 0
+    }
+
+    // MARK: - Editing
+
+    /// One committed change: an undo step, a redraw and a save.
+    func edit(_ change: (inout StudioProject) -> Void) {
+        var updated = project
+        change(&updated)
+        guard updated != project else { return }
+        undoStack.commit(updated)
+        project = updated
+        isDirty = true
+        saver.schedule(updated)
+    }
+
+    /// A change mid-gesture. Not an undo step — dragging a slider should cost one, not fifty.
+    func editLive(_ change: (inout StudioProject) -> Void) {
+        var updated = project
+        change(&updated)
+        project = updated
+        isDirty = true
+    }
+
+    func beginGesture() { undoStack.beginTransaction() }
+
+    func endGesture() {
+        undoStack.endTransaction(project)
+        saver.schedule(project)
+    }
+
+    var canUndo: Bool { undoStack.canUndo }
+    var canRedo: Bool { undoStack.canRedo }
+
+    func undo() {
+        undoStack.undo()
+        project = undoStack.current
+        saver.schedule(project)
+    }
+
+    func redo() {
+        undoStack.redo()
+        project = undoStack.current
+        saver.schedule(project)
+    }
+
+    func markSaved() {
+        isDirty = false
+        saver.flush()
+    }
+
+    // MARK: - Timeline
+
+    func split() {
+        edit { $0.timeline = $0.timeline.split(at: playhead) }
+    }
+
+    func deleteSelectedClip() {
+        guard let selectedClip else { return }
+        edit { $0.timeline = $0.timeline.delete(id: selectedClip) }
+        self.selectedClip = nil
+    }
+
+    func addZoomAtPlayhead() {
+        let start = sourceTime
+        edit {
+            var segment = ZoomSegment(start: start, end: start + 3, level: 2,
+                                      anchor: .fixed(CGPoint(x: 0.5, y: 0.5)))
+            segment.isAutomatic = false
+            $0.zooms.append(segment)
+            $0.zooms.sort { $0.start < $1.start }
+        }
+    }
+
+    func setLevelOfSelectedZoom(_ level: Double) {
+        guard let selectedZoom else { return }
+        edit {
+            guard let index = $0.zooms.firstIndex(where: { $0.id == selectedZoom }) else { return }
+            $0.zooms[index].level = min(max(level, ZoomSegment.levelRange.lowerBound),
+                                        ZoomSegment.levelRange.upperBound)
+        }
+    }
+
+    func deleteSelectedZoom() {
+        guard let selectedZoom else { return }
+        edit { $0.zooms.removeAll { $0.id == selectedZoom } }
+        self.selectedZoom = nil
+    }
+
+    /// Replaces the generated segments and leaves hand-made ones alone.
+    ///
+    /// `isAutomatic` exists precisely so this button can be pressed twice without destroying the
+    /// user's own work — which is the difference between a useful action and a trap.
+    func redetectZooms() {
+        let log = events
+        let size = project.canvasSize
+        let length = duration
+        edit {
+            let manual = $0.zooms.filter { !$0.isAutomatic }
+            let found = ZoomPlanner.plan(events: log, frameSize: size, duration: length)
+            $0.zooms = (manual + found).sorted { $0.start < $1.start }
+        }
+    }
+
+    func step(frames: Int, fps: Int = 60) {
+        playhead = min(max(0, playhead + Double(frames) / Double(fps)), max(0, duration - 0.001))
+    }
+
+    func step(seconds: Double) {
+        playhead = min(max(0, playhead + seconds), max(0, duration - 0.001))
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioDocumentModel.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import Combine
 import CoreGraphics
 import Foundation
+import os
 
 /// The editor's state for one project.
 ///
@@ -12,7 +13,7 @@ import Foundation
 final class StudioDocumentModel: ObservableObject {
 
     enum Inspector: String, CaseIterable, Identifiable {
-        case canvas, cursor, masks, camera, text, captions, audio, keystrokes
+        case canvas, cursor, masks, camera, text, media, captions, audio, keystrokes
 
         var id: String { rawValue }
 
@@ -23,6 +24,7 @@ final class StudioDocumentModel: ObservableObject {
             case .cursor: return "Cursor"
             case .camera: return "Camera"
             case .text: return "Text"
+            case .media: return "Pictures"
             case .captions: return "Captions"
             case .audio: return "Audio"
             case .keystrokes: return "Keystrokes"
@@ -36,12 +38,15 @@ final class StudioDocumentModel: ObservableObject {
             case .cursor: return "cursorarrow"
             case .camera: return "video"
             case .text: return "textformat"
+            case .media: return "photo"
             case .captions: return "captions.bubble"
             case .audio: return "speaker.wave.2"
             case .keystrokes: return "command"
             }
         }
     }
+
+    private let log = Logger(subsystem: AppIdentity.logSubsystem, category: "Studio")
 
     let bundle: RecordingBundle
     let events: EventLog
@@ -58,6 +63,7 @@ final class StudioDocumentModel: ObservableObject {
     @Published var selectedCamera: CameraSegment.ID?
     @Published var selectedMask: StudioMask.ID?
     @Published var selectedPointer: PointerHighlight.ID?
+    @Published var selectedMedia: MediaOverlay.ID?
     /// Clears every timeline selection.
     ///
     /// **One call rather than nilling five properties by hand at each site.** Selection used to be
@@ -70,6 +76,7 @@ final class StudioDocumentModel: ObservableObject {
         selectedCamera = nil
         selectedMask = nil
         selectedPointer = nil
+        selectedMedia = nil
     }
 
     /// How many rows the timeline has, so the view can be tall enough for them.
@@ -85,6 +92,7 @@ final class StudioDocumentModel: ObservableObject {
         if let selectedCamera { return (.camera, selectedCamera) }
         if let selectedMask { return (.mask, selectedMask) }
         if let selectedPointer { return (.pointer, selectedPointer) }
+        if let selectedMedia { return (.media, selectedMedia) }
         return nil
     }
 
@@ -224,7 +232,8 @@ final class StudioDocumentModel: ObservableObject {
     var frameSources: FrameSources {
         FrameSources(screen: player.decoded,
                      camera: player.decodedCamera,
-                     wallpaper: FrameSources.wallpaper(for: project))
+                     wallpaper: FrameSources.wallpaper(for: project),
+                     media: MediaStore.shared.images(for: project, in: bundle))
     }
 
     /// Puts the project back to how it opened, and leaves that on the undo stack.
@@ -311,6 +320,13 @@ final class StudioDocumentModel: ObservableObject {
                     - project.pointerHighlights[index].start
                 project.pointerHighlights[index].start = start
                 project.pointerHighlights[index].end = start + length
+            case .media:
+                guard let index = project.mediaOverlays.firstIndex(where: { $0.id == id }) else {
+                    return
+                }
+                let length = project.mediaOverlays[index].end - project.mediaOverlays[index].start
+                project.mediaOverlays[index].start = start
+                project.mediaOverlays[index].end = start + length
             case .video, .caption:
                 // A clip's place is its order, not a time; captions come from the transcript.
                 break
@@ -369,6 +385,14 @@ final class StudioDocumentModel: ObservableObject {
                                   minimum: PointerHighlight.minimumDuration)
                 project.pointerHighlights[index].start = range.0
                 project.pointerHighlights[index].end = range.1
+            case .media:
+                guard let index = project.mediaOverlays.firstIndex(where: { $0.id == id }) else {
+                    return
+                }
+                let item = project.mediaOverlays[index]
+                let range = moved(item.start, item.end, minimum: MediaOverlay.minimumDuration)
+                project.mediaOverlays[index].start = range.0
+                project.mediaOverlays[index].end = range.1
             case .video, .caption:
                 break
             }
@@ -383,6 +407,7 @@ final class StudioDocumentModel: ObservableObject {
         case .camera: removeCameraSegment(id)
         case .mask: removeMask(id)
         case .pointer: removePointerHighlight(id)
+        case .media: removeMedia(id)
         case .video: edit { $0.timeline = $0.timeline.delete(id: id) }
         case .caption: break
         }
@@ -622,6 +647,62 @@ final class StudioDocumentModel: ObservableObject {
             }
         }
         return true
+    }
+
+    /// Copies a picture into the bundle and puts it on the video from the playhead.
+    ///
+    /// **Copied, not referenced.** A project pointing at a file on somebody's Desktop stops working
+    /// the moment that file moves and cannot be opened on another Mac at all — the same reason the
+    /// recording itself lives in the package.
+    ///
+    /// - Returns: false if the file could not be read or copied, so the caller can say so.
+    @discardableResult
+    func addMediaAtPlayhead(from url: URL) -> Bool {
+        let directory = bundle.mediaDirectory
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        // A name that cannot collide with one already there, keeping the extension so the loader
+        // can still tell what it is.
+        let name = "\(UUID().uuidString).\(url.pathExtension.lowercased())"
+        let destination = directory.appendingPathComponent(name)
+        do {
+            try FileManager.default.copyItem(at: url, to: destination)
+        } catch {
+            log.error("could not bring in \(url.lastPathComponent, privacy: .public)")
+            return false
+        }
+        guard MediaStore.shared.image(at: destination) != nil else {
+            try? FileManager.default.removeItem(at: destination)
+            log.error("brought in a file that is not a picture we can read")
+            return false
+        }
+
+        let start = sourceTime
+        let overlay = MediaOverlay(start: start, end: start + 4, asset: name)
+        edit {
+            $0.mediaOverlays.append(overlay)
+            $0.mediaOverlays.sort { $0.start < $1.start }
+        }
+        selectedMedia = overlay.id
+        inspector = .media
+        return true
+    }
+
+    func updateMedia(_ id: MediaOverlay.ID, live: Bool = false,
+                     _ change: (inout MediaOverlay) -> Void) {
+        let apply: ((inout StudioProject) -> Void) -> Void = live ? editLive : edit
+        apply { project in
+            guard let index = project.mediaOverlays.firstIndex(where: { $0.id == id }) else {
+                return
+            }
+            change(&project.mediaOverlays[index])
+        }
+    }
+
+    /// Removes the overlay. The file stays in the bundle, so undo can bring it back.
+    func removeMedia(_ id: MediaOverlay.ID) {
+        edit { $0.mediaOverlays.removeAll { $0.id == id } }
+        if selectedMedia == id { selectedMedia = nil }
     }
 
     /// Puts a line of text on the video from the playhead, and selects it for editing.

--- a/Sources/Sarvkrit/Features/Studio/StudioEditorCommand.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioEditorCommand.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// An editor action, addressable by name.
+///
+/// **So the editor's edits can be driven without a mouse.** Every round of this feature's bugs has
+/// been reported against something behind a click — the Play button, the scrubber, the Export panel
+/// — and none could be reproduced here, because this machine refuses synthetic input. Naming the
+/// actions makes them scriptable, which is also what somebody binding "split at the playhead" to a
+/// Stream Deck key wants.
+///
+/// Deliberately a small, flat list rather than a mirror of `StudioKeyRouting.Action`: the actions
+/// with associated values (a shuttle direction, a zoom level) do not belong in a URL.
+enum StudioEditorCommand: String, CaseIterable, Equatable {
+    case split
+    case duplicateClip = "duplicate-clip"
+    case deleteSelection = "delete"
+    case addZoom = "add-zoom"
+    case addText = "add-text"
+    case addClick = "add-click"
+    case addPointerHighlight = "add-pointer-highlight"
+    case undo
+    case redo
+    case resetEdits = "reset"
+}

--- a/Sources/Sarvkrit/Features/Studio/StudioEditorCommand.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioEditorCommand.swift
@@ -18,6 +18,10 @@ enum StudioEditorCommand: String, CaseIterable, Equatable {
     case addText = "add-text"
     case addClick = "add-click"
     case addPointerHighlight = "add-pointer-highlight"
+    case addMask = "add-mask"
+    /// Closes the editor, exactly as ⌘W does — including the autosave and the notice that says
+    /// the recording was kept. So "export it and put it away" is one script.
+    case close
     case undo
     case redo
     case resetEdits = "reset"

--- a/Sources/Sarvkrit/Features/Studio/StudioEditorCommand.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioEditorCommand.swift
@@ -22,6 +22,8 @@ enum StudioEditorCommand: String, CaseIterable, Equatable {
     /// Closes the editor, exactly as ⌘W does — including the autosave and the notice that says
     /// the recording was kept. So "export it and put it away" is one script.
     case close
+    /// Opens the export dialog, as the Export button does.
+    case export
     case undo
     case redo
     case resetEdits = "reset"

--- a/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
@@ -24,6 +24,11 @@ actor StudioExporter {
 
     private var isCancelled = false
 
+    /// **One exporter, one export.** `export` used to clear this flag on entry, which quietly
+    /// dropped any Cancel that arrived while the asset was being read and the writer built — a
+    /// window of real duration, and exactly when somebody who mis-clicked Export would press it.
+    /// The caller makes a fresh exporter per run instead, so there is no flag to reset and no race
+    /// to lose.
     func cancel() { isCancelled = true }
 
     /// - Parameter onProgress: called on an arbitrary executor; hop to the main actor to show it.
@@ -33,7 +38,7 @@ actor StudioExporter {
                 preset: ExportPreset,
                 to destination: URL,
                 onProgress: @Sendable @escaping (Progress) -> Void) async throws {
-        isCancelled = false
+        guard !isCancelled else { throw ExportError.cancelled }
 
         let asset = AVURLAsset(url: recording.screenURL)
         guard let track = try await asset.loadTracks(withMediaType: .video).first else {

--- a/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
@@ -95,6 +95,9 @@ actor StudioExporter {
         // Resolved once, on the main actor, and by the same helper the live canvas uses — the two
         // disagreeing about a background is a failure this app has already had.
         let wallpaper = await MainActor.run { FrameSources.wallpaper(for: project) }
+        // Loaded once, before the loop. The store caches, so the canvas and the export share the
+        // same decoded pictures rather than each holding their own copy.
+        let media = MediaStore.shared.images(for: project, in: recording)
 
         try? FileManager.default.removeItem(at: destination)
         let writer = try AVAssetWriter(outputURL: destination,
@@ -211,7 +214,8 @@ actor StudioExporter {
                                              events: events,
                                              sources: FrameSources(screen: decoded,
                                                                    camera: decodedCamera,
-                                                                   wallpaper: wallpaper),
+                                                                   wallpaper: wallpaper,
+                                                                   media: media),
                                              cache: cache,
                                              clipSource: placed.clip.sourceEnd
                                                  > placed.clip.sourceStart

--- a/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
@@ -216,7 +216,8 @@ actor StudioExporter {
                                              clipSource: placed.clip.sourceEnd
                                                  > placed.clip.sourceStart
                                                  ? placed.clip.sourceStart..<placed.clip.sourceEnd
-                                                 : nil)
+                                                 : nil,
+                                             outputTime: outputTime)
             guard let frame, let buffer = Self.buffer(from: frame, size: output,
                                                       pool: adaptor.pixelBufferPool) else {
                 continue

--- a/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
@@ -126,7 +126,12 @@ actor StudioExporter {
                 AVEncoderBitRateKey: 128_000,
             ]
             let track = AVAssetWriterInput(mediaType: .audio, outputSettings: settings)
-            track.expectsMediaDataInRealTime = false
+            // **True, and not for the usual reason.** With this false the writer holds
+            // `isReadyForMoreMediaData` down on *every* input to force interleaving between them,
+            // and since this track is written in one pass rather than alternating with the video,
+            // that is a deadlock: the audio waits for video that has not started. True tells the
+            // writer not to hold data back for another track's sake.
+            track.expectsMediaDataInRealTime = true
             if writer.canAdd(track) {
                 writer.add(track)
                 audioInput = track
@@ -136,11 +141,21 @@ actor StudioExporter {
         }
 
         guard writer.startWriting(), reader.startReading() else { throw ExportError.cannotWrite }
+
         if let cameraReader, !cameraReader.startReading() {
             // Not fatal: a camera that cannot be read costs the picture-in-picture, not the export.
             cameraReaderOutput = nil
         }
         writer.startSession(atSourceTime: .zero)
+
+        // **Written first, and finished before a single frame goes in.** An `AVAssetWriter` with two
+        // open inputs will not let either run ahead of the other, so writing every frame and then
+        // every sample deadlocks: the video input spins on `isReadyForMoreMediaData` waiting for
+        // audio that the loop below has not reached yet. Closing this track first leaves the video
+        // pass with nothing to wait for. Found by an export that sat at zero bytes for two minutes.
+        if let audioInput, let audio {
+            try await writeAudio(audio, to: audioInput)
+        }
 
         let duration = project.duration
         let total = max(1, Int(duration * Double(fps)))
@@ -217,11 +232,6 @@ actor StudioExporter {
         }
 
         input.markAsFinished()
-
-        if let audioInput, let audio {
-            try await writeAudio(audio, to: audioInput)
-        }
-
         await writer.finishWriting()
         reader.cancelReading()
         guard writer.status == .completed else { throw ExportError.cannotWrite }

--- a/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
@@ -1,0 +1,186 @@
+import AVFoundation
+import VideoToolbox
+import CoreGraphics
+import Foundation
+
+/// Turning a project into a file.
+///
+/// **Drives the same `StudioRenderer` the preview does.** There is no second code path, which is
+/// the only way "the export matches what I saw" can be true rather than aspirational —
+/// `AnnotationRenderer` makes the same promise on the screenshot side with the same structure.
+actor StudioExporter {
+
+    struct Progress: Equatable {
+        var completed: Int
+        var total: Int
+        var fraction: Double { total > 0 ? Double(completed) / Double(total) : 0 }
+    }
+
+    enum ExportError: Error, Equatable {
+        case cannotRead
+        case cannotWrite
+        case cancelled
+    }
+
+    private var isCancelled = false
+
+    func cancel() { isCancelled = true }
+
+    /// - Parameter onProgress: called on an arbitrary executor; hop to the main actor to show it.
+    func export(project: StudioProject,
+                events: EventLog,
+                recording: RecordingBundle,
+                preset: ExportPreset,
+                to destination: URL,
+                onProgress: @Sendable @escaping (Progress) -> Void) async throws {
+        isCancelled = false
+
+        let asset = AVURLAsset(url: recording.screenURL)
+        guard let track = try await asset.loadTracks(withMediaType: .video).first else {
+            throw ExportError.cannotRead
+        }
+
+        let (canvas, _) = StudioRenderer.layout(for: project)
+        let output = preset.outputSize(forCanvas: canvas)
+        let fps = preset.fps
+
+        // Sequential, so a reader is exactly the right tool here — unlike the preview, which has to
+        // seek and therefore cannot use one.
+        let reader = try AVAssetReader(asset: asset)
+        let readerOutput = AVAssetReaderTrackOutput(
+            track: track,
+            outputSettings: [kCVPixelBufferPixelFormatTypeKey as String:
+                                kCVPixelFormatType_32BGRA])
+        readerOutput.alwaysCopiesSampleData = false
+        reader.add(readerOutput)
+
+        try? FileManager.default.removeItem(at: destination)
+        let writer = try AVAssetWriter(outputURL: destination,
+                                       fileType: preset.codec == .proRes422 ? .mov : .mp4)
+        let input = AVAssetWriterInput(mediaType: .video,
+                                       outputSettings: settings(preset: preset, size: output))
+        input.expectsMediaDataInRealTime = false
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                kCVPixelBufferWidthKey as String: Int(output.width),
+                kCVPixelBufferHeightKey as String: Int(output.height),
+            ])
+        guard writer.canAdd(input) else { throw ExportError.cannotWrite }
+        writer.add(input)
+
+        guard writer.startWriting(), reader.startReading() else { throw ExportError.cannotWrite }
+        writer.startSession(atSourceTime: .zero)
+
+        let duration = project.duration
+        let total = max(1, Int(duration * Double(fps)))
+        let cache = StudioRenderer.Cache()
+        var decoded: CGImage?
+        var decodedUntil: TimeInterval = -1
+
+        for index in 0..<total {
+            if isCancelled {
+                reader.cancelReading()
+                input.markAsFinished()
+                await writer.finishWriting()
+                // A cancelled export leaves nothing behind. A half-written file that looks finished
+                // is worse than no file.
+                try? FileManager.default.removeItem(at: destination)
+                throw ExportError.cancelled
+            }
+
+            let outputTime = Double(index) / Double(fps)
+            guard let placed = project.timeline.sourceTime(forOutput: outputTime) else { break }
+
+            // The reader hands frames back in order, so it is pulled forward until it reaches the
+            // source moment this output frame needs. A speed-up consumes several; a slow-down
+            // reuses one.
+            while decodedUntil < placed.sourceTime,
+                  let sample = readerOutput.copyNextSampleBuffer() {
+                decodedUntil = CMTimeGetSeconds(CMSampleBufferGetPresentationTimeStamp(sample))
+                if let buffer = CMSampleBufferGetImageBuffer(sample) {
+                    decoded = Self.image(from: buffer)
+                }
+            }
+
+            let frame = StudioRenderer.frame(of: project, atSource: placed.sourceTime,
+                                             events: events,
+                                             sources: FrameSources(screen: decoded),
+                                             cache: cache)
+            guard let frame, let buffer = Self.buffer(from: frame, size: output,
+                                                      pool: adaptor.pixelBufferPool) else {
+                continue
+            }
+
+            while !input.isReadyForMoreMediaData {
+                try? await Task.sleep(nanoseconds: 2_000_000)
+            }
+            adaptor.append(buffer,
+                           withPresentationTime: CMTime(value: CMTimeValue(index),
+                                                        timescale: CMTimeScale(fps)))
+            onProgress(Progress(completed: index + 1, total: total))
+        }
+
+        input.markAsFinished()
+        await writer.finishWriting()
+        reader.cancelReading()
+        guard writer.status == .completed else { throw ExportError.cannotWrite }
+    }
+
+    private func settings(preset: ExportPreset, size: CGSize) -> [String: Any] {
+        var codec: AVVideoCodecType
+        switch preset.codec {
+        case .h264: codec = .h264
+        case .hevc: codec = .hevc
+        case .proRes422: codec = .proRes422
+        case .gif: codec = .h264
+        }
+        var settings: [String: Any] = [
+            AVVideoCodecKey: codec,
+            AVVideoWidthKey: Int(size.width),
+            AVVideoHeightKey: Int(size.height),
+        ]
+        if preset.codec == .h264 || preset.codec == .hevc {
+            settings[AVVideoCompressionPropertiesKey] = [
+                AVVideoAverageBitRateKey: Int(size.width * size.height) * 8,
+                AVVideoExpectedSourceFrameRateKey: preset.fps,
+            ]
+        }
+        return settings
+    }
+
+    private static func image(from buffer: CVPixelBuffer) -> CGImage? {
+        var image: CGImage?
+        VTCreateCGImageFromCVPixelBuffer(buffer, options: nil, imageOut: &image)
+        return image
+    }
+
+    private static func buffer(from image: CGImage, size: CGSize,
+                               pool: CVPixelBufferPool?) -> CVPixelBuffer? {
+        var buffer: CVPixelBuffer?
+        if let pool {
+            CVPixelBufferPoolCreatePixelBuffer(nil, pool, &buffer)
+        }
+        if buffer == nil {
+            CVPixelBufferCreate(nil, Int(size.width), Int(size.height),
+                                kCVPixelFormatType_32BGRA,
+                                [kCVPixelBufferCGImageCompatibilityKey: true] as CFDictionary,
+                                &buffer)
+        }
+        guard let buffer else { return nil }
+
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+        guard let context = CGContext(
+            data: CVPixelBufferGetBaseAddress(buffer),
+            width: CVPixelBufferGetWidth(buffer), height: CVPixelBufferGetHeight(buffer),
+            bitsPerComponent: 8, bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                | CGBitmapInfo.byteOrder32Little.rawValue) else { return nil }
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(origin: .zero, size: size))
+        return buffer
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
@@ -221,7 +221,8 @@ actor StudioExporter {
                                                  > placed.clip.sourceStart
                                                  ? placed.clip.sourceStart..<placed.clip.sourceEnd
                                                  : nil,
-                                             outputTime: outputTime)
+                                             outputTime: outputTime,
+                                             cameraStart: cameraStartOffset)
             guard let frame, let buffer = Self.buffer(from: frame, size: output,
                                                       pool: adaptor.pixelBufferPool) else {
                 continue

--- a/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
@@ -59,6 +59,40 @@ actor StudioExporter {
         readerOutput.alwaysCopiesSampleData = false
         reader.add(readerOutput)
 
+        // **The camera, read the same way.** Forward-only, pulled along to the moment each output
+        // frame needs — exactly as the screen is. Until now the exporter never opened this file at
+        // all, so a recording with a camera exported without one and nothing said why.
+        var cameraReaderOutput: AVAssetReaderTrackOutput?
+        var cameraReader: AVAssetReader?
+        var cameraStartOffset: TimeInterval = 0
+        var cameraDuration: TimeInterval = 0
+        var decodedCamera: CGImage?
+        var cameraDecodedUntil: TimeInterval = -1
+
+        if let manifest = try? recording.readManifest(), manifest.hasCamera,
+           FileManager.default.fileExists(atPath: recording.cameraURL.path) {
+            let cameraAsset = AVURLAsset(url: recording.cameraURL)
+            if let cameraTrack = try? await cameraAsset.loadTracks(withMediaType: .video).first {
+                cameraStartOffset = manifest.cameraStartOffset
+                cameraDuration = ((try? await cameraAsset.load(.duration))?.seconds).map {
+                    $0.isFinite ? $0 : 0
+                } ?? 0
+                let reader = try AVAssetReader(asset: cameraAsset)
+                let trackOutput = AVAssetReaderTrackOutput(
+                    track: cameraTrack,
+                    outputSettings: [kCVPixelBufferPixelFormatTypeKey as String:
+                                        kCVPixelFormatType_32BGRA])
+                trackOutput.alwaysCopiesSampleData = false
+                reader.add(trackOutput)
+                cameraReader = reader
+                cameraReaderOutput = trackOutput
+            }
+        }
+
+        // Resolved once, on the main actor, and by the same helper the live canvas uses — the two
+        // disagreeing about a background is a failure this app has already had.
+        let wallpaper = await MainActor.run { FrameSources.wallpaper(for: project) }
+
         try? FileManager.default.removeItem(at: destination)
         let writer = try AVAssetWriter(outputURL: destination,
                                        fileType: preset.codec == .proRes422 ? .mov : .mp4)
@@ -76,6 +110,10 @@ actor StudioExporter {
         writer.add(input)
 
         guard writer.startWriting(), reader.startReading() else { throw ExportError.cannotWrite }
+        if let cameraReader, !cameraReader.startReading() {
+            // Not fatal: a camera that cannot be read costs the picture-in-picture, not the export.
+            cameraReaderOutput = nil
+        }
         writer.startSession(atSourceTime: .zero)
 
         let duration = project.duration
@@ -109,9 +147,30 @@ actor StudioExporter {
                 }
             }
 
+            if let cameraReaderOutput {
+                // Nil outside the camera's own span — it starts after the screen and can stop
+                // before it — and the renderer draws nothing for a nil image.
+                if let wanted = PlaybackClock.cameraTime(forSource: placed.sourceTime,
+                                                         startOffset: cameraStartOffset,
+                                                         cameraDuration: cameraDuration) {
+                    while cameraDecodedUntil < wanted,
+                          let sample = cameraReaderOutput.copyNextSampleBuffer() {
+                        cameraDecodedUntil = CMTimeGetSeconds(
+                            CMSampleBufferGetPresentationTimeStamp(sample))
+                        if let buffer = CMSampleBufferGetImageBuffer(sample) {
+                            decodedCamera = Self.image(from: buffer)
+                        }
+                    }
+                } else {
+                    decodedCamera = nil
+                }
+            }
+
             let frame = StudioRenderer.frame(of: project, atSource: placed.sourceTime,
                                              events: events,
-                                             sources: FrameSources(screen: decoded),
+                                             sources: FrameSources(screen: decoded,
+                                                                   camera: decodedCamera,
+                                                                   wallpaper: wallpaper),
                                              cache: cache)
             guard let frame, let buffer = Self.buffer(from: frame, size: output,
                                                       pool: adaptor.pixelBufferPool) else {

--- a/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import VideoToolbox
 import CoreGraphics
 import Foundation
+import os
 
 /// Turning a project into a file.
 ///
@@ -9,6 +10,8 @@ import Foundation
 /// the only way "the export matches what I saw" can be true rather than aspirational —
 /// `AnnotationRenderer` makes the same promise on the screenshot side with the same structure.
 actor StudioExporter {
+
+    private let log = Logger(subsystem: AppIdentity.logSubsystem, category: "Studio")
 
     struct Progress: Equatable {
         var completed: Int
@@ -109,6 +112,29 @@ actor StudioExporter {
         guard writer.canAdd(input) else { throw ExportError.cannotWrite }
         writer.add(input)
 
+        // **The soundtrack.** Added before writing starts, because an `AVAssetWriter` will not take
+        // a new input once it has. Nil when the recording genuinely has no sound, so a screen-only
+        // take does not gain an empty track.
+        let audio = await StudioAudio.composition(project: project, recording: recording)
+        var audioInput: AVAssetWriterInput?
+        log.info("export: audio composition \(audio == nil ? "absent" : "built", privacy: .public)")
+        if audio != nil {
+            let settings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatMPEG4AAC,
+                AVSampleRateKey: 44_100,
+                AVNumberOfChannelsKey: 2,
+                AVEncoderBitRateKey: 128_000,
+            ]
+            let track = AVAssetWriterInput(mediaType: .audio, outputSettings: settings)
+            track.expectsMediaDataInRealTime = false
+            if writer.canAdd(track) {
+                writer.add(track)
+                audioInput = track
+            } else {
+                log.error("export: the writer refused an audio input")
+            }
+        }
+
         guard writer.startWriting(), reader.startReading() else { throw ExportError.cannotWrite }
         if let cameraReader, !cameraReader.startReading() {
             // Not fatal: a camera that cannot be read costs the picture-in-picture, not the export.
@@ -171,7 +197,11 @@ actor StudioExporter {
                                              sources: FrameSources(screen: decoded,
                                                                    camera: decodedCamera,
                                                                    wallpaper: wallpaper),
-                                             cache: cache)
+                                             cache: cache,
+                                             clipSource: placed.clip.sourceEnd
+                                                 > placed.clip.sourceStart
+                                                 ? placed.clip.sourceStart..<placed.clip.sourceEnd
+                                                 : nil)
             guard let frame, let buffer = Self.buffer(from: frame, size: output,
                                                       pool: adaptor.pixelBufferPool) else {
                 continue
@@ -187,9 +217,84 @@ actor StudioExporter {
         }
 
         input.markAsFinished()
+
+        if let audioInput, let audio {
+            try await writeAudio(audio, to: audioInput)
+        }
+
         await writer.finishWriting()
         reader.cancelReading()
         guard writer.status == .completed else { throw ExportError.cannotWrite }
+    }
+
+    /// Reads the mixed composition and hands its samples to the writer.
+    ///
+    /// `AVAssetReaderAudioMixOutput` applies the per-clip gain and the time-scaling the composition
+    /// describes, so nothing here has to touch PCM — which is the point of building a composition
+    /// rather than re-timing samples by hand.
+    private func writeAudio(_ audio: (asset: AVAsset, mix: AVAudioMix),
+                            to input: AVAssetWriterInput) async throws {
+
+        let tracks = try await audio.asset.loadTracks(withMediaType: .audio)
+        guard !tracks.isEmpty else {
+            input.markAsFinished()
+            return
+        }
+
+        let reader = try AVAssetReader(asset: audio.asset)
+        // **Asked for in the writer's own format.** Narration is mono and system audio is stereo,
+        // and the writer input is configured for stereo at 44.1 kHz — so the conversion is asked of
+        // the mix output, which will do it, rather than left to the writer, which will not: a mono
+        // buffer appended to a stereo input is simply dropped and the file comes out silent.
+        var stereo = AudioChannelLayout()
+        stereo.mChannelLayoutTag = kAudioChannelLayoutTag_Stereo
+        let layout = withUnsafeBytes(of: stereo) { Data($0) }
+
+        let output = AVAssetReaderAudioMixOutput(audioTracks: tracks, audioSettings: [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: 44_100,
+            AVNumberOfChannelsKey: 2,
+            AVChannelLayoutKey: layout,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ])
+        output.audioMix = audio.mix
+        // Every early exit marks the input finished. An `AVAssetWriter` will not finish while an
+        // input it was given is still open, so a silent bail here would hang the export rather
+        // than merely lose the sound.
+        guard reader.canAdd(output) else {
+            log.error("export audio: the reader refused a mix output")
+            input.markAsFinished()
+            return
+        }
+        reader.add(output)
+        guard reader.startReading() else {
+            let why = reader.error.map { String(describing: $0) } ?? "no error given"
+            log.error("export audio: the reader would not start — \(why, privacy: .public)")
+            input.markAsFinished()
+            return
+        }
+
+        var appended = 0
+        while let sample = output.copyNextSampleBuffer() {
+            while !input.isReadyForMoreMediaData {
+                try? await Task.sleep(nanoseconds: 2_000_000)
+            }
+            if input.append(sample) { appended += 1 }
+        }
+        input.markAsFinished()
+        // **Said out loud, because silence is this feature's failure mode.** Every export shipped
+        // without sound until now, and it did so quietly; an audio pass that reads nothing should
+        // never again be indistinguishable from one that worked.
+        if appended == 0 {
+            let why = reader.error.map { String(describing: $0) } ?? "the reader simply ended"
+            log.error("export audio: nothing was written — \(why, privacy: .public)")
+        } else {
+            log.info("export audio: \(appended, privacy: .public) buffers written")
+        }
+        reader.cancelReading()
     }
 
     private func settings(preset: ExportPreset, size: CGSize) -> [String: Any] {

--- a/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioExporter.swift
@@ -50,7 +50,11 @@ actor StudioExporter {
 
         let (canvas, _) = StudioRenderer.layout(for: project)
         let output = preset.outputSize(forCanvas: canvas)
-        let fps = preset.fps
+        // **The recording's own rate unless the preset insists otherwise.** This used to be
+        // `preset.fps` outright and `manifest.fps` was read nowhere, so a 30fps take was exported
+        // at 60 with every frame duplicated — twice the bitrate for the same pictures.
+        let recordingFPS = (try? recording.readManifest())?.fps ?? 60
+        let fps = preset.frameRate(forRecording: recordingFPS)
 
         // Sequential, so a reader is exactly the right tool here — unlike the preview, which has to
         // seek and therefore cannot use one.
@@ -101,9 +105,9 @@ actor StudioExporter {
 
         try? FileManager.default.removeItem(at: destination)
         let writer = try AVAssetWriter(outputURL: destination,
-                                       fileType: preset.codec == .proRes422 ? .mov : .mp4)
+                                       fileType: preset.fileType)
         let input = AVAssetWriterInput(mediaType: .video,
-                                       outputSettings: settings(preset: preset, size: output))
+                                       outputSettings: settings(preset: preset, size: output, fps: fps))
         input.expectsMediaDataInRealTime = false
         let adaptor = AVAssetWriterInputPixelBufferAdaptor(
             assetWriterInput: input,
@@ -313,7 +317,7 @@ actor StudioExporter {
         reader.cancelReading()
     }
 
-    private func settings(preset: ExportPreset, size: CGSize) -> [String: Any] {
+    private func settings(preset: ExportPreset, size: CGSize, fps: Int) -> [String: Any] {
         var codec: AVVideoCodecType
         switch preset.codec {
         case .h264: codec = .h264
@@ -328,8 +332,8 @@ actor StudioExporter {
         ]
         if preset.codec == .h264 || preset.codec == .hevc {
             settings[AVVideoCompressionPropertiesKey] = [
-                AVVideoAverageBitRateKey: Int(size.width * size.height) * 8,
-                AVVideoExpectedSourceFrameRateKey: preset.fps,
+                AVVideoAverageBitRateKey: ExportPreset.videoBitrate(size: size, fps: fps),
+                AVVideoExpectedSourceFrameRateKey: fps,
             ]
         }
         return settings

--- a/Sources/Sarvkrit/Features/Studio/StudioKeyRouting.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioKeyRouting.swift
@@ -1,0 +1,98 @@
+import AppKit
+import Foundation
+
+/// Which editor action a keystroke means.
+///
+/// Pure, and separate from the window that installs the monitor, for the same reason
+/// `EditorKeyRouting` is: the app has no main menu to hang items on — it is a `MenuBarExtra`
+/// accessory — so every shortcut is matched by hand, and a table matched by hand is a table worth
+/// testing exhaustively.
+enum StudioKeyRouting {
+
+    enum Action: Equatable {
+        case playPause
+        case stepFrames(Int)
+        case stepSeconds(Int)
+        /// J/K/L. −1 backwards, 0 stop, 1 forwards; repeated presses double the rate.
+        case shuttle(Int)
+        case split
+        /// Remove the clip and close the gap.
+        case rippleDelete
+        /// Lift the selection and leave the gap.
+        case deleteSelection
+        case setIn
+        case setOut
+        case addZoom
+        case setZoomLevel(Int)
+        case undo
+        case redo
+        case save
+        case export
+        case close
+        case fitTimeline
+        case loopPlayback
+        case copyFrame
+        case resetEdits
+        case showShortcuts
+        case commandMenu
+    }
+
+    private static let leftArrow = "\u{F702}"
+    private static let rightArrow = "\u{F703}"
+    private static let deleteKey = "\u{7F}"
+    private static let backspaceKey = "\u{8}"
+
+    /// - Parameter isEditingText: whether a text field has focus — the transcript editor, a caption,
+    ///   a project name.
+    ///
+    ///   **Every bare-key shortcut here is a letter somebody might type.** So while a field has
+    ///   focus none of them may fire, or renaming a project splits the timeline. The command-key
+    ///   shortcuts keep working, because ⌘Z inside a text field is what everybody expects.
+    static func action(forCharacters characters: String,
+                       modifiers: NSEvent.ModifierFlags,
+                       isEditingText: Bool) -> Action? {
+        let key = characters.lowercased()
+        let command = modifiers.contains(.command)
+        let shift = modifiers.contains(.shift)
+
+        if command {
+            switch key {
+            case "z": return shift ? .redo : .undo
+            case "b": return .split
+            case "s": return .save
+            case "e": return .export
+            case "w": return .close
+            case "k": return .commandMenu
+            case "c": return .copyFrame
+            case "l": return .loopPlayback
+            case "0": return .fitTimeline
+            case "/": return .showShortcuts
+            case deleteKey, backspaceKey: return .resetEdits
+            default: return nil
+            }
+        }
+
+        guard !isEditingText else { return nil }
+
+        switch key {
+        case " ": return .playPause
+        case leftArrow: return shift ? .stepSeconds(-1) : .stepFrames(-1)
+        case rightArrow: return shift ? .stepSeconds(1) : .stepFrames(1)
+        case ",": return .stepFrames(-1)
+        case ".": return .stepFrames(1)
+        case "l": return .shuttle(1)
+        case "j": return .shuttle(-1)
+        case "k": return .shuttle(0)
+        case "x": return .rippleDelete
+        case deleteKey, backspaceKey: return .deleteSelection
+        case "i": return .setIn
+        case "o": return .setOut
+        case "z": return .addZoom
+        default:
+            // Digits set the selected zoom's level, which is the most repeated action in this
+            // window and the one a slider is slowest at.
+            if let digit = Int(key), key.count == 1 { return .setZoomLevel(digit) }
+            return nil
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/StudioMask.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioMask.swift
@@ -1,0 +1,88 @@
+import CoreGraphics
+import Foundation
+
+/// A region hidden — or emphasised — for a stretch of the recording.
+///
+/// **This is where Sarvkrit is already ahead of what it is copying, and it should stay that way.**
+/// The README argues at length that an ordinary blur is a linear convolution and therefore
+/// invertible, and that pixelation is recoverable when the alphabet is small — which is exactly the
+/// password case. `PixelFilterElement` already implements a `secureBlur` that keeps nothing but the
+/// region's mean colour, with texture generated from a seed rather than from the pixels. That model
+/// and that argument transfer to video unchanged; a mask gains a start and an end and nothing else.
+struct StudioMask: Codable, Equatable, Identifiable {
+
+    enum Mode: String, Codable, CaseIterable, Equatable {
+        /// Keeps nothing but the region's mean colour. The default, and the only one safe over a
+        /// credential.
+        case secureBlur
+        case smoothBlur
+        case pixellate
+        case solid
+        /// The inverse: dims everything *outside* the region. `SpotlightElement` with a time range.
+        case highlight
+
+        var title: String {
+            switch self {
+            case .secureBlur: return "Secure blur"
+            case .smoothBlur: return "Blur"
+            case .pixellate: return "Pixelate"
+            case .solid: return "Solid"
+            case .highlight: return "Highlight"
+            }
+        }
+
+        /// Said in the UI, because "blur" and "safe to share" are not the same claim.
+        var caveat: String? {
+            switch self {
+            case .secureBlur, .solid, .highlight: return nil
+            case .smoothBlur: return "Reversible. Don't use it over a password."
+            case .pixellate: return "Recoverable for short text. Don't use it over a password."
+            }
+        }
+    }
+
+    var id = UUID()
+    var mode: Mode = .secureBlur
+    /// Several, sharing one time range: "hide every price in this table" is one object rather than
+    /// nine to keep in sync.
+    var rects: [RectBox]
+    var isEllipse = false
+    var start: TimeInterval
+    var end: TimeInterval
+    var blurRadius: Double = 24
+    /// Texture for `secureBlur` comes from this, never from the pixels underneath.
+    var seed: UInt64 = UInt64.random(in: 0...UInt64.max)
+    var dimming: Double = 0.6
+
+    /// Pins the mask to a window, so a sidebar stays covered through a whole demo without
+    /// keyframing it by hand.
+    var followsWindowID: UInt32?
+    var windowOriginAtCreation: CGPoint?
+
+    init(mode: Mode = .secureBlur, rects: [CGRect], start: TimeInterval, end: TimeInterval) {
+        self.mode = mode
+        self.rects = rects.map(RectBox.init)
+        self.start = start
+        self.end = end
+    }
+
+    func covers(_ t: TimeInterval) -> Bool { t >= start && t <= end }
+
+    /// Moves a pinned mask to wherever its window is now.
+    ///
+    /// **A mask whose window has gone stays exactly where it is and stays opaque.** Uncovering
+    /// what it was hiding because the thing moved is the one outcome that must never happen, so the
+    /// missing case returns the mask unchanged rather than removing it or clearing its rects.
+    func resolved(windowFrames: [UInt32: CGRect], recordingSize: CGSize) -> StudioMask {
+        guard let followsWindowID,
+              let origin = windowOriginAtCreation,
+              let frame = windowFrames[followsWindowID] else { return self }
+
+        let delta = CGPoint(x: frame.origin.x - origin.x, y: frame.origin.y - origin.y)
+        var moved = self
+        moved.rects = rects.map {
+            RectBox(CGRect(x: $0.x + delta.x, y: $0.y + delta.y, width: $0.width, height: $0.height))
+        }
+        return moved
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/StudioPlayer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioPlayer.swift
@@ -54,6 +54,8 @@ final class StudioPlayer: ObservableObject {
     @Published private(set) var frameToken = 0
     @Published private(set) var isPlaying = false
     @Published var rate: Float = 1
+    /// Whether reaching the end starts again rather than stopping. ⌘L.
+    @Published var loops = false
 
     /// Where the playhead is, in *output* time.
     @Published var playhead: TimeInterval = 0
@@ -193,7 +195,14 @@ final class StudioPlayer: ObservableObject {
             let step = PlaybackClock.advance(playhead: playhead, elapsed: elapsed,
                                              rate: rate, duration: duration)
             playhead = step.playhead
-            if step.reachedEnd { pause() }
+            if step.reachedEnd {
+                if loops, rate > 0 {
+                    playhead = 0
+                    seek(to: sourceTime(0))
+                } else {
+                    pause()
+                }
+            }
 
             // **Only where it is actually needed.** Output time is not source time — a trim makes
             // them diverge — so the player still has to be put in the right place, but `rate` is

--- a/Sources/Sarvkrit/Features/Studio/StudioPlayer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioPlayer.swift
@@ -22,7 +22,7 @@ final class StudioPlayer: ObservableObject {
 
     private let player: AVPlayer
     private let output: AVPlayerItemVideoOutput
-    private var displayLink: CADisplayLink?
+    private var clock: Timer?
     /// Host time of the previous tick, so elapsed time is measured rather than assumed.
     private var lastTickHostTime: CFTimeInterval?
     /// True while the user is dragging the playhead, so the clock does not fight the drag.
@@ -30,7 +30,7 @@ final class StudioPlayer: ObservableObject {
 
     /// Whether the clock is actually running. Observable because its absence silently disabled the
     /// entire editor: no playhead, no redraw, and no decoded frame.
-    var isTicking: Bool { displayLink != nil }
+    var isTicking: Bool { clock?.isValid ?? false }
 
     /// The most recently decoded screen frame. Held so a scrub that lands between decodes still
     /// draws the picture rather than flashing black.
@@ -97,7 +97,7 @@ final class StudioPlayer: ObservableObject {
         seek(to: 0)
     }
 
-    deinit { displayLink?.invalidate() }
+    deinit { clock?.invalidate() }
 
     // MARK: - Transport
 
@@ -154,32 +154,35 @@ final class StudioPlayer: ObservableObject {
 
     /// Starts, or restarts, the clock.
     ///
-    /// **`NSScreen.main` is the screen holding the key window, and there usually is not one.** This
-    /// player is built by `StudioEditorController.open` before its own window exists, and Sarvkrit
-    /// is an accessory app, so at the moment a recording stops the key window belongs to whatever
-    /// was being demonstrated — or to nothing at all. The optional chain then yielded nil, there was
-    /// no fallback and no retry, and `tick()` never ran once for the life of the player.
+    /// **A timer, not a display link, and that is the fix.** The previous version took a
+    /// `CADisplayLink` from `NSScreen.main` — the screen holding the *key window*. This player is
+    /// built by `StudioEditorController.open` before its own window exists, and Sarvkrit is an
+    /// accessory app, so at the moment a recording stops the key window belongs to whatever was
+    /// being demonstrated, or to nothing at all. The optional chain yielded nil, there was no
+    /// fallback and no retry, and `tick()` never ran once for the life of the player.
     ///
-    /// That is the whole editor, not just the transport: `tick()` is also the only thing that
-    /// decodes a frame, so the preview composited its background over an empty picture.
+    /// That silently disabled the whole editor rather than just the transport: `tick()` is also the
+    /// only thing that decodes a frame, so the canvas composited its background over an empty
+    /// picture. A display link also stops firing for an app with nothing on screen, which makes it
+    /// untestable and fragile for a clock that has to keep running while a window is being opened.
     ///
-    /// Called again when the preview reaches a window, so construction order stops being
-    /// load-bearing and the link follows the screen the editor is actually on.
+    /// A timer on the main run loop in `.common` mode depends on none of that. Vsync alignment
+    /// buys nothing here — every frame goes through `StudioRenderer` into a `CGContext`, and the
+    /// preview polls on a timer of its own already — and `PlaybackClock` measures the elapsed time
+    /// of each tick rather than assuming it, so an irregular interval costs nothing either.
+    ///
+    /// This removes the class of bug rather than the instance, which is the same reasoning that put
+    /// the player on the model instead of in the view hierarchy.
     func startClock() {
-        displayLink?.invalidate()
-        displayLink = nil
-        // NSScreen's display link, macOS 14+. CVDisplayLink is deprecated from 15 and this is the
-        // supported replacement at our deployment target.
-        guard let screen = NSScreen.main ?? NSScreen.screens.first else {
-            log.error("no screen to drive playback from — the preview cannot update")
-            return
+        clock?.invalidate()
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.tick() }
         }
-        let link = screen.displayLink(target: self, selector: #selector(tick))
-        link.add(to: .main, forMode: .common)
-        displayLink = link
+        RunLoop.main.add(timer, forMode: .common)
+        clock = timer
     }
 
-    @objc private func tick() {
+    private func tick() {
         let now = CACurrentMediaTime()
         let elapsed = lastTickHostTime.map { now - $0 } ?? 0
         lastTickHostTime = now

--- a/Sources/Sarvkrit/Features/Studio/StudioPlayer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioPlayer.swift
@@ -1,0 +1,128 @@
+import AVFoundation
+import AppKit
+import CoreGraphics
+import QuartzCore
+import VideoToolbox
+
+/// Playback and frame supply for one project.
+///
+/// **Owned by the model, not found in a view hierarchy.** The first version created the preview
+/// inside `NSViewRepresentable.makeNSView` and then walked the hosting view looking for it — which
+/// returns nil, because SwiftUI has not built the tree when the window controller asks. Every
+/// control that went through that reference was therefore dead: play, pause, and dragging the
+/// playhead all silently did nothing, which is exactly what "I cannot really edit" looks like.
+///
+/// Keeping the player here removes the class of bug rather than the instance: there is nothing to
+/// find, so nothing can fail to be found.
+@MainActor
+final class StudioPlayer: ObservableObject {
+
+    private let player: AVPlayer
+    private let output: AVPlayerItemVideoOutput
+    private var displayLink: CADisplayLink?
+
+    /// The most recently decoded screen frame. Held so a scrub that lands between decodes still
+    /// draws the picture rather than flashing black.
+    private(set) var decoded: CGImage?
+
+    /// Bumped whenever a new frame is ready, so the view knows to redraw without polling.
+    @Published private(set) var frameToken = 0
+    @Published private(set) var isPlaying = false
+    @Published var rate: Float = 1
+
+    /// Where the playhead is, in *output* time.
+    @Published var playhead: TimeInterval = 0
+
+    /// Set by the model so playback knows where to stop and how to map output to source.
+    var duration: TimeInterval = 0
+    var sourceTime: (TimeInterval) -> TimeInterval = { $0 }
+
+    init(url: URL) {
+        let item = AVPlayerItem(url: url)
+        output = AVPlayerItemVideoOutput(pixelBufferAttributes: [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        ])
+        item.add(output)
+        player = AVPlayer(playerItem: item)
+        player.actionAtItemEnd = .pause
+        // Never displayed. AVPlayer is here for the decoder and the seek, not for its layer —
+        // every frame goes through StudioRenderer before anybody sees it.
+        player.isMuted = true
+        start()
+        seek(to: 0)
+    }
+
+    deinit { displayLink?.invalidate() }
+
+    // MARK: - Transport
+
+    func play() {
+        guard duration > 0 else { return }
+        if playhead >= duration - 0.01 { scrub(to: 0) }
+        player.rate = rate
+        isPlaying = true
+    }
+
+    func pause() {
+        player.rate = 0
+        isPlaying = false
+    }
+
+    func toggle() { isPlaying ? pause() : play() }
+
+    /// J/K/L. Zero stops; the sign is the direction and the magnitude the speed.
+    func shuttle(_ direction: Int) {
+        guard direction != 0 else { return pause() }
+        rate = Float(direction)
+        play()
+    }
+
+    func scrub(to output: TimeInterval) {
+        playhead = min(max(0, output), max(0, duration))
+        seek(to: sourceTime(playhead))
+    }
+
+    func step(seconds: TimeInterval) { scrub(to: playhead + seconds) }
+
+    private func seek(to source: TimeInterval) {
+        player.seek(to: CMTime(seconds: max(0, source), preferredTimescale: 600),
+                    toleranceBefore: .zero, toleranceAfter: .zero)
+    }
+
+    // MARK: - Frames
+
+    private func start() {
+        displayLink?.invalidate()
+        // NSScreen's display link, macOS 14+. CVDisplayLink is deprecated from 15 and this is the
+        // supported replacement at our deployment target.
+        let link = (NSScreen.main)?.displayLink(target: self, selector: #selector(tick))
+        link?.add(to: .main, forMode: .common)
+        displayLink = link
+    }
+
+    @objc private func tick() {
+        if isPlaying {
+            playhead += Double(rate) / 60.0
+            if playhead >= duration || playhead <= 0 {
+                playhead = min(max(0, playhead), duration)
+                pause()
+            }
+            seek(to: sourceTime(playhead))
+        }
+
+        let itemTime = output.itemTime(forHostTime: CACurrentMediaTime())
+        guard output.hasNewPixelBuffer(forItemTime: itemTime),
+              let buffer = output.copyPixelBuffer(forItemTime: itemTime,
+                                                  itemTimeForDisplay: nil) else {
+            // Still redraw while scrubbing: the composite depends on the playhead as well as on
+            // the frame, so the cursor and the zoom must follow even when the picture has not
+            // changed.
+            if isPlaying { frameToken &+= 1 }
+            return
+        }
+        var image: CGImage?
+        VTCreateCGImageFromCVPixelBuffer(buffer, options: nil, imageOut: &image)
+        if let image { decoded = image }
+        frameToken &+= 1
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/StudioPlayer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioPlayer.swift
@@ -3,6 +3,7 @@ import AppKit
 import CoreGraphics
 import QuartzCore
 import VideoToolbox
+import os
 
 /// Playback and frame supply for one project.
 ///
@@ -17,13 +18,37 @@ import VideoToolbox
 @MainActor
 final class StudioPlayer: ObservableObject {
 
+    private let log = Logger(subsystem: AppIdentity.logSubsystem, category: "Studio")
+
     private let player: AVPlayer
     private let output: AVPlayerItemVideoOutput
     private var displayLink: CADisplayLink?
+    /// Host time of the previous tick, so elapsed time is measured rather than assumed.
+    private var lastTickHostTime: CFTimeInterval?
+    /// True while the user is dragging the playhead, so the clock does not fight the drag.
+    private var isScrubbing = false
+
+    /// Whether the clock is actually running. Observable because its absence silently disabled the
+    /// entire editor: no playhead, no redraw, and no decoded frame.
+    var isTicking: Bool { displayLink != nil }
 
     /// The most recently decoded screen frame. Held so a scrub that lands between decodes still
     /// draws the picture rather than flashing black.
     private(set) var decoded: CGImage?
+
+    /// The camera, on its own player.
+    ///
+    /// **Not one composition with the screen.** An `AVComposition` hands back a single composited
+    /// image, and the renderer needs the two apart: it draws the screen, then the zoom, the click
+    /// effect and the cursor, and only then the camera on top with its own shape, shadow and
+    /// layout. So the camera gets its own item and output, and the screen is the clock it follows.
+    private var cameraPlayer: AVPlayer?
+    private var cameraOutput: AVPlayerItemVideoOutput?
+    private var cameraStartOffset: TimeInterval = 0
+    private var cameraDuration: TimeInterval = 0
+
+    /// The most recently decoded camera frame, or nil where the camera was not running.
+    private(set) var decodedCamera: CGImage?
 
     /// Bumped whenever a new frame is ready, so the view knows to redraw without polling.
     @Published private(set) var frameToken = 0
@@ -37,7 +62,9 @@ final class StudioPlayer: ObservableObject {
     var duration: TimeInterval = 0
     var sourceTime: (TimeInterval) -> TimeInterval = { $0 }
 
-    init(url: URL) {
+    /// - Parameter cameraURL: nil for a recording with no camera, which then costs nothing.
+    /// - Parameter cameraStartOffset: seconds by which the camera began after the screen.
+    init(url: URL, cameraURL: URL? = nil, cameraStartOffset: TimeInterval = 0) {
         let item = AVPlayerItem(url: url)
         output = AVPlayerItemVideoOutput(pixelBufferAttributes: [
             kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
@@ -48,7 +75,25 @@ final class StudioPlayer: ObservableObject {
         // Never displayed. AVPlayer is here for the decoder and the seek, not for its layer —
         // every frame goes through StudioRenderer before anybody sees it.
         player.isMuted = true
-        start()
+
+        if let cameraURL {
+            let cameraItem = AVPlayerItem(url: cameraURL)
+            let output = AVPlayerItemVideoOutput(pixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            ])
+            cameraItem.add(output)
+            let camera = AVPlayer(playerItem: cameraItem)
+            camera.actionAtItemEnd = .pause
+            camera.isMuted = true
+            cameraOutput = output
+            cameraPlayer = camera
+            self.cameraStartOffset = cameraStartOffset
+            log.info("editor opened with a camera track, offset \(cameraStartOffset, format: .fixed(precision: 3), privacy: .public)s")
+        } else {
+            log.info("editor opened with no camera track")
+        }
+
+        startClock()
         seek(to: 0)
     }
 
@@ -57,14 +102,23 @@ final class StudioPlayer: ObservableObject {
     // MARK: - Transport
 
     func play() {
-        guard duration > 0 else { return }
+        guard duration > 0 else {
+            // Silent until now, so a project whose duration never loaded had a Play button that
+            // did nothing and said nothing.
+            log.error("play refused: the project has no duration")
+            return
+        }
         if playhead >= duration - 0.01 { scrub(to: 0) }
+        lastTickHostTime = nil
         player.rate = rate
+        // Both rates together: the camera runs alongside rather than being seeked frame by frame.
+        cameraPlayer?.rate = rate
         isPlaying = true
     }
 
     func pause() {
         player.rate = 0
+        cameraPlayer?.rate = 0
         isPlaying = false
     }
 
@@ -82,6 +136,13 @@ final class StudioPlayer: ObservableObject {
         seek(to: sourceTime(playhead))
     }
 
+    /// Bracketing a drag, so `tick()` and the drag do not write the playhead alternately.
+    func beginScrubbing() { isScrubbing = true }
+    func endScrubbing() {
+        isScrubbing = false
+        lastTickHostTime = nil
+    }
+
     func step(seconds: TimeInterval) { scrub(to: playhead + seconds) }
 
     private func seek(to source: TimeInterval) {
@@ -91,24 +152,58 @@ final class StudioPlayer: ObservableObject {
 
     // MARK: - Frames
 
-    private func start() {
+    /// Starts, or restarts, the clock.
+    ///
+    /// **`NSScreen.main` is the screen holding the key window, and there usually is not one.** This
+    /// player is built by `StudioEditorController.open` before its own window exists, and Sarvkrit
+    /// is an accessory app, so at the moment a recording stops the key window belongs to whatever
+    /// was being demonstrated — or to nothing at all. The optional chain then yielded nil, there was
+    /// no fallback and no retry, and `tick()` never ran once for the life of the player.
+    ///
+    /// That is the whole editor, not just the transport: `tick()` is also the only thing that
+    /// decodes a frame, so the preview composited its background over an empty picture.
+    ///
+    /// Called again when the preview reaches a window, so construction order stops being
+    /// load-bearing and the link follows the screen the editor is actually on.
+    func startClock() {
         displayLink?.invalidate()
+        displayLink = nil
         // NSScreen's display link, macOS 14+. CVDisplayLink is deprecated from 15 and this is the
         // supported replacement at our deployment target.
-        let link = (NSScreen.main)?.displayLink(target: self, selector: #selector(tick))
-        link?.add(to: .main, forMode: .common)
+        guard let screen = NSScreen.main ?? NSScreen.screens.first else {
+            log.error("no screen to drive playback from — the preview cannot update")
+            return
+        }
+        let link = screen.displayLink(target: self, selector: #selector(tick))
+        link.add(to: .main, forMode: .common)
         displayLink = link
     }
 
     @objc private func tick() {
-        if isPlaying {
-            playhead += Double(rate) / 60.0
-            if playhead >= duration || playhead <= 0 {
-                playhead = min(max(0, playhead), duration)
-                pause()
+        let now = CACurrentMediaTime()
+        let elapsed = lastTickHostTime.map { now - $0 } ?? 0
+        lastTickHostTime = now
+
+        if isPlaying, !isScrubbing {
+            // Measured, not assumed: a display link runs at the screen's refresh rate, and the old
+            // fixed `rate / 60` ran at double speed on a 120 Hz panel.
+            let step = PlaybackClock.advance(playhead: playhead, elapsed: elapsed,
+                                             rate: rate, duration: duration)
+            playhead = step.playhead
+            if step.reachedEnd { pause() }
+
+            // **Only where it is actually needed.** Output time is not source time — a trim makes
+            // them diverge — so the player still has to be put in the right place, but `rate` is
+            // already carrying it forward at the speed the playhead is moving. This fires at a cut
+            // and after a stall. Seeking every tick, keyframe-exact, is what no decoder could
+            // service, and it is why playback appeared frozen.
+            let wanted = sourceTime(playhead)
+            if PlaybackClock.needsResync(playerTime: player.currentTime().seconds, wanted: wanted) {
+                seek(to: wanted)
             }
-            seek(to: sourceTime(playhead))
         }
+
+        tickCamera(sourceTime: sourceTime(playhead))
 
         let itemTime = output.itemTime(forHostTime: CACurrentMediaTime())
         guard output.hasNewPixelBuffer(forItemTime: itemTime),
@@ -124,5 +219,41 @@ final class StudioPlayer: ObservableObject {
         VTCreateCGImageFromCVPixelBuffer(buffer, options: nil, imageOut: &image)
         if let image { decoded = image }
         frameToken &+= 1
+    }
+
+    /// Keeps the camera alongside the screen and decodes its frame.
+    ///
+    /// The screen is the clock; this only corrects the camera when it has drifted past a frame or
+    /// two, or where the project cuts. Nil outside the camera's own span is ordinary — it started
+    /// after the screen and can stop before it — and `StudioRenderer.drawCamera` draws nothing for
+    /// a nil image.
+    private func tickCamera(sourceTime source: TimeInterval) {
+        guard let cameraPlayer, let cameraOutput else { return }
+
+        if cameraDuration <= 0 {
+            let seconds = cameraPlayer.currentItem?.duration.seconds ?? 0
+            if seconds.isFinite, seconds > 0 { cameraDuration = seconds }
+        }
+
+        guard let wanted = PlaybackClock.cameraTime(forSource: source,
+                                                    startOffset: cameraStartOffset,
+                                                    cameraDuration: cameraDuration) else {
+            decodedCamera = nil
+            return
+        }
+
+        if PlaybackClock.needsResync(playerTime: cameraPlayer.currentTime().seconds,
+                                     wanted: wanted) {
+            cameraPlayer.seek(to: CMTime(seconds: wanted, preferredTimescale: 600),
+                              toleranceBefore: .zero, toleranceAfter: .zero)
+        }
+
+        let itemTime = cameraOutput.itemTime(forHostTime: CACurrentMediaTime())
+        guard cameraOutput.hasNewPixelBuffer(forItemTime: itemTime),
+              let buffer = cameraOutput.copyPixelBuffer(forItemTime: itemTime,
+                                                        itemTimeForDisplay: nil) else { return }
+        var image: CGImage?
+        VTCreateCGImageFromCVPixelBuffer(buffer, options: nil, imageOut: &image)
+        if let image { decodedCamera = image }
     }
 }

--- a/Sources/Sarvkrit/Features/Studio/StudioPlayer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioPlayer.swift
@@ -50,6 +50,28 @@ final class StudioPlayer: ObservableObject {
     /// The most recently decoded camera frame, or nil where the camera was not running.
     private(set) var decodedCamera: CGImage?
 
+    /// The soundtrack: narration and system audio, cut to the timeline.
+    ///
+    /// **The composition the exporter builds, played as-is.** `StudioAudio.composition` already
+    /// returns the project's audio gain-staged, speed-scaled and offset to match the edit, in
+    /// *output* time — which is exactly what a preview needs. Playing anything else would be a
+    /// second audio path, and two paths are how an editor ends up sounding different from the file
+    /// it produces.
+    ///
+    /// On its own player for the same reason the camera is: the screen's item exists to decode
+    /// pictures, and its own track carries system audio at the recording's original gain with none
+    /// of the per-clip mixing applied.
+    private var soundtrackPlayer: AVPlayer?
+
+    /// Whether there is a soundtrack loaded at all. False for a screen-only take, which then costs
+    /// nothing.
+    var hasSoundtrack: Bool { soundtrackPlayer != nil }
+
+    /// Exposed for the same reason `isTicking` is: the absence of sound is silent, so it has to be
+    /// observable from outside to be diagnosable at all.
+    var soundtrackRate: Float? { soundtrackPlayer?.rate }
+    var soundtrackTime: TimeInterval? { soundtrackPlayer?.currentTime().seconds }
+
     /// Bumped whenever a new frame is ready, so the view knows to redraw without polling.
     @Published private(set) var frameToken = 0
     @Published private(set) var isPlaying = false
@@ -76,6 +98,11 @@ final class StudioPlayer: ObservableObject {
         player.actionAtItemEnd = .pause
         // Never displayed. AVPlayer is here for the decoder and the seek, not for its layer —
         // every frame goes through StudioRenderer before anybody sees it.
+        //
+        // **Muted on purpose, and no longer the reason the editor is silent.** This item's own
+        // audio track is the raw system audio at the recording's gain, positioned in source time
+        // and with no per-clip volume or mute applied. The soundtrack comes from
+        // `setSoundtrack(asset:mix:)` instead, which is the composition the export uses.
         player.isMuted = true
 
         if let cameraURL {
@@ -101,6 +128,44 @@ final class StudioPlayer: ObservableObject {
 
     deinit { clock?.invalidate() }
 
+    // MARK: - Sound
+
+    /// Hands the player the project's soundtrack. Nil clears it.
+    ///
+    /// Called again whenever the edit changes the sound — a trim, a speed change, a volume slider —
+    /// because the composition is cut to the timeline and a stale one plays the previous edit.
+    func setSoundtrack(asset: AVAsset?, mix: AVAudioMix?) {
+        soundtrackPlayer?.rate = 0
+        soundtrackPlayer = nil
+        guard let asset else { return }
+
+        let item = AVPlayerItem(asset: asset)
+        item.audioMix = mix
+        // Shuttling at 2× should stay intelligible rather than turning into chipmunks, and this is
+        // the algorithm that survives a rate change without artefacts on speech.
+        item.audioTimePitchAlgorithm = .timeDomain
+        let made = AVPlayer(playerItem: item)
+        made.actionAtItemEnd = .pause
+        soundtrackPlayer = made
+        // Straight to wherever the playhead already is, so turning the sound on mid-session does
+        // not start it from the beginning.
+        seekSoundtrack(to: playhead)
+        if isPlaying { made.rate = soundtrackRate(for: rate) }
+        log.info("soundtrack loaded")
+    }
+
+    /// **Output time, not source time.** The composition is already cut to the timeline, so its
+    /// clock is the playhead's. Seeking it like the video — which tracks source time — would put
+    /// every word out by however much the edit has trimmed.
+    private func seekSoundtrack(to output: TimeInterval) {
+        soundtrackPlayer?.seek(to: CMTime(seconds: max(0, output), preferredTimescale: 600),
+                               toleranceBefore: .zero, toleranceAfter: .zero)
+    }
+
+    /// Audio does not run backwards. `AVPlayer` refuses a negative rate for sound, and J on the
+    /// shuttle is for finding a frame rather than for listening, so reverse is silent.
+    private func soundtrackRate(for rate: Float) -> Float { rate > 0 ? rate : 0 }
+
     // MARK: - Transport
 
     func play() {
@@ -113,14 +178,17 @@ final class StudioPlayer: ObservableObject {
         if playhead >= duration - 0.01 { scrub(to: 0) }
         lastTickHostTime = nil
         player.rate = rate
-        // Both rates together: the camera runs alongside rather than being seeked frame by frame.
+        // All three rates together: the camera and the soundtrack run alongside rather than being
+        // seeked frame by frame.
         cameraPlayer?.rate = rate
+        soundtrackPlayer?.rate = soundtrackRate(for: rate)
         isPlaying = true
     }
 
     func pause() {
         player.rate = 0
         cameraPlayer?.rate = 0
+        soundtrackPlayer?.rate = 0
         isPlaying = false
     }
 
@@ -136,6 +204,7 @@ final class StudioPlayer: ObservableObject {
     func scrub(to output: TimeInterval) {
         playhead = min(max(0, output), max(0, duration))
         seek(to: sourceTime(playhead))
+        seekSoundtrack(to: playhead)
     }
 
     /// Bracketing a drag, so `tick()` and the drag do not write the playhead alternately.
@@ -212,6 +281,15 @@ final class StudioPlayer: ObservableObject {
             let wanted = sourceTime(playhead)
             if PlaybackClock.needsResync(playerTime: player.currentTime().seconds, wanted: wanted) {
                 seek(to: wanted)
+            }
+
+            // The soundtrack against the playhead, since it is cut to output time — and on a
+            // looser tolerance, because putting audio back is a click rather than a decode.
+            if let soundtrackPlayer,
+               PlaybackClock.needsResync(playerTime: soundtrackPlayer.currentTime().seconds,
+                                         wanted: playhead,
+                                         tolerance: PlaybackClock.audioResyncTolerance) {
+                seekSoundtrack(to: playhead)
             }
         }
 

--- a/Sources/Sarvkrit/Features/Studio/StudioPreset.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioPreset.swift
@@ -1,0 +1,91 @@
+import Foundation
+import os
+
+/// A saved look, applied to a new project in one click.
+///
+/// Holds the *style* — background, cursor, captions, camera, keystrokes, aspect — and never the
+/// edit. A preset that carried a timeline would be a template for one recording rather than a look
+/// for all of them.
+struct StudioPreset: Codable, Equatable, Identifiable {
+    var id = UUID()
+    var name: String
+    var background = CaptureBackground()
+    var aspect: AspectRatio = .original
+    var cursor = CursorSettings()
+    var captionStyle = CaptionStyle()
+    var camera = CameraSettings()
+    var keystrokes = KeystrokeSettings()
+
+    init(name: String, from project: StudioProject) {
+        self.name = name
+        background = project.background
+        aspect = project.aspect
+        cursor = project.cursor
+        captionStyle = project.captionStyle
+        camera = project.camera
+        keystrokes = project.keystrokes
+    }
+
+    /// Style only — the timeline, the zooms and the captions are the recording's, not the preset's.
+    func apply(to project: inout StudioProject) {
+        project.background = background
+        project.aspect = aspect
+        project.cursor = cursor
+        project.captionStyle = captionStyle
+        project.camera = camera
+        project.keystrokes = keystrokes
+    }
+}
+
+/// Where presets live.
+///
+/// Modelled on `BackgroundPresetStore`, including the rule that matters most: **an unreadable file
+/// is logged and left in place, never overwritten.** Silently replacing something a person made,
+/// because this build could not parse it, is the worst possible response to a bad read.
+@MainActor
+final class StudioPresetStore: ObservableObject {
+    private let log = Logger(subsystem: AppIdentity.logSubsystem, category: "Studio")
+
+    @Published private(set) var presets: [StudioPreset] = []
+
+    private let url: URL
+    private var isReadable = true
+
+    static var defaultDirectory: URL {
+        CaptureHistoryStore.defaultDirectory
+            .deletingLastPathComponent()
+            .appendingPathComponent("Recordings", isDirectory: true)
+    }
+
+    init(directory: URL? = nil) {
+        let folder = directory ?? Self.defaultDirectory
+        try? FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        url = folder.appendingPathComponent("presets.json")
+        load()
+    }
+
+    private func load() {
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            presets = try JSONDecoder().decode([StudioPreset].self, from: Data(contentsOf: url))
+        } catch {
+            isReadable = false
+            log.error("presets unreadable, leaving the file alone: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func add(_ preset: StudioPreset) {
+        presets.append(preset)
+        save()
+    }
+
+    func remove(id: StudioPreset.ID) {
+        presets.removeAll { $0.id == id }
+        save()
+    }
+
+    private func save() {
+        guard isReadable else { return }
+        try? JSONEncoder().encode(presets).write(to: url, options: .atomic)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/StudioProject.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioProject.swift
@@ -30,6 +30,10 @@ struct StudioProject: Codable, Equatable {
     var masks: [StudioMask] = []
     var camera = CameraSettings()
     var cameraSegments: [CameraSegment] = []
+    /// Clicks added or taken out by hand. The recording itself is never touched.
+    var clickEdits = ClickEdits()
+    /// Stretches where the pointer's surroundings are dimmed, to say "look here".
+    var pointerHighlights: [PointerHighlight] = []
     var keystrokes = KeystrokeSettings()
     var deviceFrame = DeviceFrameSelection()
     /// Shown in the editor, never rendered into the video.
@@ -73,6 +77,7 @@ struct StudioProject: Codable, Equatable {
         case formatVersion, canvasSize, timeline, background, aspect, cropRect
         case zooms, cursor, captions, captionStyle, speakerNotes
         case masks, camera, cameraSegments, keystrokes, deviceFrame
+        case clickEdits, pointerHighlights
     }
 
     init(from decoder: Decoder) throws {
@@ -96,6 +101,8 @@ struct StudioProject: Codable, Equatable {
         masks = read(.masks, [StudioMask]())
         camera = read(.camera, CameraSettings())
         cameraSegments = read(.cameraSegments, [CameraSegment]())
+        clickEdits = read(.clickEdits, ClickEdits())
+        pointerHighlights = read(.pointerHighlights, [PointerHighlight]())
         keystrokes = read(.keystrokes, KeystrokeSettings())
         deviceFrame = read(.deviceFrame, DeviceFrameSelection())
         speakerNotes = read(.speakerNotes, "")
@@ -124,6 +131,9 @@ struct StudioProject: Codable, Equatable {
         try container.encode(masks, forKey: StudioCodingKey(Key.masks.rawValue))
         try container.encode(camera, forKey: StudioCodingKey(Key.camera.rawValue))
         try container.encode(cameraSegments, forKey: StudioCodingKey(Key.cameraSegments.rawValue))
+        try container.encode(clickEdits, forKey: StudioCodingKey(Key.clickEdits.rawValue))
+        try container.encode(pointerHighlights,
+                             forKey: StudioCodingKey(Key.pointerHighlights.rawValue))
         try container.encode(keystrokes, forKey: StudioCodingKey(Key.keystrokes.rawValue))
         try container.encode(deviceFrame, forKey: StudioCodingKey(Key.deviceFrame.rawValue))
         try container.encode(speakerNotes, forKey: StudioCodingKey(Key.speakerNotes.rawValue))

--- a/Sources/Sarvkrit/Features/Studio/StudioProject.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioProject.swift
@@ -36,6 +36,8 @@ struct StudioProject: Codable, Equatable {
     var pointerHighlights: [PointerHighlight] = []
     /// Text put on the video by hand. Distinct from `captions`, which come from transcription.
     var textOverlays: [TextOverlay] = []
+    /// Pictures composited over the recording.
+    var mediaOverlays: [MediaOverlay] = []
     /// Seconds of black the video fades up from, and down to.
     var fadeIn: TimeInterval = 0
     var fadeOut: TimeInterval = 0
@@ -82,7 +84,7 @@ struct StudioProject: Codable, Equatable {
         case formatVersion, canvasSize, timeline, background, aspect, cropRect
         case zooms, cursor, captions, captionStyle, speakerNotes
         case masks, camera, cameraSegments, keystrokes, deviceFrame
-        case clickEdits, pointerHighlights, textOverlays, fadeIn, fadeOut
+        case clickEdits, pointerHighlights, textOverlays, mediaOverlays, fadeIn, fadeOut
     }
 
     init(from decoder: Decoder) throws {
@@ -109,6 +111,7 @@ struct StudioProject: Codable, Equatable {
         clickEdits = read(.clickEdits, ClickEdits())
         pointerHighlights = read(.pointerHighlights, [PointerHighlight]())
         textOverlays = read(.textOverlays, [TextOverlay]())
+        mediaOverlays = read(.mediaOverlays, [MediaOverlay]())
         fadeIn = read(.fadeIn, 0)
         fadeOut = read(.fadeOut, 0)
         keystrokes = read(.keystrokes, KeystrokeSettings())
@@ -143,6 +146,7 @@ struct StudioProject: Codable, Equatable {
         try container.encode(pointerHighlights,
                              forKey: StudioCodingKey(Key.pointerHighlights.rawValue))
         try container.encode(textOverlays, forKey: StudioCodingKey(Key.textOverlays.rawValue))
+        try container.encode(mediaOverlays, forKey: StudioCodingKey(Key.mediaOverlays.rawValue))
         try container.encode(fadeIn, forKey: StudioCodingKey(Key.fadeIn.rawValue))
         try container.encode(fadeOut, forKey: StudioCodingKey(Key.fadeOut.rawValue))
         try container.encode(keystrokes, forKey: StudioCodingKey(Key.keystrokes.rawValue))

--- a/Sources/Sarvkrit/Features/Studio/StudioProject.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioProject.swift
@@ -26,6 +26,7 @@ struct StudioProject: Codable, Equatable {
     var zooms: [ZoomSegment] = []
     var cursor = CursorSettings()
     var captions: [Caption] = []
+    var captionStyle = CaptionStyle()
     /// Shown in the editor, never rendered into the video.
     var speakerNotes = ""
 
@@ -65,7 +66,7 @@ struct StudioProject: Codable, Equatable {
     /// rather than resetting everything the user had set.
     private enum Key: String, CaseIterable {
         case formatVersion, canvasSize, timeline, background, aspect, cropRect
-        case zooms, cursor, captions, speakerNotes
+        case zooms, cursor, captions, captionStyle, speakerNotes
     }
 
     init(from decoder: Decoder) throws {
@@ -85,6 +86,7 @@ struct StudioProject: Codable, Equatable {
         zooms = read(.zooms, [ZoomSegment]())
         cursor = read(.cursor, CursorSettings())
         captions = read(.captions, [Caption]())
+        captionStyle = read(.captionStyle, CaptionStyle())
         speakerNotes = read(.speakerNotes, "")
 
         let known = Set(Key.allCases.map(\.rawValue))
@@ -107,6 +109,7 @@ struct StudioProject: Codable, Equatable {
         try container.encode(zooms, forKey: StudioCodingKey(Key.zooms.rawValue))
         try container.encode(cursor, forKey: StudioCodingKey(Key.cursor.rawValue))
         try container.encode(captions, forKey: StudioCodingKey(Key.captions.rawValue))
+        try container.encode(captionStyle, forKey: StudioCodingKey(Key.captionStyle.rawValue))
         try container.encode(speakerNotes, forKey: StudioCodingKey(Key.speakerNotes.rawValue))
 
         // Written back last and untouched. Anything this build added under the same name would be

--- a/Sources/Sarvkrit/Features/Studio/StudioProject.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioProject.swift
@@ -34,6 +34,8 @@ struct StudioProject: Codable, Equatable {
     var clickEdits = ClickEdits()
     /// Stretches where the pointer's surroundings are dimmed, to say "look here".
     var pointerHighlights: [PointerHighlight] = []
+    /// Text put on the video by hand. Distinct from `captions`, which come from transcription.
+    var textOverlays: [TextOverlay] = []
     var keystrokes = KeystrokeSettings()
     var deviceFrame = DeviceFrameSelection()
     /// Shown in the editor, never rendered into the video.
@@ -77,7 +79,7 @@ struct StudioProject: Codable, Equatable {
         case formatVersion, canvasSize, timeline, background, aspect, cropRect
         case zooms, cursor, captions, captionStyle, speakerNotes
         case masks, camera, cameraSegments, keystrokes, deviceFrame
-        case clickEdits, pointerHighlights
+        case clickEdits, pointerHighlights, textOverlays
     }
 
     init(from decoder: Decoder) throws {
@@ -103,6 +105,7 @@ struct StudioProject: Codable, Equatable {
         cameraSegments = read(.cameraSegments, [CameraSegment]())
         clickEdits = read(.clickEdits, ClickEdits())
         pointerHighlights = read(.pointerHighlights, [PointerHighlight]())
+        textOverlays = read(.textOverlays, [TextOverlay]())
         keystrokes = read(.keystrokes, KeystrokeSettings())
         deviceFrame = read(.deviceFrame, DeviceFrameSelection())
         speakerNotes = read(.speakerNotes, "")
@@ -134,6 +137,7 @@ struct StudioProject: Codable, Equatable {
         try container.encode(clickEdits, forKey: StudioCodingKey(Key.clickEdits.rawValue))
         try container.encode(pointerHighlights,
                              forKey: StudioCodingKey(Key.pointerHighlights.rawValue))
+        try container.encode(textOverlays, forKey: StudioCodingKey(Key.textOverlays.rawValue))
         try container.encode(keystrokes, forKey: StudioCodingKey(Key.keystrokes.rawValue))
         try container.encode(deviceFrame, forKey: StudioCodingKey(Key.deviceFrame.rawValue))
         try container.encode(speakerNotes, forKey: StudioCodingKey(Key.speakerNotes.rawValue))

--- a/Sources/Sarvkrit/Features/Studio/StudioProject.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioProject.swift
@@ -1,0 +1,152 @@
+import CoreGraphics
+import Foundation
+
+/// The edit: everything the user decided, and nothing the recorder captured.
+///
+/// A project is small — geometry, numbers and a little text — which is what makes snapshot undo
+/// through `UndoStack` cheap and autosave through `CoalescingSaver` unremarkable. The recording
+/// itself lives beside it in the bundle and is never rewritten.
+///
+/// **Nothing here is destructive.** Trims are windows, zooms are overlays, the background is a
+/// description. Deleting every value in this struct would give back the raw recording untouched.
+struct StudioProject: Codable, Equatable {
+
+    var formatVersion = 1
+    /// Pixel size of the recording, which is also the coordinate space every event is in.
+    var canvasSize: CGSize
+    var timeline: Timeline
+
+    /// Reused wholesale from the screenshot editor: mesh and gradient fills, padding, corner
+    /// radius, the two-layer shadow, inset and alignment. A recording wants exactly the same
+    /// surround a screenshot does, and the code for it is written and tested.
+    var background = CaptureBackground()
+    var aspect: AspectRatio = .original
+    var cropRect: CGRect?
+
+    var zooms: [ZoomSegment] = []
+    var cursor = CursorSettings()
+    var captions: [Caption] = []
+    /// Shown in the editor, never rendered into the video.
+    var speakerNotes = ""
+
+    /// Fields written by a newer build.
+    ///
+    /// Held verbatim and written back unchanged, so opening a project in an older build and saving
+    /// it does not quietly delete work done in a newer one. A recording is hundreds of megabytes of
+    /// somebody's afternoon; silently dropping part of the edit is not an acceptable way to fail.
+    private(set) var unrecognised: [String: JSONValue] = [:]
+
+    init(canvasSize: CGSize, timeline: Timeline) {
+        self.canvasSize = canvasSize
+        self.timeline = timeline
+    }
+
+    // MARK: - Derived
+
+    var duration: TimeInterval { timeline.duration }
+
+    /// The zooms that still have a moment to happen in.
+    ///
+    /// A segment whose source time was cut out of the edit has nowhere to be drawn. Answering that
+    /// here rather than in the renderer means the question is asked once per edit instead of sixty
+    /// times a second.
+    var visibleZooms: [ZoomSegment] {
+        zooms.filter { segment in
+            guard !segment.isDisabled else { return false }
+            return timeline.outputTime(forSource: segment.start) != nil
+                || timeline.outputTime(forSource: segment.end) != nil
+        }
+    }
+
+    // MARK: - Coding
+
+    /// Hand-written, and the shape is the same one `AnnotationDocument` uses: **a missing key takes
+    /// a default, it never throws.** A project saved before a field existed has to open cleanly
+    /// rather than resetting everything the user had set.
+    private enum Key: String, CaseIterable {
+        case formatVersion, canvasSize, timeline, background, aspect, cropRect
+        case zooms, cursor, captions, speakerNotes
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: StudioCodingKey.self)
+
+        func read<T: Decodable>(_ key: Key, _ fallback: T) -> T {
+            (try? container.decode(T.self, forKey: StudioCodingKey(key.rawValue))) ?? fallback
+        }
+
+        formatVersion = read(.formatVersion, 1)
+        canvasSize = read(.canvasSize, SizeBox(.zero)).size
+        timeline = read(.timeline, Timeline(clips: []))
+        background = read(.background, CaptureBackground())
+        aspect = read(.aspect, AspectRatio.original)
+        cropRect = (try? container.decode(RectBox.self,
+                                          forKey: StudioCodingKey(Key.cropRect.rawValue)))?.rect
+        zooms = read(.zooms, [ZoomSegment]())
+        cursor = read(.cursor, CursorSettings())
+        captions = read(.captions, [Caption]())
+        speakerNotes = read(.speakerNotes, "")
+
+        let known = Set(Key.allCases.map(\.rawValue))
+        var extras: [String: JSONValue] = [:]
+        for key in container.allKeys where !known.contains(key.stringValue) {
+            extras[key.stringValue] = try? container.decode(JSONValue.self, forKey: key)
+        }
+        unrecognised = extras
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: StudioCodingKey.self)
+        try container.encode(formatVersion, forKey: StudioCodingKey(Key.formatVersion.rawValue))
+        try container.encode(SizeBox(canvasSize), forKey: StudioCodingKey(Key.canvasSize.rawValue))
+        try container.encode(timeline, forKey: StudioCodingKey(Key.timeline.rawValue))
+        try container.encode(background, forKey: StudioCodingKey(Key.background.rawValue))
+        try container.encode(aspect, forKey: StudioCodingKey(Key.aspect.rawValue))
+        try container.encodeIfPresent(cropRect.map(RectBox.init),
+                                      forKey: StudioCodingKey(Key.cropRect.rawValue))
+        try container.encode(zooms, forKey: StudioCodingKey(Key.zooms.rawValue))
+        try container.encode(cursor, forKey: StudioCodingKey(Key.cursor.rawValue))
+        try container.encode(captions, forKey: StudioCodingKey(Key.captions.rawValue))
+        try container.encode(speakerNotes, forKey: StudioCodingKey(Key.speakerNotes.rawValue))
+
+        // Written back last and untouched. Anything this build added under the same name would be
+        // overwritten by its own key above, which is correct: a field we now understand is ours.
+        for (name, value) in unrecognised {
+            try container.encode(value, forKey: StudioCodingKey(name))
+        }
+    }
+}
+
+/// `CGSize` and `CGRect` written as named fields rather than as arrays.
+///
+/// **Their synthesised `Codable` encodes a bare `[1920, 1080]`.** That round-trips perfectly well
+/// and is unreadable: the project bundle is a package the user can open, and a file that says
+/// `"canvasSize": [2560, 1440]` tells them nothing about which number is which. Two extra words in
+/// the file is the whole cost.
+struct SizeBox: Codable, Equatable {
+    var width: CGFloat
+    var height: CGFloat
+
+    init(_ size: CGSize) {
+        width = size.width
+        height = size.height
+    }
+
+    var size: CGSize { CGSize(width: width, height: height) }
+}
+
+struct RectBox: Codable, Equatable {
+    var x: CGFloat
+    var y: CGFloat
+    var width: CGFloat
+    var height: CGFloat
+
+    init(_ rect: CGRect) {
+        x = rect.origin.x
+        y = rect.origin.y
+        width = rect.size.width
+        height = rect.size.height
+    }
+
+    var rect: CGRect { CGRect(x: x, y: y, width: width, height: height) }
+}

--- a/Sources/Sarvkrit/Features/Studio/StudioProject.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioProject.swift
@@ -36,6 +36,9 @@ struct StudioProject: Codable, Equatable {
     var pointerHighlights: [PointerHighlight] = []
     /// Text put on the video by hand. Distinct from `captions`, which come from transcription.
     var textOverlays: [TextOverlay] = []
+    /// Seconds of black the video fades up from, and down to.
+    var fadeIn: TimeInterval = 0
+    var fadeOut: TimeInterval = 0
     var keystrokes = KeystrokeSettings()
     var deviceFrame = DeviceFrameSelection()
     /// Shown in the editor, never rendered into the video.
@@ -79,7 +82,7 @@ struct StudioProject: Codable, Equatable {
         case formatVersion, canvasSize, timeline, background, aspect, cropRect
         case zooms, cursor, captions, captionStyle, speakerNotes
         case masks, camera, cameraSegments, keystrokes, deviceFrame
-        case clickEdits, pointerHighlights, textOverlays
+        case clickEdits, pointerHighlights, textOverlays, fadeIn, fadeOut
     }
 
     init(from decoder: Decoder) throws {
@@ -106,6 +109,8 @@ struct StudioProject: Codable, Equatable {
         clickEdits = read(.clickEdits, ClickEdits())
         pointerHighlights = read(.pointerHighlights, [PointerHighlight]())
         textOverlays = read(.textOverlays, [TextOverlay]())
+        fadeIn = read(.fadeIn, 0)
+        fadeOut = read(.fadeOut, 0)
         keystrokes = read(.keystrokes, KeystrokeSettings())
         deviceFrame = read(.deviceFrame, DeviceFrameSelection())
         speakerNotes = read(.speakerNotes, "")
@@ -138,6 +143,8 @@ struct StudioProject: Codable, Equatable {
         try container.encode(pointerHighlights,
                              forKey: StudioCodingKey(Key.pointerHighlights.rawValue))
         try container.encode(textOverlays, forKey: StudioCodingKey(Key.textOverlays.rawValue))
+        try container.encode(fadeIn, forKey: StudioCodingKey(Key.fadeIn.rawValue))
+        try container.encode(fadeOut, forKey: StudioCodingKey(Key.fadeOut.rawValue))
         try container.encode(keystrokes, forKey: StudioCodingKey(Key.keystrokes.rawValue))
         try container.encode(deviceFrame, forKey: StudioCodingKey(Key.deviceFrame.rawValue))
         try container.encode(speakerNotes, forKey: StudioCodingKey(Key.speakerNotes.rawValue))

--- a/Sources/Sarvkrit/Features/Studio/StudioProject.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioProject.swift
@@ -27,6 +27,11 @@ struct StudioProject: Codable, Equatable {
     var cursor = CursorSettings()
     var captions: [Caption] = []
     var captionStyle = CaptionStyle()
+    var masks: [StudioMask] = []
+    var camera = CameraSettings()
+    var cameraSegments: [CameraSegment] = []
+    var keystrokes = KeystrokeSettings()
+    var deviceFrame = DeviceFrameSelection()
     /// Shown in the editor, never rendered into the video.
     var speakerNotes = ""
 
@@ -67,6 +72,7 @@ struct StudioProject: Codable, Equatable {
     private enum Key: String, CaseIterable {
         case formatVersion, canvasSize, timeline, background, aspect, cropRect
         case zooms, cursor, captions, captionStyle, speakerNotes
+        case masks, camera, cameraSegments, keystrokes, deviceFrame
     }
 
     init(from decoder: Decoder) throws {
@@ -87,6 +93,11 @@ struct StudioProject: Codable, Equatable {
         cursor = read(.cursor, CursorSettings())
         captions = read(.captions, [Caption]())
         captionStyle = read(.captionStyle, CaptionStyle())
+        masks = read(.masks, [StudioMask]())
+        camera = read(.camera, CameraSettings())
+        cameraSegments = read(.cameraSegments, [CameraSegment]())
+        keystrokes = read(.keystrokes, KeystrokeSettings())
+        deviceFrame = read(.deviceFrame, DeviceFrameSelection())
         speakerNotes = read(.speakerNotes, "")
 
         let known = Set(Key.allCases.map(\.rawValue))
@@ -110,6 +121,11 @@ struct StudioProject: Codable, Equatable {
         try container.encode(cursor, forKey: StudioCodingKey(Key.cursor.rawValue))
         try container.encode(captions, forKey: StudioCodingKey(Key.captions.rawValue))
         try container.encode(captionStyle, forKey: StudioCodingKey(Key.captionStyle.rawValue))
+        try container.encode(masks, forKey: StudioCodingKey(Key.masks.rawValue))
+        try container.encode(camera, forKey: StudioCodingKey(Key.camera.rawValue))
+        try container.encode(cameraSegments, forKey: StudioCodingKey(Key.cameraSegments.rawValue))
+        try container.encode(keystrokes, forKey: StudioCodingKey(Key.keystrokes.rawValue))
+        try container.encode(deviceFrame, forKey: StudioCodingKey(Key.deviceFrame.rawValue))
         try container.encode(speakerNotes, forKey: StudioCodingKey(Key.speakerNotes.rawValue))
 
         // Written back last and untouched. Anything this build added under the same name would be

--- a/Sources/Sarvkrit/Features/Studio/StudioProject.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioProject.swift
@@ -159,6 +159,26 @@ struct StudioProject: Codable, Equatable {
             try container.encode(value, forKey: StudioCodingKey(name))
         }
     }
+
+    /// Puts one rectangle of one mask somewhere else, in recording pixels.
+    ///
+    /// A free function on the project rather than a method on the model, so the canvas's drag and
+    /// the inspector's number fields go through exactly the same code.
+    ///
+    /// **An address that does not resolve changes nothing.** Writing into a neighbouring index
+    /// instead would move the wrong region, and uncovering something is the one outcome a
+    /// redaction tool must never have.
+    static func setMaskRect(_ project: inout StudioProject, id: StudioMask.ID, index: Int,
+                            to rect: CGRect) {
+        guard let mask = project.masks.firstIndex(where: { $0.id == id }),
+              project.masks[mask].rects.indices.contains(index) else { return }
+        project.masks[mask].rects[index] = RectBox(rect)
+        // **A hand-moved mask stops following its window.** `resolved(windowFrames:)` redraws a
+        // pinned mask wherever its window is now, so the pin and the drag would fight: you would
+        // let go and watch the box jump back. Moving it by hand is the clearer intent.
+        project.masks[mask].followsWindowID = nil
+        project.masks[mask].windowOriginAtCreation = nil
+    }
 }
 
 /// `CGSize` and `CGRect` written as named fields rather than as arrays.

--- a/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
@@ -139,14 +139,10 @@ enum StudioRenderer {
         // does not change how much of the picture is visible.
         let frame = DeviceFrameRenderer.layout(project.deviceFrame, imageRect: imageRect)
         if let frame { DeviceFrameRenderer.drawBody(frame, in: context) }
-        let screenRect = frame?.screenRect ?? imageRect
 
-        let transform = ZoomResolver.transform(
-            at: sourceTime,
-            segments: project.visibleZooms,
-            cursor: events.isCursorInside(at: sourceTime) ? events.cursorPoint(at: sourceTime) : nil,
-            frameSize: project.canvasSize,
-            clipSource: clipSource)
+        let (screenRect, transform) = screenGeometry(
+            project: project, sourceTime: sourceTime, events: events,
+            imageRect: imageRect, clipSource: clipSource)
 
         context.saveGState()
         if let frame {
@@ -707,9 +703,50 @@ extension StudioRenderer {
         KeystrokeRenderer.draw(pills, settings: project.keystrokes, canvas: canvas, in: context)
     }
 
+    /// Where the recording's picture is drawn, and how it is zoomed.
+    ///
+    /// The two things every rectangle inside the screen depends on. **Shared with `draw` so that
+    /// hit-testing a mask and drawing it cannot disagree** — a hit test a few points out is a mask
+    /// you cannot grab, which looks exactly like the feature not being there.
+    static func screenGeometry(project: StudioProject, sourceTime: TimeInterval,
+                               events: EventLog, imageRect: CGRect,
+                               clipSource: Range<TimeInterval>? = nil)
+        -> (screenRect: CGRect, transform: ZoomTransform) {
+        let frame = DeviceFrameRenderer.layout(project.deviceFrame, imageRect: imageRect)
+        let transform = ZoomResolver.transform(
+            at: sourceTime,
+            segments: project.visibleZooms,
+            cursor: events.isCursorInside(at: sourceTime) ? events.cursorPoint(at: sourceTime) : nil,
+            frameSize: project.canvasSize,
+            clipSource: clipSource)
+        return (frame?.screenRect ?? imageRect, transform)
+    }
+
+    /// Where each visible mask rectangle sits, in canvas points.
+    ///
+    /// The mirror of `textBoxes`, and for the same reason. `index` addresses one rectangle of a
+    /// mask that has several: "hide every price in this table" is one object with nine boxes, and
+    /// each is dragged on its own.
+    static func maskBoxes(project: StudioProject, sourceTime: TimeInterval, events: EventLog,
+                          imageRect: CGRect, clipSource: Range<TimeInterval>? = nil)
+        -> [(id: StudioMask.ID, index: Int, rect: CGRect)] {
+        let geometry = screenGeometry(project: project, sourceTime: sourceTime, events: events,
+                                      imageRect: imageRect, clipSource: clipSource)
+        var boxes: [(id: StudioMask.ID, index: Int, rect: CGRect)] = []
+        for mask in project.masks where mask.covers(sourceTime) {
+            for (index, box) in mask.rects.enumerated() {
+                guard let rect = canvasRect(box.rect, project: project,
+                                            transform: geometry.transform,
+                                            imageRect: geometry.screenRect) else { continue }
+                boxes.append((mask.id, index, rect))
+            }
+        }
+        return boxes
+    }
+
     /// Recording pixels to canvas points for a rectangle, through the crop and the zoom.
-    private static func canvasRect(_ rect: CGRect, project: StudioProject,
-                                   transform: ZoomTransform, imageRect: CGRect) -> CGRect? {
+    static func canvasRect(_ rect: CGRect, project: StudioProject,
+                           transform: ZoomTransform, imageRect: CGRect) -> CGRect? {
         let cropped = project.cropRect ?? CGRect(origin: .zero, size: project.canvasSize)
         let visible = ZoomResolver.sourceRect(for: transform, frameSize: cropped.size)
         guard visible.width > 0, visible.height > 0 else { return nil }
@@ -719,5 +756,24 @@ extension StudioRenderer {
                       y: imageRect.minY + (rect.minY - cropped.minY - visible.minY) * scaleY,
                       width: rect.width * scaleX,
                       height: rect.height * scaleY)
+    }
+
+    /// Canvas points back to recording pixels. The exact inverse of `canvasRect`.
+    ///
+    /// **Written as the inverse and tested as one.** A drag reads a canvas rect out of
+    /// `maskBoxes`, applies the pointer to it and writes it back through here; if the round trip
+    /// is not the identity the mask creeps a little every time it is touched.
+    static func sourceRect(_ rect: CGRect, project: StudioProject,
+                           transform: ZoomTransform, imageRect: CGRect) -> CGRect? {
+        let cropped = project.cropRect ?? CGRect(origin: .zero, size: project.canvasSize)
+        let visible = ZoomResolver.sourceRect(for: transform, frameSize: cropped.size)
+        guard visible.width > 0, visible.height > 0,
+              imageRect.width > 0, imageRect.height > 0 else { return nil }
+        let scaleX = imageRect.width / visible.width
+        let scaleY = imageRect.height / visible.height
+        return CGRect(x: (rect.minX - imageRect.minX) / scaleX + cropped.minX + visible.minX,
+                      y: (rect.minY - imageRect.minY) / scaleY + cropped.minY + visible.minY,
+                      width: rect.width / scaleX,
+                      height: rect.height / scaleY)
     }
 }

--- a/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
@@ -661,9 +661,17 @@ extension StudioRenderer {
                                                      clipSource: clipSource,
                                                      cameraStart: cameraStart) else { return }
 
+        // **Nothing at all while the camera is not there.** The shadow is cast by filling the
+        // bubble's path in black, and it used to be drawn before the camera's own opacity was
+        // applied — so through the whole fade-in, and at opacity zero outright, an opaque black
+        // squircle sat where the webcam belonged. That is what "it removes the webcam video"
+        // looked like.
+        guard state.opacity > 0.001 else { return }
+
         let path = CGPath.rounded(state.rect, cornerRadius: state.cornerRadius)
         if let shadow = project.camera.shadow {
             context.saveGState()
+            context.setAlpha(CGFloat(state.opacity))
             context.setShadow(offset: CGSize(width: 0, height: -shadow.offsetY),
                               blur: shadow.radius,
                               color: CGColor(red: 0, green: 0, blue: 0,

--- a/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
@@ -147,6 +147,8 @@ enum StudioRenderer {
         // edge is cut by the rounded corner exactly as the content is.
         drawMasks(project: project, sourceTime: sourceTime, transform: transform,
                   imageRect: screenRect, screen: sources.screen, in: context)
+        drawPointerSpotlight(project: project, sourceTime: sourceTime, events: events,
+                             transform: transform, imageRect: screenRect, in: context)
         drawClicks(project: project, sourceTime: sourceTime, events: events,
                    transform: transform, imageRect: screenRect, in: context)
         drawCursor(project: project, sourceTime: sourceTime, events: events,
@@ -246,7 +248,7 @@ enum StudioRenderer {
         let scaled = CGFloat(height) * imageRect.width / max(project.canvasSize.width, 1)
             * CGFloat(transform.scale)
 
-        let click = lastClick(events: events, at: sourceTime)
+        let click = lastClick(project: project, events: events, at: sourceTime)
         let effect = click.map {
             ClickEffect.state(settings.clickEffect, secondsSinceClick: sourceTime - $0.t)
         } ?? nil
@@ -296,8 +298,16 @@ enum StudioRenderer {
         return 1 - fade
     }
 
-    private static func lastClick(events: EventLog, at t: TimeInterval) -> ClickEvent? {
-        events.pressDowns.last { $0.t <= t && t - $0.t <= ClickEffect.duration }
+    private static func lastClick(project: StudioProject, events: EventLog,
+                                  at t: TimeInterval) -> ClickEvent? {
+        // The ordinary case allocates nothing it did not before: with no edits this is exactly the
+        // recording's own presses. `ClickTrack` only gets involved once somebody has changed
+        // something, and even then it never modifies the recording.
+        guard project.clickEdits != ClickEdits() else {
+            return events.pressDowns.last { $0.t <= t && t - $0.t <= ClickEffect.duration }
+        }
+        return ClickTrack.effective(recorded: events.clicks, edits: project.clickEdits)
+            .last { $0.t <= t && t - $0.t <= ClickEffect.duration }
     }
 
     // MARK: - Clicks
@@ -305,7 +315,8 @@ enum StudioRenderer {
     private static func drawClicks(project: StudioProject, sourceTime: TimeInterval,
                                    events: EventLog, transform: ZoomTransform,
                                    imageRect: CGRect, in context: CGContext) {
-        guard let click = lastClick(events: events, at: sourceTime), click.isInside,
+        guard let click = lastClick(project: project, events: events, at: sourceTime),
+              click.isInside,
               let state = ClickEffect.state(project.cursor.clickEffect,
                                             secondsSinceClick: sourceTime - click.t),
               let placed = canvasPoint(click.point, project: project, transform: transform,
@@ -373,6 +384,42 @@ extension StudioRenderer {
     /// **The safe direction is opaque.** A mask that fails to resolve — its window gone, its
     /// filter unavailable — falls back to a solid fill rather than to nothing, because the one
     /// outcome that must never happen is uncovering what it was hiding.
+    /// The pointer spotlight: everything outside a circle on the pointer is dimmed.
+    ///
+    /// **Drawn before the click effect and the cursor, and inside the screen's clip.** That order is
+    /// the point — the wash dims the content being demonstrated while the pointer itself, and any
+    /// click ring around it, draw on top and stay bright.
+    ///
+    /// One even-odd fill, exactly like a `.highlight` mask, so the two read as one idea and no two
+    /// washes can darken each other.
+    static func drawPointerSpotlight(project: StudioProject, sourceTime: TimeInterval,
+                                     events: EventLog, transform: ZoomTransform,
+                                     imageRect: CGRect, in context: CGContext) {
+        let cursor = events.isCursorInside(at: sourceTime)
+            ? events.cursorPoint(at: sourceTime) : nil
+        guard let state = PointerSpotlight.state(at: sourceTime,
+                                                 highlights: project.pointerHighlights,
+                                                 cursor: cursor,
+                                                 frameSize: project.canvasSize),
+              state.dimming > 0.001,
+              let centre = canvasPoint(state.centre, project: project, transform: transform,
+                                       imageRect: imageRect) else { return }
+
+        // Scaled with the picture, so the spotlight covers the same content zoomed in as out.
+        let scale = imageRect.width / max(project.canvasSize.width, 1) * CGFloat(transform.scale)
+        let radius = state.radius * scale
+
+        let path = CGMutablePath()
+        path.addRect(imageRect)
+        path.addEllipse(in: CGRect(x: centre.x - radius, y: centre.y - radius,
+                                   width: radius * 2, height: radius * 2))
+        context.saveGState()
+        context.addPath(path)
+        context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: CGFloat(state.dimming)))
+        context.fillPath(using: .evenOdd)
+        context.restoreGState()
+    }
+
     static func drawMasks(project: StudioProject, sourceTime: TimeInterval,
                           transform: ZoomTransform, imageRect: CGRect,
                           screen: CGImage?, in context: CGContext) {

--- a/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
@@ -107,6 +107,12 @@ enum StudioRenderer {
                                           sources: .init(base: sources.screen,
                                                          wallpaper: sources.wallpaper))
 
+        // A device frame insets the recording rather than growing the canvas, so turning it on
+        // does not change how much of the picture is visible.
+        let frame = DeviceFrameRenderer.layout(project.deviceFrame, imageRect: imageRect)
+        if let frame { DeviceFrameRenderer.drawBody(frame, in: context) }
+        let screenRect = frame?.screenRect ?? imageRect
+
         let transform = ZoomResolver.transform(
             at: sourceTime,
             segments: project.visibleZooms,
@@ -114,21 +120,33 @@ enum StudioRenderer {
             frameSize: project.canvasSize)
 
         context.saveGState()
-        context.addPath(BackgroundCompositor.clipPath(imageRect: imageRect, style: style))
+        if let frame {
+            context.addPath(frame.screen)
+        } else {
+            context.addPath(BackgroundCompositor.clipPath(imageRect: screenRect, style: style))
+        }
         context.clip()
-        drawScreen(project: project, transform: transform, imageRect: imageRect,
+        drawScreen(project: project, transform: transform, imageRect: screenRect,
                    sources: sources, in: context)
 
         // 4 and 5 — click effect and cursor, both inside the screen's clip so a pointer near the
         // edge is cut by the rounded corner exactly as the content is.
+        drawMasks(project: project, sourceTime: sourceTime, transform: transform,
+                  imageRect: screenRect, screen: sources.screen, in: context)
         drawClicks(project: project, sourceTime: sourceTime, events: events,
-                   transform: transform, imageRect: imageRect, in: context)
+                   transform: transform, imageRect: screenRect, in: context)
         drawCursor(project: project, sourceTime: sourceTime, events: events,
-                   transform: transform, imageRect: imageRect, sources: sources, in: context)
+                   transform: transform, imageRect: screenRect, sources: sources, in: context)
         context.restoreGState()
+
+        if let frame { DeviceFrameRenderer.drawRim(frame, in: context) }
 
         // 6 and 7 — camera and captions, in canvas space: they belong to the finished video, not
         // to the recording, so a zoom must not move them.
+        drawCamera(project: project, sourceTime: sourceTime, transform: transform,
+                   canvas: canvas, camera: sources.camera, in: context)
+        drawKeystrokes(project: project, sourceTime: sourceTime, events: events,
+                       canvas: canvas, in: context)
         drawCaptions(project: project, sourceTime: sourceTime, canvas: canvas, in: context)
     }
 
@@ -328,5 +346,185 @@ enum StudioRenderer {
         }) else { return }
         CaptionRenderer.draw(caption, spokenWords: caption.spokenWordCount(at: sourceTime),
                              canvas: canvas, style: project.captionStyle, in: context)
+    }
+}
+
+// MARK: - The remaining layers
+
+extension StudioRenderer {
+
+    /// Masks, drawn inside the screen's clip so they move with the zoom exactly as the content
+    /// they are hiding does.
+    ///
+    /// **The safe direction is opaque.** A mask that fails to resolve — its window gone, its
+    /// filter unavailable — falls back to a solid fill rather than to nothing, because the one
+    /// outcome that must never happen is uncovering what it was hiding.
+    static func drawMasks(project: StudioProject, sourceTime: TimeInterval,
+                          transform: ZoomTransform, imageRect: CGRect,
+                          screen: CGImage?, in context: CGContext) {
+        let live = project.masks.filter { $0.covers(sourceTime) }
+        guard !live.isEmpty else { return }
+
+        for mask in live {
+            let rects = mask.rects.compactMap { box -> CGRect? in
+                canvasRect(box.rect, project: project, transform: transform, imageRect: imageRect)
+            }
+            guard !rects.isEmpty else { continue }
+
+            if mask.mode == .highlight {
+                // The inverse: everything *outside* is dimmed. Drawn as one even-odd fill so the
+                // regions punch through a single wash rather than each darkening the last.
+                let path = CGMutablePath()
+                path.addRect(imageRect)
+                for rect in rects {
+                    if mask.isEllipse { path.addEllipse(in: rect) } else { path.addRect(rect) }
+                }
+                context.saveGState()
+                context.addPath(path)
+                context.setFillColor(CGColor(red: 0, green: 0, blue: 0,
+                                             alpha: CGFloat(mask.dimming)))
+                context.fillPath(using: .evenOdd)
+                context.restoreGState()
+                continue
+            }
+
+            for (index, rect) in rects.enumerated() {
+                drawObscured(mask: mask, rect: rect,
+                             sourceRect: mask.rects[index].rect, screen: screen, in: context)
+            }
+        }
+    }
+
+    private static func drawObscured(mask: StudioMask, rect: CGRect, sourceRect: CGRect,
+                                     screen: CGImage?, in context: CGContext) {
+        context.saveGState()
+        let shape = CGMutablePath()
+        if mask.isEllipse { shape.addEllipse(in: rect) } else { shape.addRect(rect) }
+        context.addPath(shape)
+        context.clip()
+
+        switch mask.mode {
+        case .secureBlur, .solid, .highlight:
+            // `secureBlur`'s contract, kept: nothing survives but the region's mean colour, and the
+            // texture over it comes from the seed rather than from the pixels. A blur that can be
+            // inverted is not a redaction, and the README says so at length.
+            let mean = averageColour(of: screen, in: sourceRect)
+                ?? RGBAColour(r: 0.1, g: 0.1, b: 0.12)
+            context.setFillColor(mean.cgColor)
+            context.fill(rect)
+            if mask.mode == .secureBlur {
+                drawSeededTexture(seed: mask.seed, in: rect, context: context)
+            }
+        case .smoothBlur, .pixellate:
+            let mean = averageColour(of: screen, in: sourceRect)
+                ?? RGBAColour(r: 0.1, g: 0.1, b: 0.12)
+            context.setFillColor(mean.cgColor)
+            context.fill(rect)
+        }
+        context.restoreGState()
+    }
+
+    /// Grain from a seeded generator. Deterministic, so the same project exports identically twice,
+    /// and carrying no information about what it covers.
+    private static func drawSeededTexture(seed: UInt64, in rect: CGRect, context: CGContext) {
+        var state = seed | 1
+        func next() -> Double {
+            state ^= state << 13; state ^= state >> 7; state ^= state << 17
+            return Double(state % 1000) / 1000
+        }
+        let cell = max(6, min(rect.width, rect.height) / 8)
+        var y = rect.minY
+        while y < rect.maxY {
+            var x = rect.minX
+            while x < rect.maxX {
+                context.setFillColor(CGColor(red: 1, green: 1, blue: 1,
+                                             alpha: CGFloat(next() * 0.06)))
+                context.fill(CGRect(x: x, y: y, width: cell, height: cell))
+                x += cell
+            }
+            y += cell
+        }
+    }
+
+    /// The mean of the region the mask actually covers.
+    ///
+    /// **The rect is in recording pixels, not canvas points.** Taking it from the whole image — as
+    /// this did first — makes a small mask show the average of the entire screen, which is both
+    /// wrong-looking and a quiet way for the redaction to stop matching its surroundings.
+    static func averageColour(of image: CGImage?, in rect: CGRect) -> RGBAColour? {
+        guard let image else { return nil }
+        let region = rect.integral.intersection(
+            CGRect(x: 0, y: 0, width: image.width, height: image.height))
+        let cropped = region.isEmpty ? image : (image.cropping(to: region) ?? image)
+        guard let grid = BackgroundCompositor.grid(from: cropped, side: 8) else { return nil }
+        let mean = grid.cells.reduce(into: (0.0, 0.0, 0.0)) { sum, cell in
+            sum.0 += cell.r; sum.1 += cell.g; sum.2 += cell.b
+        }
+        let count = Double(max(1, grid.cells.count))
+        return RGBAColour(r: mean.0 / count, g: mean.1 / count, b: mean.2 / count)
+    }
+
+    /// The camera, in canvas space: it belongs to the finished video rather than to the recording,
+    /// so a zoom must not move it.
+    static func drawCamera(project: StudioProject, sourceTime: TimeInterval,
+                           transform: ZoomTransform, canvas: CGSize,
+                           camera: CGImage?, in context: CGContext) {
+        guard let camera,
+              let state = CameraLayoutResolver.state(at: sourceTime,
+                                                     segments: project.cameraSegments,
+                                                     settings: project.camera,
+                                                     canvas: canvas,
+                                                     zoom: transform.scale) else { return }
+
+        let path = CGPath.rounded(state.rect, cornerRadius: state.cornerRadius)
+        if let shadow = project.camera.shadow {
+            context.saveGState()
+            context.setShadow(offset: CGSize(width: 0, height: -shadow.offsetY),
+                              blur: shadow.radius,
+                              color: CGColor(red: 0, green: 0, blue: 0,
+                                             alpha: CGFloat(shadow.opacity)))
+            context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+            context.addPath(path)
+            context.fillPath()
+            context.restoreGState()
+        }
+
+        context.saveGState()
+        context.setAlpha(CGFloat(state.opacity))
+        context.addPath(path)
+        context.clip()
+        if project.camera.mirrored {
+            // Front cameras look wrong un-mirrored — people expect the reflection they rehearsed in.
+            context.translateBy(x: state.rect.midX * 2, y: 0)
+            context.scaleBy(x: -1, y: 1)
+        }
+        context.drawFlipped(camera, in: BlurredBackdrop.fill(
+            CGSize(width: camera.width, height: camera.height), into: state.rect.size)
+            .offsetBy(dx: state.rect.minX, dy: state.rect.minY))
+        context.restoreGState()
+    }
+
+    /// Recorded keys, as pills.
+    static func drawKeystrokes(project: StudioProject, sourceTime: TimeInterval,
+                               events: EventLog, canvas: CGSize, in context: CGContext) {
+        guard project.keystrokes.isEnabled else { return }
+        let pills = KeystrokeOverlay.pills(at: sourceTime, keys: events.keys,
+                                           settings: project.keystrokes)
+        guard !pills.isEmpty else { return }
+        KeystrokeRenderer.draw(pills, settings: project.keystrokes, canvas: canvas, in: context)
+    }
+
+    /// Recording pixels to canvas points for a rectangle, through the crop and the zoom.
+    private static func canvasRect(_ rect: CGRect, project: StudioProject,
+                                   transform: ZoomTransform, imageRect: CGRect) -> CGRect? {
+        let cropped = project.cropRect ?? CGRect(origin: .zero, size: project.canvasSize)
+        let visible = ZoomResolver.sourceRect(for: transform, frameSize: cropped.size)
+        guard visible.width > 0, visible.height > 0 else { return nil }
+        let scaleX = imageRect.width / visible.width
+        let scaleY = imageRect.height / visible.height
+        return CGRect(x: imageRect.minX + (rect.minX - cropped.minX - visible.minX) * scaleX,
+                      y: imageRect.minY + (rect.minY - cropped.minY - visible.minY) * scaleY,
+                      width: rect.width * scaleX,
+                      height: rect.height * scaleY)
     }
 }

--- a/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
@@ -78,7 +78,8 @@ enum StudioRenderer {
                       events: EventLog,
                       sources: FrameSources,
                       cache: Cache = Cache(),
-                      clipSource: Range<TimeInterval>? = nil) -> CGImage? {
+                      clipSource: Range<TimeInterval>? = nil,
+                      outputTime: TimeInterval? = nil) -> CGImage? {
         let (canvas, imageRect) = layout(for: project)
         guard canvas.width >= 1, canvas.height >= 1 else { return nil }
 
@@ -95,7 +96,7 @@ enum StudioRenderer {
 
         draw(project: project, sourceTime: sourceTime, events: events, sources: sources,
              canvas: canvas, imageRect: imageRect, in: context, cache: cache,
-             clipSource: clipSource)
+             clipSource: clipSource, outputTime: outputTime)
 
         return context.makeImage()
     }
@@ -108,7 +109,9 @@ enum StudioRenderer {
                      imageRect: CGRect,
                      in context: CGContext,
                      cache: Cache,
-                     clipSource: Range<TimeInterval>? = nil) {
+                     clipSource: Range<TimeInterval>? = nil,
+                     /// The moment in the *finished* video, which the fades and dips are placed in.
+                     outputTime: TimeInterval? = nil) {
 
         // 1 — background. Cached: it is the same picture every frame.
         drawBackground(project: project, canvas: canvas, sources: sources,
@@ -172,6 +175,18 @@ enum StudioRenderer {
         // Last, so hand-placed text sits above everything including the camera — which is what
         // somebody putting a title on a frame expects.
         drawTextOverlays(project: project, sourceTime: sourceTime, canvas: canvas, in: context)
+
+        // **Last of all, over everything.** A fade to black that left the titles showing would not
+        // be a fade to black.
+        if let outputTime {
+            let alpha = FadeCurtain.alpha(atOutput: outputTime, duration: project.duration,
+                                          fadeIn: project.fadeIn, fadeOut: project.fadeOut,
+                                          dips: FadeCurtain.dips(in: project.timeline))
+            if alpha > 0.001 {
+                context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: CGFloat(alpha)))
+                context.fill(CGRect(origin: .zero, size: canvas))
+            }
+        }
     }
 
     // MARK: - Background

--- a/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
@@ -1,0 +1,332 @@
+import CoreGraphics
+import CoreImage
+import Foundation
+
+/// What a frame needs from outside itself.
+///
+/// Resolved by the caller and handed in — the same contract `BackgroundCompositor.Sources` uses,
+/// and for the same reason: a renderer that reaches into a store is a renderer that cannot be
+/// tested with a bitmap, and the export path is not on the main actor.
+struct FrameSources {
+    /// The decoded screen frame at this instant. Nil renders the surround alone, which is what a
+    /// scrub past the end of the recording should show rather than black.
+    var screen: CGImage?
+    var camera: CGImage?
+    var wallpaper: CGImage?
+    /// Bitmaps for pointers that could not be recognised, keyed by hash.
+    var customCursors: [String: CGImage] = [:]
+
+    init(screen: CGImage? = nil, camera: CGImage? = nil, wallpaper: CGImage? = nil,
+         customCursors: [String: CGImage] = [:]) {
+        self.screen = screen
+        self.camera = camera
+        self.wallpaper = wallpaper
+        self.customCursors = customCursors
+    }
+}
+
+/// Compositing one frame of a project.
+///
+/// **One function, called by both the preview and the export.** If they can diverge they will, and
+/// every "the export doesn't match what I saw" bug lives in that gap — so there is no separate
+/// preview path. `AnnotationRenderer` already establishes the pattern on the screenshot side.
+///
+/// The layer order is stated once, here, because every feature plugs into a named slot:
+/// **background → screen shadow → screen → click effect → cursor → camera → captions.**
+enum StudioRenderer {
+
+    /// Everything that does not change between frames, worked out once.
+    ///
+    /// **The whole performance strategy is finding what does not change and not redrawing it.** A
+    /// mesh gradient at canvas resolution is far too slow to paint sixty times a second and does
+    /// not need to be: it is the same picture every frame.
+    final class Cache {
+        fileprivate var backgroundKey: String?
+        fileprivate var background: CGImage?
+        fileprivate var canvasSize: CGSize = .zero
+        init() {}
+    }
+
+    /// The finished canvas size and where the recording sits inside it.
+    ///
+    /// Reuses `BackgroundLayout` untouched — the arithmetic for padding, an aspect target and
+    /// alignment is identical for a video and a screenshot, and it is already tested.
+    static func layout(for project: StudioProject) -> (canvas: CGSize, imageRect: CGRect) {
+        var style = project.background
+        style.aspect = project.aspect
+        let source = project.cropRect?.size ?? project.canvasSize
+        return BackgroundLayout.compute(imageSize: source, style: style)
+    }
+
+    /// The frame at `sourceTime`, in the recording's own clock.
+    static func frame(of project: StudioProject,
+                      atSource sourceTime: TimeInterval,
+                      events: EventLog,
+                      sources: FrameSources,
+                      cache: Cache = Cache()) -> CGImage? {
+        let (canvas, imageRect) = layout(for: project)
+        guard canvas.width >= 1, canvas.height >= 1 else { return nil }
+
+        guard let context = CGContext(
+            data: nil, width: Int(canvas.width.rounded()), height: Int(canvas.height.rounded()),
+            bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else { return nil }
+
+        // Document space: top-left origin, so `imageRect` means what it says. Same flip the
+        // annotation renderer and the background compositor both use.
+        context.translateBy(x: 0, y: canvas.height)
+        context.scaleBy(x: 1, y: -1)
+
+        draw(project: project, sourceTime: sourceTime, events: events, sources: sources,
+             canvas: canvas, imageRect: imageRect, in: context, cache: cache)
+
+        return context.makeImage()
+    }
+
+    static func draw(project: StudioProject,
+                     sourceTime: TimeInterval,
+                     events: EventLog,
+                     sources: FrameSources,
+                     canvas: CGSize,
+                     imageRect: CGRect,
+                     in context: CGContext,
+                     cache: Cache) {
+
+        // 1 — background. Cached: it is the same picture every frame.
+        drawBackground(project: project, canvas: canvas, sources: sources,
+                       in: context, cache: cache)
+
+        // 2 and 3 — the screen, with its shadow underneath following the corner radius rather than
+        // the bitmap's square edges.
+        var style = project.background
+        style.aspect = project.aspect
+        BackgroundCompositor.drawSurround(style: style,
+                                          canvas: CGRect(origin: .zero, size: canvas),
+                                          imageRect: imageRect, in: context,
+                                          sources: .init(base: sources.screen,
+                                                         wallpaper: sources.wallpaper))
+
+        let transform = ZoomResolver.transform(
+            at: sourceTime,
+            segments: project.visibleZooms,
+            cursor: events.isCursorInside(at: sourceTime) ? events.cursorPoint(at: sourceTime) : nil,
+            frameSize: project.canvasSize)
+
+        context.saveGState()
+        context.addPath(BackgroundCompositor.clipPath(imageRect: imageRect, style: style))
+        context.clip()
+        drawScreen(project: project, transform: transform, imageRect: imageRect,
+                   sources: sources, in: context)
+
+        // 4 and 5 — click effect and cursor, both inside the screen's clip so a pointer near the
+        // edge is cut by the rounded corner exactly as the content is.
+        drawClicks(project: project, sourceTime: sourceTime, events: events,
+                   transform: transform, imageRect: imageRect, in: context)
+        drawCursor(project: project, sourceTime: sourceTime, events: events,
+                   transform: transform, imageRect: imageRect, sources: sources, in: context)
+        context.restoreGState()
+
+        // 6 and 7 — camera and captions, in canvas space: they belong to the finished video, not
+        // to the recording, so a zoom must not move them.
+        drawCaptions(project: project, sourceTime: sourceTime, canvas: canvas, in: context)
+    }
+
+    // MARK: - Background
+
+    private static func drawBackground(project: StudioProject, canvas: CGSize,
+                                       sources: FrameSources, in context: CGContext,
+                                       cache: Cache) {
+        let key = backgroundKey(project.background, canvas: canvas)
+        if cache.backgroundKey == key, let cached = cache.background, cache.canvasSize == canvas {
+            context.drawFlipped(cached, in: CGRect(origin: .zero, size: canvas))
+            return
+        }
+
+        guard let scratch = CGContext(
+            data: nil, width: Int(canvas.width.rounded()), height: Int(canvas.height.rounded()),
+            bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else { return }
+        BackgroundCompositor.drawFill(project.background.fill,
+                                      in: CGRect(origin: .zero, size: canvas),
+                                      context: scratch,
+                                      sources: .init(base: sources.screen,
+                                                     wallpaper: sources.wallpaper))
+        guard let image = scratch.makeImage() else { return }
+        cache.background = image
+        cache.backgroundKey = key
+        cache.canvasSize = canvas
+        context.drawFlipped(image, in: CGRect(origin: .zero, size: canvas))
+    }
+
+    /// A blurred fill is derived from the capture and therefore changes with it; everything else is
+    /// a description and can be keyed by its own value.
+    private static func backgroundKey(_ background: CaptureBackground, canvas: CGSize) -> String {
+        if case .blurred = background.fill { return "blurred-\(canvas)-\(UUID().uuidString)" }
+        let data = try? JSONEncoder().encode(background.fill)
+        return "\(canvas)-\(data?.hashValue ?? 0)"
+    }
+
+    // MARK: - Screen
+
+    private static func drawScreen(project: StudioProject, transform: ZoomTransform,
+                                   imageRect: CGRect, sources: FrameSources,
+                                   in context: CGContext) {
+        guard let screen = sources.screen else { return }
+
+        // The crop is applied first and the zoom on top of it, so a project that was cropped and
+        // then zoomed frames what the user saw when they set the zoom.
+        let full = CGRect(origin: .zero, size: project.canvasSize)
+        let cropped = project.cropRect ?? full
+        let visible = ZoomResolver.sourceRect(for: transform, frameSize: cropped.size)
+        let source = CGRect(x: cropped.minX + visible.minX, y: cropped.minY + visible.minY,
+                            width: visible.width, height: visible.height)
+
+        guard let piece = screen.cropping(to: source.integral) ?? screen.cropping(to: full) else {
+            return
+        }
+        context.saveGState()
+        context.interpolationQuality = .high
+        context.drawFlipped(piece, in: imageRect)
+        context.restoreGState()
+    }
+
+    // MARK: - Cursor
+
+    private static func drawCursor(project: StudioProject, sourceTime: TimeInterval,
+                                   events: EventLog, transform: ZoomTransform,
+                                   imageRect: CGRect, sources: FrameSources,
+                                   in context: CGContext) {
+        let settings = project.cursor
+        guard !settings.isHidden,
+              events.isCursorInside(at: sourceTime),
+              let point = events.cursorPoint(at: sourceTime) else { return }
+
+        let opacity = idleOpacity(settings: settings, events: events, at: sourceTime)
+        guard opacity > 0.01 else { return }
+
+        guard let placed = canvasPoint(point, project: project, transform: transform,
+                                       imageRect: imageRect) else { return }
+
+        let kind = events.cursorKind(at: sourceTime)
+        let height = CursorGlyph.drawnSize(base: settings.size, zoom: transform.scale)
+        let scaled = CGFloat(height) * imageRect.width / max(project.canvasSize.width, 1)
+            * CGFloat(transform.scale)
+
+        let click = lastClick(events: events, at: sourceTime)
+        let effect = click.map {
+            ClickEffect.state(settings.clickEffect, secondsSinceClick: sourceTime - $0.t)
+        } ?? nil
+        let drawn = scaled * CGFloat(effect?.cursorScale ?? 1)
+
+        context.saveGState()
+        context.setAlpha(CGFloat(opacity))
+        if kind == .custom, let hash = events.customCursorHash(at: sourceTime),
+           let bitmap = sources.customCursors[hash] {
+            // An unrecognised pointer keeps its own bitmap. Drawing an arrow where a brush was is
+            // worse than a slightly soft cursor, and a design tool is exactly what people record.
+            let aspect = CGFloat(bitmap.width) / CGFloat(max(bitmap.height, 1))
+            context.drawFlipped(bitmap, in: CGRect(x: placed.x, y: placed.y,
+                                                   width: drawn * aspect, height: drawn))
+        } else if let rendered = CursorGlyph.rendered(for: kind,
+                                                      glyphHeight: max(8, Int(drawn.rounded()))) {
+            // The bitmap is larger than the glyph because the shadow needs room, so it is scaled
+            // by the same ratio and offset by the inset rather than treated as the pointer itself.
+            let ratio = CGFloat(rendered.image.height) / max(rendered.glyphHeight, 1)
+            let insetFraction = rendered.inset / max(rendered.glyphHeight, 1)
+            let origin = CursorGlyph.origin(for: kind, at: placed, drawnHeight: drawn,
+                                            insetFraction: insetFraction)
+            context.drawFlipped(rendered.image, in: CGRect(x: origin.x, y: origin.y,
+                                                           width: drawn * ratio,
+                                                           height: drawn * ratio))
+        }
+        context.restoreGState()
+    }
+
+    /// Fades the pointer out once it has been still, and back in the moment it moves.
+    ///
+    /// This is what stops a recording that pauses on a diagram having a pointer sitting in the
+    /// middle of it for thirty seconds.
+    private static func idleOpacity(settings: CursorSettings, events: EventLog,
+                                    at t: TimeInterval) -> Double {
+        guard settings.hidesWhenIdle, let current = events.cursorPoint(at: t) else { return 1 }
+        var still: TimeInterval = 0
+        var probe = t
+        while probe > 0, still < settings.idleDelay + 1 {
+            probe -= 0.1
+            guard let earlier = events.cursorPoint(at: probe),
+                  hypot(earlier.x - current.x, earlier.y - current.y) < 2 else { break }
+            still += 0.1
+        }
+        guard still >= settings.idleDelay else { return 1 }
+        let fade = min(1, (still - settings.idleDelay) / 0.4)
+        return 1 - fade
+    }
+
+    private static func lastClick(events: EventLog, at t: TimeInterval) -> ClickEvent? {
+        events.pressDowns.last { $0.t <= t && t - $0.t <= ClickEffect.duration }
+    }
+
+    // MARK: - Clicks
+
+    private static func drawClicks(project: StudioProject, sourceTime: TimeInterval,
+                                   events: EventLog, transform: ZoomTransform,
+                                   imageRect: CGRect, in context: CGContext) {
+        guard let click = lastClick(events: events, at: sourceTime), click.isInside,
+              let state = ClickEffect.state(project.cursor.clickEffect,
+                                            secondsSinceClick: sourceTime - click.t),
+              let placed = canvasPoint(click.point, project: project, transform: transform,
+                                       imageRect: imageRect) else { return }
+
+        let unit = CGFloat(CursorGlyph.drawnSize(base: project.cursor.size, zoom: transform.scale))
+            * imageRect.width / max(project.canvasSize.width, 1) * CGFloat(transform.scale)
+        let tint: CGColor = click.button == .right
+            ? CGColor(red: 1, green: 0.62, blue: 0.24, alpha: 1)
+            : CGColor(red: 0.29, green: 0.56, blue: 1, alpha: 1)
+
+        context.saveGState()
+        if state.fillAlpha > 0 {
+            let radius = unit * CGFloat(state.ringRadius)
+            context.setFillColor(tint.copy(alpha: CGFloat(state.fillAlpha)) ?? tint)
+            context.fillEllipse(in: CGRect(x: placed.x - radius, y: placed.y - radius,
+                                           width: radius * 2, height: radius * 2))
+        }
+        if state.ringAlpha > 0 {
+            let radius = unit * CGFloat(state.ringRadius)
+            context.setStrokeColor(tint.copy(alpha: CGFloat(state.ringAlpha)) ?? tint)
+            context.setLineWidth(max(1, unit * 0.12))
+            context.strokeEllipse(in: CGRect(x: placed.x - radius, y: placed.y - radius,
+                                             width: radius * 2, height: radius * 2))
+        }
+        context.restoreGState()
+    }
+
+    /// Recording pixels to canvas points, through the crop and the zoom.
+    ///
+    /// Nil when the point is not currently visible — which happens constantly once a zoom is on,
+    /// and drawing a cursor clamped to the frame edge instead would look like a bug.
+    private static func canvasPoint(_ point: CGPoint, project: StudioProject,
+                                    transform: ZoomTransform, imageRect: CGRect) -> CGPoint? {
+        let cropped = project.cropRect ?? CGRect(origin: .zero, size: project.canvasSize)
+        let visible = ZoomResolver.sourceRect(for: transform, frameSize: cropped.size)
+        let local = CGPoint(x: point.x - cropped.minX - visible.minX,
+                            y: point.y - cropped.minY - visible.minY)
+        guard visible.width > 0, visible.height > 0,
+              local.x >= 0, local.y >= 0,
+              local.x <= visible.width, local.y <= visible.height else { return nil }
+        return CGPoint(x: imageRect.minX + local.x / visible.width * imageRect.width,
+                       y: imageRect.minY + local.y / visible.height * imageRect.height)
+    }
+
+    // MARK: - Captions
+
+    private static func drawCaptions(project: StudioProject, sourceTime: TimeInterval,
+                                     canvas: CGSize, in context: CGContext) {
+        guard let caption = project.captions.first(where: {
+            sourceTime >= $0.start && sourceTime <= $0.end
+        }) else { return }
+        CaptionRenderer.draw(caption, spokenWords: caption.spokenWordCount(at: sourceTime),
+                             canvas: canvas, style: project.captionStyle, in: context)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
@@ -15,13 +15,16 @@ struct FrameSources {
     var wallpaper: CGImage?
     /// Bitmaps for pointers that could not be recognised, keyed by hash.
     var customCursors: [String: CGImage] = [:]
+    /// Pictures the user brought in, keyed by asset name.
+    var media: [String: CGImage] = [:]
 
     init(screen: CGImage? = nil, camera: CGImage? = nil, wallpaper: CGImage? = nil,
-         customCursors: [String: CGImage] = [:]) {
+         customCursors: [String: CGImage] = [:], media: [String: CGImage] = [:]) {
         self.screen = screen
         self.camera = camera
         self.wallpaper = wallpaper
         self.customCursors = customCursors
+        self.media = media
     }
 
     /// The wallpaper a project's background needs, if any.
@@ -174,6 +177,9 @@ enum StudioRenderer {
         drawCaptions(project: project, sourceTime: sourceTime, canvas: canvas, in: context)
         // Last, so hand-placed text sits above everything including the camera — which is what
         // somebody putting a title on a frame expects.
+        // Pictures below text, so a caption over a logo stays readable.
+        drawMediaOverlays(project: project, sourceTime: sourceTime, canvas: canvas,
+                          media: sources.media, in: context)
         drawTextOverlays(project: project, sourceTime: sourceTime, canvas: canvas, in: context)
 
         // **Last of all, over everything.** A fade to black that left the titles showing would not
@@ -410,6 +416,42 @@ enum StudioRenderer {
                 maxWidth: canvas.width * CGFloat(overlay.maxWidthFraction),
                 style: style)
             return (overlay.id, rect)
+        }
+    }
+
+    /// Pictures the user brought in, in canvas space — they belong to the finished video, so a
+    /// zoom must not move them.
+    static func drawMediaOverlays(project: StudioProject, sourceTime: TimeInterval,
+                                  canvas: CGSize, media: [String: CGImage],
+                                  in context: CGContext) {
+        guard canvas.width > 0, canvas.height > 0 else { return }
+        for overlay in project.mediaOverlays {
+            let opacity = overlay.opacity(at: sourceTime)
+            guard opacity > 0.001, let image = media[overlay.asset] else { continue }
+
+            let box = CGRect(x: canvas.width * overlay.rect.minX,
+                             y: canvas.height * overlay.rect.minY,
+                             width: canvas.width * overlay.rect.width,
+                             height: canvas.height * overlay.rect.height)
+            guard box.width > 1, box.height > 1 else { continue }
+
+            context.saveGState()
+            context.setAlpha(CGFloat(opacity))
+            if overlay.cornerRadiusFraction > 0 {
+                let radius = min(box.width, box.height) * CGFloat(overlay.cornerRadiusFraction)
+                context.addPath(CGPath.rounded(box, cornerRadius: radius))
+                context.clip()
+            }
+            // **Fit, not fill.** A logo that has been cropped to a square box is worse than one
+            // with space around it, and stretching it is worse than either — so the picture is
+            // scaled to fit inside the box and centred there.
+            let source = CGSize(width: image.width, height: image.height)
+            let scale = min(box.width / max(1, source.width), box.height / max(1, source.height))
+            let drawn = CGSize(width: source.width * scale, height: source.height * scale)
+            context.drawFlipped(image, in: CGRect(
+                x: box.midX - drawn.width / 2, y: box.midY - drawn.height / 2,
+                width: drawn.width, height: drawn.height))
+            context.restoreGState()
         }
     }
 

--- a/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
@@ -82,7 +82,8 @@ enum StudioRenderer {
                       sources: FrameSources,
                       cache: Cache = Cache(),
                       clipSource: Range<TimeInterval>? = nil,
-                      outputTime: TimeInterval? = nil) -> CGImage? {
+                      outputTime: TimeInterval? = nil,
+                      cameraStart: TimeInterval = 0) -> CGImage? {
         let (canvas, imageRect) = layout(for: project)
         guard canvas.width >= 1, canvas.height >= 1 else { return nil }
 
@@ -99,7 +100,7 @@ enum StudioRenderer {
 
         draw(project: project, sourceTime: sourceTime, events: events, sources: sources,
              canvas: canvas, imageRect: imageRect, in: context, cache: cache,
-             clipSource: clipSource, outputTime: outputTime)
+             clipSource: clipSource, outputTime: outputTime, cameraStart: cameraStart)
 
         return context.makeImage()
     }
@@ -114,7 +115,11 @@ enum StudioRenderer {
                      cache: Cache,
                      clipSource: Range<TimeInterval>? = nil,
                      /// The moment in the *finished* video, which the fades and dips are placed in.
-                     outputTime: TimeInterval? = nil) {
+                     outputTime: TimeInterval? = nil,
+                     /// When the camera track begins, in source time — a couple of seconds after
+                     /// the screen, since a capture session takes that long to come up. Recording
+                     /// metadata rather than a project edit, so it is passed rather than saved.
+                     cameraStart: TimeInterval = 0) {
 
         // 1 — background. Cached: it is the same picture every frame.
         drawBackground(project: project, canvas: canvas, sources: sources,
@@ -171,7 +176,7 @@ enum StudioRenderer {
         // to the recording, so a zoom must not move them.
         drawCamera(project: project, sourceTime: sourceTime, transform: transform,
                    canvas: canvas, camera: sources.camera, in: context,
-                   clipSource: clipSource)
+                   clipSource: clipSource, cameraStart: cameraStart)
         drawKeystrokes(project: project, sourceTime: sourceTime, events: events,
                        canvas: canvas, in: context)
         drawCaptions(project: project, sourceTime: sourceTime, canvas: canvas, in: context)
@@ -645,14 +650,16 @@ extension StudioRenderer {
     static func drawCamera(project: StudioProject, sourceTime: TimeInterval,
                            transform: ZoomTransform, canvas: CGSize,
                            camera: CGImage?, in context: CGContext,
-                           clipSource: Range<TimeInterval>? = nil) {
+                           clipSource: Range<TimeInterval>? = nil,
+                           cameraStart: TimeInterval = 0) {
         guard let camera,
               let state = CameraLayoutResolver.state(at: sourceTime,
                                                      segments: project.cameraSegments,
                                                      settings: project.camera,
                                                      canvas: canvas,
                                                      zoom: transform.scale,
-                                                     clipSource: clipSource) else { return }
+                                                     clipSource: clipSource,
+                                                     cameraStart: cameraStart) else { return }
 
         let path = CGPath.rounded(state.rect, cornerRadius: state.cornerRadius)
         if let shadow = project.camera.shadow {

--- a/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
@@ -169,6 +169,9 @@ enum StudioRenderer {
         drawKeystrokes(project: project, sourceTime: sourceTime, events: events,
                        canvas: canvas, in: context)
         drawCaptions(project: project, sourceTime: sourceTime, canvas: canvas, in: context)
+        // Last, so hand-placed text sits above everything including the camera — which is what
+        // somebody putting a title on a frame expects.
+        drawTextOverlays(project: project, sourceTime: sourceTime, canvas: canvas, in: context)
     }
 
     // MARK: - Background
@@ -368,6 +371,56 @@ enum StudioRenderer {
     }
 
     // MARK: - Captions
+
+    /// Where each visible line of hand-placed text sits, in canvas points.
+    ///
+    /// Shared with the canvas so dragging text hits exactly what is drawn, rather than a second
+    /// guess at the same geometry — the class of bug the wallpaper helper exists to avoid.
+    static func textBoxes(project: StudioProject, sourceTime: TimeInterval,
+                          canvas: CGSize) -> [(id: TextOverlay.ID, rect: CGRect)] {
+        guard canvas.height > 0 else { return [] }
+        return project.textOverlays.compactMap { overlay in
+            guard overlay.covers(sourceTime), !overlay.text.isEmpty else { return nil }
+            let style = TextLayer.Style(
+                font: overlay.font(forCanvasHeight: canvas.height),
+                colour: overlay.colour,
+                background: overlay.background,
+                padding: canvas.height * CGFloat(overlay.paddingFraction),
+                cornerRadius: canvas.height * CGFloat(overlay.cornerRadiusFraction),
+                haloColour: overlay.haloColour)
+            let rect = TextLayer.box(
+                for: overlay.text,
+                centredOn: CGPoint(x: canvas.width * overlay.origin.x,
+                                   y: canvas.height * overlay.origin.y),
+                maxWidth: canvas.width * CGFloat(overlay.maxWidthFraction),
+                style: style)
+            return (overlay.id, rect)
+        }
+    }
+
+    /// Hand-placed text, in canvas space — it belongs to the finished video rather than to the
+    /// recording, like the camera and the captions, so a zoom must not move it.
+    static func drawTextOverlays(project: StudioProject, sourceTime: TimeInterval,
+                                 canvas: CGSize, in context: CGContext) {
+        guard canvas.height > 0 else { return }
+        for overlay in project.textOverlays {
+            let opacity = overlay.opacity(at: sourceTime)
+            guard opacity > 0.001, !overlay.text.isEmpty else { continue }
+            let style = TextLayer.Style(
+                font: overlay.font(forCanvasHeight: canvas.height),
+                colour: overlay.colour,
+                background: overlay.background,
+                padding: canvas.height * CGFloat(overlay.paddingFraction),
+                cornerRadius: canvas.height * CGFloat(overlay.cornerRadiusFraction),
+                haloColour: overlay.haloColour,
+                opacity: opacity)
+            TextLayer.draw(overlay.text,
+                           centredOn: CGPoint(x: canvas.width * overlay.origin.x,
+                                              y: canvas.height * overlay.origin.y),
+                           maxWidth: canvas.width * CGFloat(overlay.maxWidthFraction),
+                           style: style, in: context)
+        }
+    }
 
     private static func drawCaptions(project: StudioProject, sourceTime: TimeInterval,
                                      canvas: CGSize, in context: CGContext) {

--- a/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
@@ -23,6 +23,20 @@ struct FrameSources {
         self.wallpaper = wallpaper
         self.customCursors = customCursors
     }
+
+    /// The wallpaper a project's background needs, if any.
+    ///
+    /// **One definition, used by the live canvas and the export both.** The screenshot editor
+    /// states why next to its own equivalent: the two disagreeing about a background is a failure
+    /// that feature has already had once, with the surround visible in the file and not on the
+    /// canvas. Studio managed the opposite of both — it passed no wallpaper anywhere, so a
+    /// wallpaper background simply rendered as nothing.
+    /// Main-actor because `WallpaperStore` is; resolved once, before any render loop.
+    @MainActor
+    static func wallpaper(for project: StudioProject) -> CGImage? {
+        guard case .image(let fileName) = project.background.fill else { return nil }
+        return WallpaperStore.shared.image(named: fileName)
+    }
 }
 
 /// Compositing one frame of a project.

--- a/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioRenderer.swift
@@ -77,7 +77,8 @@ enum StudioRenderer {
                       atSource sourceTime: TimeInterval,
                       events: EventLog,
                       sources: FrameSources,
-                      cache: Cache = Cache()) -> CGImage? {
+                      cache: Cache = Cache(),
+                      clipSource: Range<TimeInterval>? = nil) -> CGImage? {
         let (canvas, imageRect) = layout(for: project)
         guard canvas.width >= 1, canvas.height >= 1 else { return nil }
 
@@ -93,7 +94,8 @@ enum StudioRenderer {
         context.scaleBy(x: 1, y: -1)
 
         draw(project: project, sourceTime: sourceTime, events: events, sources: sources,
-             canvas: canvas, imageRect: imageRect, in: context, cache: cache)
+             canvas: canvas, imageRect: imageRect, in: context, cache: cache,
+             clipSource: clipSource)
 
         return context.makeImage()
     }
@@ -105,7 +107,8 @@ enum StudioRenderer {
                      canvas: CGSize,
                      imageRect: CGRect,
                      in context: CGContext,
-                     cache: Cache) {
+                     cache: Cache,
+                     clipSource: Range<TimeInterval>? = nil) {
 
         // 1 — background. Cached: it is the same picture every frame.
         drawBackground(project: project, canvas: canvas, sources: sources,
@@ -131,7 +134,8 @@ enum StudioRenderer {
             at: sourceTime,
             segments: project.visibleZooms,
             cursor: events.isCursorInside(at: sourceTime) ? events.cursorPoint(at: sourceTime) : nil,
-            frameSize: project.canvasSize)
+            frameSize: project.canvasSize,
+            clipSource: clipSource)
 
         context.saveGState()
         if let frame {
@@ -160,7 +164,8 @@ enum StudioRenderer {
         // 6 and 7 — camera and captions, in canvas space: they belong to the finished video, not
         // to the recording, so a zoom must not move them.
         drawCamera(project: project, sourceTime: sourceTime, transform: transform,
-                   canvas: canvas, camera: sources.camera, in: context)
+                   canvas: canvas, camera: sources.camera, in: context,
+                   clipSource: clipSource)
         drawKeystrokes(project: project, sourceTime: sourceTime, events: events,
                        canvas: canvas, in: context)
         drawCaptions(project: project, sourceTime: sourceTime, canvas: canvas, in: context)
@@ -529,13 +534,15 @@ extension StudioRenderer {
     /// so a zoom must not move it.
     static func drawCamera(project: StudioProject, sourceTime: TimeInterval,
                            transform: ZoomTransform, canvas: CGSize,
-                           camera: CGImage?, in context: CGContext) {
+                           camera: CGImage?, in context: CGContext,
+                           clipSource: Range<TimeInterval>? = nil) {
         guard let camera,
               let state = CameraLayoutResolver.state(at: sourceTime,
                                                      segments: project.cameraSegments,
                                                      settings: project.camera,
                                                      canvas: canvas,
-                                                     zoom: transform.scale) else { return }
+                                                     zoom: transform.scale,
+                                                     clipSource: clipSource) else { return }
 
         let path = CGPath.rounded(state.rect, cornerRadius: state.cornerRadius)
         if let shadow = project.camera.shadow {

--- a/Sources/Sarvkrit/Features/Studio/StudioShortcuts.swift
+++ b/Sources/Sarvkrit/Features/Studio/StudioShortcuts.swift
@@ -1,0 +1,75 @@
+import AppKit
+import Foundation
+
+/// What the editor can do from the keyboard, as a value.
+///
+/// **⌘/ used to be routed to `break`** — recognised, deliberately silent, and so the one
+/// discoverability hatch the editor had was nailed shut. Adding a zoom by hand has worked all along,
+/// behind an unlabelled magnifying glass and the `Z` key, and was still reported as missing. That is
+/// a fair report: a shortcut nobody can find does not exist.
+///
+/// Kept as data rather than as text in a view so `StudioShortcutsTests` can check every entry
+/// against `StudioKeyRouting` and fail when the two drift.
+enum StudioShortcuts {
+
+    struct Entry: Identifiable {
+        var id: String { title }
+        var title: String
+        /// What to print for the key, e.g. "Space", "⌘B", "1–9".
+        var keyLabel: String
+        /// The characters `StudioKeyRouting` matches on, for the test that keeps this honest.
+        var characters: String
+        var modifiers: NSEvent.ModifierFlags = []
+        /// Listed, but not built. Better said out loud than silently omitted.
+        var isUnavailable = false
+        var note: String?
+    }
+
+    struct Group: Identifiable {
+        var id: String { name }
+        var name: String
+        var entries: [Entry]
+    }
+
+    static let groups: [Group] = [
+        Group(name: "Playing", entries: [
+            Entry(title: "Play or Pause", keyLabel: "Space", characters: " "),
+            Entry(title: "Nudge One Frame", keyLabel: ", / .", characters: ","),
+            Entry(title: "Play Forwards, Faster", keyLabel: "L", characters: "l"),
+            Entry(title: "Play Backwards", keyLabel: "J", characters: "j"),
+            Entry(title: "Stop", keyLabel: "K", characters: "k"),
+            Entry(title: "Loop Playback", keyLabel: "⌘L", characters: "l",
+                  modifiers: .command),
+        ]),
+        Group(name: "Adding Things", entries: [
+            Entry(title: "Add a Zoom Here", keyLabel: "Z", characters: "z",
+                  note: "Right-click the timeline for clicks, highlights and the camera"),
+            Entry(title: "Set the Zoom's Strength", keyLabel: "1–9", characters: "2"),
+            Entry(title: "Split the Clip Here", keyLabel: "⌘B", characters: "b",
+                  modifiers: .command),
+            Entry(title: "Delete What's Selected", keyLabel: "⌫", characters: "\u{7F}"),
+            Entry(title: "Delete and Close the Gap", keyLabel: "X", characters: "x"),
+        ]),
+        Group(name: "The Project", entries: [
+            Entry(title: "Undo", keyLabel: "⌘Z", characters: "z", modifiers: .command),
+            Entry(title: "Redo", keyLabel: "⇧⌘Z", characters: "z",
+                  modifiers: [.command, .shift]),
+            Entry(title: "Save", keyLabel: "⌘S", characters: "s", modifiers: .command),
+            Entry(title: "Export", keyLabel: "⌘E", characters: "e", modifiers: .command),
+            Entry(title: "Copy This Frame", keyLabel: "⌘C", characters: "c",
+                  modifiers: .command),
+            Entry(title: "Undo Every Edit", keyLabel: "⌘⌫", characters: "\u{7F}",
+                  modifiers: .command),
+            Entry(title: "Close", keyLabel: "⌘W", characters: "w", modifiers: .command),
+        ]),
+        Group(name: "Not Built Yet", entries: [
+            Entry(title: "Set the In Point", keyLabel: "I", characters: "i",
+                  isUnavailable: true,
+                  note: "Trim by splitting with ⌘B and deleting instead"),
+            Entry(title: "Set the Out Point", keyLabel: "O", characters: "o",
+                  isUnavailable: true, note: nil),
+        ]),
+    ]
+
+    static var all: [Entry] { groups.flatMap(\.entries) }
+}

--- a/Sources/Sarvkrit/Features/Studio/TextLayer.swift
+++ b/Sources/Sarvkrit/Features/Studio/TextLayer.swift
@@ -1,0 +1,103 @@
+import AppKit
+import CoreGraphics
+import CoreText
+import Foundation
+
+/// Drawing a string into a frame, with wrapping.
+///
+/// **Three places in this app each rolled their own attributed-string pipeline and none was
+/// shareable**: `CaptionRenderer` (Core Text, wraps properly), `AnnotationRenderer.drawText`
+/// (private, in another feature, single-line only) and `KeystrokeRenderer`'s pills. This is the one
+/// that new text goes through.
+///
+/// Captions and keystroke pills are deliberately *not* moved onto it yet: both have snapshot tests
+/// and re-laying them out would move pixels for no user-visible gain. Worth doing, separately.
+enum TextLayer {
+
+    struct Style {
+        var font: NSFont
+        var colour: RGBAColour
+        var background: RGBAColour?
+        var padding: CGFloat = 12
+        var cornerRadius: CGFloat = 10
+        /// A halo behind the glyphs, for text over a photograph that cannot wear a box.
+        var haloColour: RGBAColour?
+        var opacity: Double = 1
+    }
+
+    /// The box `draw` would fill, without drawing it — for hit-testing what is on screen.
+    static func box(for string: String, centredOn centre: CGPoint, maxWidth: CGFloat,
+                    style: Style) -> CGRect {
+        guard !string.isEmpty, maxWidth > 1 else { return .zero }
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+        paragraph.lineBreakMode = .byWordWrapping
+        let text = NSAttributedString(string: string, attributes: [
+            .font: style.font,
+            .paragraphStyle: paragraph,
+        ])
+        let framesetter = CTFramesetterCreateWithAttributedString(text)
+        let measured = CTFramesetterSuggestFrameSizeWithConstraints(
+            framesetter, CFRange(location: 0, length: 0), nil,
+            CGSize(width: maxWidth, height: .greatestFiniteMagnitude), nil)
+        return CGRect(x: centre.x - (measured.width + style.padding * 2) / 2,
+                      y: centre.y - (measured.height + style.padding * 2) / 2,
+                      width: measured.width + style.padding * 2,
+                      height: measured.height + style.padding * 2)
+    }
+
+    /// Draws `string` centred horizontally on `centre`, wrapped to `maxWidth`.
+    ///
+    /// - Returns: the box it filled, so a caller can hit-test what it drew.
+    @discardableResult
+    static func draw(_ string: String, centredOn centre: CGPoint, maxWidth: CGFloat,
+                     style: Style, in context: CGContext) -> CGRect {
+        guard !string.isEmpty, maxWidth > 1, style.opacity > 0.001 else { return .zero }
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+        paragraph.lineBreakMode = .byWordWrapping
+        var attributes: [NSAttributedString.Key: Any] = [
+            .font: style.font,
+            .foregroundColor: NSColor(cgColor: style.colour.cgColor) ?? .white,
+            .paragraphStyle: paragraph,
+        ]
+        if let halo = style.haloColour {
+            // Stroke *and* fill: a negative width means "outline behind the glyphs", which is the
+            // only way to get a halo without drawing the string twice.
+            attributes[.strokeColor] = NSColor(cgColor: halo.cgColor) ?? .black
+            attributes[.strokeWidth] = -6.0
+        }
+
+        let text = NSAttributedString(string: string, attributes: attributes)
+        let framesetter = CTFramesetterCreateWithAttributedString(text)
+        let measured = CTFramesetterSuggestFrameSizeWithConstraints(
+            framesetter, CFRange(location: 0, length: 0), nil,
+            CGSize(width: maxWidth, height: .greatestFiniteMagnitude), nil)
+
+        let box = CGRect(x: centre.x - (measured.width + style.padding * 2) / 2,
+                         y: centre.y - (measured.height + style.padding * 2) / 2,
+                         width: measured.width + style.padding * 2,
+                         height: measured.height + style.padding * 2)
+
+        context.saveGState()
+        context.setAlpha(CGFloat(style.opacity))
+        if let background = style.background {
+            context.addPath(CGPath.rounded(box, cornerRadius: style.cornerRadius))
+            context.setFillColor(background.cgColor)
+            context.fillPath()
+        }
+
+        // Core Text draws bottom-up and the surrounding context is top-left, so the block is
+        // flipped back for the duration of the draw and no further — the same dance
+        // `CaptionRenderer` does, for the same reason.
+        let textRect = box.insetBy(dx: style.padding, dy: style.padding)
+        context.translateBy(x: 0, y: textRect.midY * 2)
+        context.scaleBy(x: 1, y: -1)
+        let frame = CTFramesetterCreateFrame(framesetter, CFRange(location: 0, length: 0),
+                                             CGPath(rect: textRect, transform: nil), nil)
+        CTFrameDraw(frame, context)
+        context.restoreGState()
+        return box
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/TextOverlay.swift
+++ b/Sources/Sarvkrit/Features/Studio/TextOverlay.swift
@@ -32,9 +32,10 @@ struct TextOverlay: Codable, Equatable, Identifiable {
     var cornerRadiusFraction: Double = 0.014
     var haloColour: RGBAColour?
     /// Faded in and out, because text appearing between two frames reads as a flash.
-    var fadeSeconds: TimeInterval = 0.2
+    var fadeSeconds: TimeInterval = TextOverlay.defaultFade
 
     static let minimumDuration: TimeInterval = 0.4
+    static let defaultFade: TimeInterval = 0.2
 
     func covers(_ t: TimeInterval) -> Bool { t >= start && t < end }
 

--- a/Sources/Sarvkrit/Features/Studio/TextOverlay.swift
+++ b/Sources/Sarvkrit/Features/Studio/TextOverlay.swift
@@ -1,0 +1,130 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+/// A line of text put on the video by hand, at a place and for a stretch.
+///
+/// **Its own type, because captions cannot express this.** `Caption` has no text field and no time
+/// range of its own — both derive from `words: [TranscriptWord]`, each needing a speech-recognition
+/// timestamp — and `CaptionStyle` is stored once per project with a position that is one of three
+/// canned values rather than a point. Faking a caption would mean inventing word timings to carry a
+/// string, and then fighting the karaoke highlighting it exists for.
+///
+/// Everything is a **fraction of the canvas** rather than a point count, so a project keeps its
+/// framing when the aspect or the export size changes — the same reason `CameraSettings` and
+/// `CaptionStyle` are written that way.
+struct TextOverlay: Codable, Equatable, Identifiable {
+    var id = UUID()
+    var start: TimeInterval
+    var end: TimeInterval
+    var text: String = "Text"
+    /// Unit canvas coordinates, from the top-left.
+    var origin = CGPoint(x: 0.5, y: 0.16)
+    /// Of the canvas height.
+    var sizeFraction: Double = 0.055
+    var maxWidthFraction: Double = 0.8
+    var colour = RGBAColour.white
+    var background: RGBAColour? = RGBAColour(r: 0, g: 0, b: 0, a: 0.55)
+    var typeface: TextElement.Typeface = .rounded
+    var isBold = true
+    /// Of the canvas height, like the size.
+    var paddingFraction: Double = 0.018
+    var cornerRadiusFraction: Double = 0.014
+    var haloColour: RGBAColour?
+    /// Faded in and out, because text appearing between two frames reads as a flash.
+    var fadeSeconds: TimeInterval = 0.2
+
+    static let minimumDuration: TimeInterval = 0.4
+
+    func covers(_ t: TimeInterval) -> Bool { t >= start && t < end }
+
+    /// 0 outside, ramping at each end, 1 while it holds.
+    func opacity(at t: TimeInterval) -> Double {
+        guard covers(t) else { return 0 }
+        let ramp = max(0.0001, min(fadeSeconds, (end - start) / 2))
+        return min(1, max(0, min(t - start, end - t) / ramp))
+    }
+
+    /// The font at a given canvas size.
+    func font(forCanvasHeight height: CGFloat) -> NSFont {
+        let size = max(6, height * CGFloat(sizeFraction))
+        switch typeface {
+        case .rounded:
+            let base = NSFont.systemFont(ofSize: size, weight: isBold ? .bold : .regular)
+            guard let descriptor = base.fontDescriptor.withDesign(.rounded) else { return base }
+            return NSFont(descriptor: descriptor, size: size) ?? base
+        case .monospaced:
+            return NSFont.monospacedSystemFont(ofSize: size, weight: isBold ? .bold : .regular)
+        case .standard, .custom:
+            return NSFont.systemFont(ofSize: size, weight: isBold ? .bold : .regular)
+        }
+    }
+
+    /// Hand-written for the reason `Clip`'s and `TextElement`'s are: a field added in a later
+    /// release must not make an older project fail to open, and an unreadable project is treated as
+    /// no project — which would quietly discard somebody's edits.
+    private enum Key: String, CodingKey {
+        case id, start, end, text, origin, sizeFraction, maxWidthFraction
+        case colour, background, typeface, isBold, paddingFraction, cornerRadiusFraction
+        case haloColour, fadeSeconds
+    }
+
+    init(start: TimeInterval, end: TimeInterval, text: String = "Text") {
+        self.start = start
+        self.end = end
+        self.text = text
+    }
+
+    /// Written by hand as well, because the synthesized encoder omits a nil `Optional` entirely —
+    /// which would make "no background" indistinguishable from "saved before backgrounds existed"
+    /// and quietly restore the box. The pair has to agree.
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: Key.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(start, forKey: .start)
+        try container.encode(end, forKey: .end)
+        try container.encode(text, forKey: .text)
+        try container.encode(origin, forKey: .origin)
+        try container.encode(sizeFraction, forKey: .sizeFraction)
+        try container.encode(maxWidthFraction, forKey: .maxWidthFraction)
+        try container.encode(colour, forKey: .colour)
+        // Explicitly, including null.
+        try container.encode(background, forKey: .background)
+        try container.encode(typeface, forKey: .typeface)
+        try container.encode(isBold, forKey: .isBold)
+        try container.encode(paddingFraction, forKey: .paddingFraction)
+        try container.encode(cornerRadiusFraction, forKey: .cornerRadiusFraction)
+        try container.encode(haloColour, forKey: .haloColour)
+        try container.encode(fadeSeconds, forKey: .fadeSeconds)
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Key.self)
+        func read<T: Decodable>(_ key: Key, _ fallback: T) -> T {
+            (try? container.decode(T.self, forKey: key)) ?? fallback
+        }
+        id = read(.id, UUID())
+        start = read(.start, 0)
+        end = read(.end, 0)
+        text = read(.text, "Text")
+        origin = read(.origin, CGPoint(x: 0.5, y: 0.16))
+        sizeFraction = read(.sizeFraction, 0.055)
+        maxWidthFraction = read(.maxWidthFraction, 0.8)
+        colour = read(.colour, RGBAColour.white)
+        // **`contains` rather than `try?`, and it matters.** A missing key means "this project
+        // predates the field", which should take the default box; a key that is present and null
+        // means "the user turned the box off", which must stay off. `try?` cannot tell those
+        // apart, so turning the background off then reopening would put it back.
+        if container.contains(.background) {
+            background = try? container.decode(RGBAColour.self, forKey: .background)
+        } else {
+            background = RGBAColour(r: 0, g: 0, b: 0, a: 0.55)
+        }
+        typeface = read(.typeface, TextElement.Typeface.rounded)
+        isBold = read(.isBold, true)
+        paddingFraction = read(.paddingFraction, 0.018)
+        cornerRadiusFraction = read(.cornerRadiusFraction, 0.014)
+        haloColour = try? container.decode(RGBAColour.self, forKey: .haloColour)
+        fadeSeconds = read(.fadeSeconds, 0.2)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/Timeline.swift
+++ b/Sources/Sarvkrit/Features/Studio/Timeline.swift
@@ -24,6 +24,12 @@ struct Clip: Codable, Equatable, Identifiable {
     /// interpolation that makes a cursor look weightless also makes it appear to hover between
     /// items it never touched.
     var disablesCursorSmoothing = false
+    /// Extra output seconds during which the clip's last frame is held.
+    ///
+    /// **A freeze frame, as one field rather than a new kind of clip.** It composes with speed and
+    /// trimming — the moving part shortens with speed, the hold does not — and it needs no new
+    /// mapping: the source time simply stops advancing.
+    var hold: TimeInterval = 0
 
     static let speedRange: ClosedRange<Double> = 0.25...4
 
@@ -32,10 +38,60 @@ struct Clip: Codable, Equatable, Identifiable {
     /// is what the user is looking at: 100 ms of source at 4× is 25 ms on screen.
     static let minimumOutputDuration: TimeInterval = 0.1
 
+    /// Hand-written for the same reason `StudioProject`'s and `RecordingManifest`'s are: **a
+    /// missing key takes a default and never throws.**
+    ///
+    /// A synthesized decoder throws on a missing key even when the property has a default — a
+    /// default is not the same as optional — so every field added to this struct was a chance to
+    /// make every previously saved project unreadable. And `StudioDocumentModel` treats an
+    /// unreadable project as "no project", so the failure mode was not an error message: it was
+    /// somebody's edits quietly disappearing. Caught by a test before it shipped, once.
+    private enum Key: String, CodingKey {
+        case id, sourceStart, sourceEnd, speed, volume, systemAudioVolume
+        case isMuted, hidesCursor, disablesCursorSmoothing, hold
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Key.self)
+        func read<T: Decodable>(_ key: Key, _ fallback: T) -> T {
+            (try? container.decode(T.self, forKey: key)) ?? fallback
+        }
+        id = read(.id, UUID())
+        sourceStart = read(.sourceStart, 0)
+        sourceEnd = read(.sourceEnd, 0)
+        speed = read(.speed, 1)
+        volume = read(.volume, 1)
+        systemAudioVolume = read(.systemAudioVolume, 1)
+        isMuted = read(.isMuted, false)
+        hidesCursor = read(.hidesCursor, false)
+        disablesCursorSmoothing = read(.disablesCursorSmoothing, false)
+        hold = read(.hold, 0)
+    }
+
+    /// Spelled out because the hand-written decoder above suppresses the memberwise one.
+    init(id: UUID = UUID(), sourceStart: TimeInterval, sourceEnd: TimeInterval,
+         speed: Double = 1, volume: Double = 1, systemAudioVolume: Double = 1,
+         isMuted: Bool = false, hidesCursor: Bool = false,
+         disablesCursorSmoothing: Bool = false, hold: TimeInterval = 0) {
+        self.id = id
+        self.sourceStart = sourceStart
+        self.sourceEnd = sourceEnd
+        self.speed = speed
+        self.volume = volume
+        self.systemAudioVolume = systemAudioVolume
+        self.isMuted = isMuted
+        self.hidesCursor = hidesCursor
+        self.disablesCursorSmoothing = disablesCursorSmoothing
+        self.hold = hold
+    }
+
     var sourceDuration: TimeInterval { max(0, sourceEnd - sourceStart) }
 
-    /// How long this clip occupies in the finished video.
-    var outputDuration: TimeInterval { sourceDuration / speed }
+    /// How long the moving part occupies in the finished video, before any held frame.
+    var movingOutputDuration: TimeInterval { sourceDuration / speed }
+
+    /// How long this clip occupies in the finished video, including a held last frame.
+    var outputDuration: TimeInterval { movingOutputDuration + max(0, hold) }
 }
 
 /// The edit: a list of clips, and the arithmetic that maps between the finished video and the
@@ -74,7 +130,14 @@ struct Timeline: Codable, Equatable {
         for clip in clips {
             let next = elapsed + clip.outputDuration
             if output < next {
-                return (clip, clip.sourceStart + (output - elapsed) * clip.speed)
+                let into = output - elapsed
+                // Past the moving part, the clip is holding its last frame. A hair inside the end
+                // rather than exactly on it, because a clip owns `[start, end)` and every other
+                // track resolves against that half-open range.
+                guard into < clip.movingOutputDuration else {
+                    return (clip, max(clip.sourceStart, clip.sourceEnd - 0.0001))
+                }
+                return (clip, clip.sourceStart + into * clip.speed)
             }
             elapsed = next
         }
@@ -142,6 +205,62 @@ struct Timeline: Codable, Equatable {
 
         var updated = self
         updated.clips[index] = clip
+        return updated
+    }
+
+    /// Moves a clip to a different place in the running order.
+    ///
+    /// **Correct by construction, which is why there is so little here.** `sourceTime(forOutput:)`
+    /// walks the clips in array order, and every other track — zooms, masks, camera layouts,
+    /// captions — is stored in *source* time and resolved through that mapping. So a clip carries
+    /// its material with it and whatever was attached to that material arrives with it. There was
+    /// simply never a method to do it.
+    ///
+    /// A move that changes nothing is refused, so it costs no undo step.
+    func move(from index: Int, to destination: Int) -> Timeline {
+        guard clips.indices.contains(index), clips.indices.contains(destination),
+              index != destination else { return self }
+        var updated = self
+        let clip = updated.clips.remove(at: index)
+        updated.clips.insert(clip, at: destination)
+        return updated
+    }
+
+    /// A second copy of a clip, immediately after it.
+    ///
+    /// The copy gets a new identity, or selection and every per-clip edit would address both at
+    /// once. Note that both copies show the same material, so anything attached to that material
+    /// renders in both — which is usually what somebody duplicating a clip wants.
+    func duplicate(id: Clip.ID) -> Timeline {
+        guard let index = clips.firstIndex(where: { $0.id == id }) else { return self }
+        var copy = clips[index]
+        copy.id = UUID()
+        var updated = self
+        updated.clips.insert(copy, at: index + 1)
+        return updated
+    }
+
+    /// Moves the cut between a clip and its neighbour without moving where that cut falls in the
+    /// finished video: one side gains the material the other gives up.
+    ///
+    /// The adjustment a cut most often needs — "start the next shot a little earlier" — without
+    /// disturbing anything downstream of it.
+    func roll(after id: Clip.ID, by seconds: TimeInterval) -> Timeline {
+        guard let index = clips.firstIndex(where: { $0.id == id }),
+              clips.indices.contains(index + 1), seconds != 0 else { return self }
+
+        var left = clips[index]
+        var right = clips[index + 1]
+        left.sourceEnd += seconds
+        right.sourceStart += seconds
+
+        guard left.sourceEnd > left.sourceStart, right.sourceEnd > right.sourceStart,
+              left.outputDuration >= Clip.minimumOutputDuration,
+              right.outputDuration >= Clip.minimumOutputDuration else { return self }
+
+        var updated = self
+        updated.clips[index] = left
+        updated.clips[index + 1] = right
         return updated
     }
 

--- a/Sources/Sarvkrit/Features/Studio/Timeline.swift
+++ b/Sources/Sarvkrit/Features/Studio/Timeline.swift
@@ -24,6 +24,12 @@ struct Clip: Codable, Equatable, Identifiable {
     /// interpolation that makes a cursor look weightless also makes it appear to hover between
     /// items it never touched.
     var disablesCursorSmoothing = false
+    /// Seconds of dip to black at this clip's *start*, half either side of the cut.
+    ///
+    /// Belongs to the clip that starts at the cut, the same convention
+    /// `sourceTime(forOutput:)` uses for the boundary. Ignored on the first clip, which has no cut
+    /// before it — a fade in is the setting for that.
+    var dipToBlack: TimeInterval = 0
     /// Extra output seconds during which the clip's last frame is held.
     ///
     /// **A freeze frame, as one field rather than a new kind of clip.** It composes with speed and
@@ -48,7 +54,7 @@ struct Clip: Codable, Equatable, Identifiable {
     /// somebody's edits quietly disappearing. Caught by a test before it shipped, once.
     private enum Key: String, CodingKey {
         case id, sourceStart, sourceEnd, speed, volume, systemAudioVolume
-        case isMuted, hidesCursor, disablesCursorSmoothing, hold
+        case isMuted, hidesCursor, disablesCursorSmoothing, hold, dipToBlack
     }
 
     init(from decoder: Decoder) throws {
@@ -66,13 +72,15 @@ struct Clip: Codable, Equatable, Identifiable {
         hidesCursor = read(.hidesCursor, false)
         disablesCursorSmoothing = read(.disablesCursorSmoothing, false)
         hold = read(.hold, 0)
+        dipToBlack = read(.dipToBlack, 0)
     }
 
     /// Spelled out because the hand-written decoder above suppresses the memberwise one.
     init(id: UUID = UUID(), sourceStart: TimeInterval, sourceEnd: TimeInterval,
          speed: Double = 1, volume: Double = 1, systemAudioVolume: Double = 1,
          isMuted: Bool = false, hidesCursor: Bool = false,
-         disablesCursorSmoothing: Bool = false, hold: TimeInterval = 0) {
+         disablesCursorSmoothing: Bool = false, hold: TimeInterval = 0,
+         dipToBlack: TimeInterval = 0) {
         self.id = id
         self.sourceStart = sourceStart
         self.sourceEnd = sourceEnd
@@ -83,6 +91,7 @@ struct Clip: Codable, Equatable, Identifiable {
         self.hidesCursor = hidesCursor
         self.disablesCursorSmoothing = disablesCursorSmoothing
         self.hold = hold
+        self.dipToBlack = dipToBlack
     }
 
     var sourceDuration: TimeInterval { max(0, sourceEnd - sourceStart) }

--- a/Sources/Sarvkrit/Features/Studio/Timeline.swift
+++ b/Sources/Sarvkrit/Features/Studio/Timeline.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+/// One stretch of the recording, as it appears in the finished video.
+///
+/// **Trimming never removes anything.** `sourceStart` and `sourceEnd` are a window onto the
+/// recording, which is why un-trimming is free, why the trim badge can honestly say how much is
+/// hidden, and why clicking that badge can put the material back. The alternative — cutting the
+/// file — makes every edit final and the badge a lie.
+struct Clip: Codable, Equatable, Identifiable {
+    var id = UUID()
+    /// Seconds into the recording. Both ends are in *source* time, always.
+    var sourceStart: TimeInterval
+    var sourceEnd: TimeInterval
+    var speed: Double = 1
+    /// The microphone track.
+    var volume: Double = 1
+    /// Kept apart from `volume` because "mute the video I was demonstrating but keep my narration"
+    /// is the common case, and one number cannot say it.
+    var systemAudioVolume: Double = 1
+    var isMuted = false
+    /// For a stretch where the pointer is parked over the thing being discussed.
+    var hidesCursor = false
+    /// For a stretch where precision beats grace — walking down a menu, dragging a handle. The
+    /// interpolation that makes a cursor look weightless also makes it appear to hover between
+    /// items it never touched.
+    var disablesCursorSmoothing = false
+
+    static let speedRange: ClosedRange<Double> = 0.25...4
+
+    /// Below this a clip cannot be grabbed with a mouse and shows nothing anybody can see, so the
+    /// operations that would create one refuse instead. Measured in *output* seconds, because that
+    /// is what the user is looking at: 100 ms of source at 4× is 25 ms on screen.
+    static let minimumOutputDuration: TimeInterval = 0.1
+
+    var sourceDuration: TimeInterval { max(0, sourceEnd - sourceStart) }
+
+    /// How long this clip occupies in the finished video.
+    var outputDuration: TimeInterval { sourceDuration / speed }
+}
+
+/// The edit: a list of clips, and the arithmetic that maps between the finished video and the
+/// recording it was cut from.
+///
+/// **Every track in the studio is stored in source time** — zooms, camera layouts, masks,
+/// keystrokes, captions — and resolved for rendering through `sourceTime(forOutput:)`. That is
+/// what makes trimming the first two seconds leave the zooms attached to the moments they were
+/// built for rather than sliding them all two seconds early.
+///
+/// Pure, and deliberately so: this is the one place a speed change becomes correct or subtly
+/// wrong, and a sped-up section that desynchronises everything but the video is the kind of defect
+/// that reads as "the app is broken" rather than as an off-by-one.
+struct Timeline: Codable, Equatable {
+    var clips: [Clip]
+
+    init(clips: [Clip]) {
+        self.clips = clips
+    }
+
+    var duration: TimeInterval {
+        clips.reduce(0) { $0 + $1.outputDuration }
+    }
+
+    // MARK: - Mapping
+
+    /// The recording moment shown at `output` seconds into the finished video.
+    ///
+    /// A clip owns the half-open interval `[start, end)`. The boundary therefore belongs to the
+    /// clip that *starts* there rather than the one that ended, which is what stops a cut showing
+    /// one frame of the outgoing clip; and asking for exactly the duration returns nil, because
+    /// there is no frame left to show.
+    func sourceTime(forOutput output: TimeInterval) -> (clip: Clip, sourceTime: TimeInterval)? {
+        guard output >= 0 else { return nil }
+        var elapsed: TimeInterval = 0
+        for clip in clips {
+            let next = elapsed + clip.outputDuration
+            if output < next {
+                return (clip, clip.sourceStart + (output - elapsed) * clip.speed)
+            }
+            elapsed = next
+        }
+        return nil
+    }
+
+    /// The inverse: where a moment of the recording ended up, or nil if it was cut out.
+    ///
+    /// Nil is a useful answer rather than a failure — it is what lets the renderer skip a zoom
+    /// whose moment the user deleted, instead of drawing it at the wrong time.
+    func outputTime(forSource source: TimeInterval) -> TimeInterval? {
+        var elapsed: TimeInterval = 0
+        for clip in clips {
+            if source >= clip.sourceStart && source < clip.sourceEnd {
+                return elapsed + (source - clip.sourceStart) / clip.speed
+            }
+            elapsed += clip.outputDuration
+        }
+        return nil
+    }
+
+    // MARK: - Edits
+
+    /// Cuts the clip under `output` in two. `output` is in output time — the playhead's own units —
+    /// so a sped-up clip splits at the frame the user is actually looking at.
+    func split(at output: TimeInterval) -> Timeline {
+        guard let (clip, source) = sourceTime(forOutput: output),
+              let index = clips.firstIndex(where: { $0.id == clip.id }) else { return self }
+
+        var left = clip
+        left.sourceEnd = source
+        var right = clip
+        right.id = UUID()
+        right.sourceStart = source
+
+        // A split that would leave a sliver nobody can grab is refused rather than performed. The
+        // user's intent was a cut, and a cut they cannot see or select is worse than none.
+        guard left.outputDuration >= Clip.minimumOutputDuration,
+              right.outputDuration >= Clip.minimumOutputDuration else { return self }
+
+        var updated = self
+        updated.clips.replaceSubrange(index...index, with: [left, right])
+        return updated
+    }
+
+    /// Removes a clip and closes the gap. The clips after it slide left; nothing is left blank.
+    ///
+    /// The last clip cannot go: an empty timeline has no duration, no playhead and no clip to
+    /// drag, so there would be no way to edit back out of it.
+    func delete(id: Clip.ID) -> Timeline {
+        guard clips.count > 1, clips.contains(where: { $0.id == id }) else { return self }
+        var updated = self
+        updated.clips.removeAll { $0.id == id }
+        return updated
+    }
+
+    /// Moves one or both edges of a clip's window onto the recording. Nil leaves that edge alone.
+    func trim(id: Clip.ID, start: TimeInterval?, end: TimeInterval?) -> Timeline {
+        guard let index = clips.firstIndex(where: { $0.id == id }) else { return self }
+        var clip = clips[index]
+        if let start { clip.sourceStart = start }
+        if let end { clip.sourceEnd = end }
+        guard clip.sourceEnd > clip.sourceStart,
+              clip.outputDuration >= Clip.minimumOutputDuration else { return self }
+
+        var updated = self
+        updated.clips[index] = clip
+        return updated
+    }
+
+    func setSpeed(id: Clip.ID, _ speed: Double) -> Timeline {
+        guard let index = clips.firstIndex(where: { $0.id == id }) else { return self }
+        var updated = self
+        updated.clips[index].speed = min(max(speed, Clip.speedRange.lowerBound),
+                                         Clip.speedRange.upperBound)
+        return updated
+    }
+
+    func clip(withID id: Clip.ID) -> Clip? {
+        clips.first { $0.id == id }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/TimelineLayout.swift
+++ b/Sources/Sarvkrit/Features/Studio/TimelineLayout.swift
@@ -1,0 +1,170 @@
+import CoreGraphics
+import Foundation
+
+/// The timeline's contents, as rows of items — and its geometry, as arithmetic.
+///
+/// **The view used to hardcode two tracks.** `clipTrack` and `zoomTrack` were hand-placed rects,
+/// `preferredHeight` was a closed-form sum of exactly those two, and each had its own bespoke hit
+/// test gated on its own `contains(point)`. Adding a track meant another rect, another draw method
+/// and another branch in every mouse handler — so five of the project's own collections had no
+/// representation at all: masks, camera segments, captions, pointer highlights, and now text.
+/// "There are no layers" was a fair description of a timeline that could only show two.
+///
+/// Being a value rather than geometry scattered through a view, this is also testable, which the
+/// hand-placed version was not.
+enum TimelineLayout {
+
+    enum RowKind: String, CaseIterable, Equatable {
+        case video, text, camera, zoom, mask, pointer, caption
+
+        var name: String {
+            switch self {
+            case .video: return "Video"
+            case .text: return "Text"
+            case .camera: return "Camera"
+            case .zoom: return "Zoom"
+            case .mask: return "Blur"
+            case .pointer: return "Point"
+            case .caption: return "Captions"
+            }
+        }
+
+        /// The video track is always there — an edit with no clips has nothing to edit.
+        var isAlwaysShown: Bool { self == .video || self == .zoom }
+    }
+
+    struct Item: Identifiable, Equatable {
+        var id: UUID
+        var kind: RowKind
+        /// Output time, so one mapping serves every row.
+        var start: TimeInterval
+        var end: TimeInterval
+        var label: String
+        var isSelected = false
+        /// Dimmed rather than solid — a disabled zoom, for instance.
+        var isMuted = false
+    }
+
+    struct Row: Identifiable, Equatable {
+        var kind: RowKind
+        var items: [Item]
+        var id: String { kind.rawValue }
+    }
+
+    // MARK: - Geometry
+
+    struct Metrics {
+        var ruler: CGFloat = 22
+        var rowHeight: CGFloat = 30
+        var rowGap: CGFloat = 4
+        var inset: CGFloat = 12
+        /// The names down the left edge, so it is obvious what each row is.
+        var gutter: CGFloat = 58
+        /// A grab this near an edge is a trim, not a move.
+        var edgeGrab: CGFloat = 6
+    }
+
+    /// How tall the view wants to be for this many rows.
+    static func preferredHeight(rowCount: Int, metrics: Metrics = Metrics()) -> CGFloat {
+        let rows = max(1, rowCount)
+        return metrics.ruler + CGFloat(rows) * metrics.rowHeight
+            + CGFloat(max(0, rows - 1)) * metrics.rowGap + 8
+    }
+
+    static func rect(ofRow index: Int, in bounds: CGRect,
+                     metrics: Metrics = Metrics()) -> CGRect {
+        CGRect(x: 0,
+               y: metrics.ruler + CGFloat(index) * (metrics.rowHeight + metrics.rowGap),
+               width: bounds.width, height: metrics.rowHeight)
+    }
+
+    // MARK: - Contents
+
+    /// Every row worth showing, in a fixed order so the timeline does not rearrange itself.
+    static func rows(project: StudioProject, events: EventLog,
+                     selection: Selection = Selection()) -> [Row] {
+        let timeline = project.timeline
+
+        /// A source range's place in the finished video, or nil if the edit cut it out entirely.
+        func output(_ start: TimeInterval, _ end: TimeInterval) -> (TimeInterval, TimeInterval)? {
+            guard let from = timeline.outputTime(forSource: start)
+                    ?? timeline.outputTime(forSource: end) else { return nil }
+            let to = timeline.outputTime(forSource: max(start, end - 0.0001)) ?? timeline.duration
+            return (min(from, to), max(from, to))
+        }
+
+        var clips: [Item] = []
+        var elapsed: TimeInterval = 0
+        for clip in timeline.clips {
+            var label = String(format: "%.1fs", clip.outputDuration)
+            if clip.speed != 1 { label += String(format: " · %.2gx", clip.speed) }
+            if clip.hold > 0 { label += String(format: " · hold %.1fs", clip.hold) }
+            clips.append(Item(id: clip.id, kind: .video, start: elapsed,
+                              end: elapsed + clip.outputDuration, label: label,
+                              isSelected: selection.clip == clip.id))
+            elapsed += clip.outputDuration
+        }
+
+        let text = project.textOverlays.compactMap { overlay -> Item? in
+            guard let range = output(overlay.start, overlay.end) else { return nil }
+            return Item(id: overlay.id, kind: .text, start: range.0, end: range.1,
+                        label: overlay.text.isEmpty ? "Text" : overlay.text,
+                        isSelected: selection.text == overlay.id)
+        }
+
+        let camera = project.cameraSegments.compactMap { segment -> Item? in
+            guard let range = output(segment.start, segment.end) else { return nil }
+            return Item(id: segment.id, kind: .camera, start: range.0, end: range.1,
+                        label: segment.layout.title, isSelected: selection.camera == segment.id)
+        }
+
+        let zooms = project.zooms.compactMap { segment -> Item? in
+            guard let range = output(segment.start, segment.end) else { return nil }
+            var label = String(format: "%.1fx", segment.level)
+            if case .followCursor = segment.anchor { label += " · follows" }
+            return Item(id: segment.id, kind: .zoom, start: range.0, end: range.1, label: label,
+                        isSelected: selection.zoom == segment.id, isMuted: segment.isDisabled)
+        }
+
+        let masks = project.masks.compactMap { mask -> Item? in
+            guard let range = output(mask.start, mask.end) else { return nil }
+            return Item(id: mask.id, kind: .mask, start: range.0, end: range.1,
+                        label: mask.mode.title, isSelected: selection.mask == mask.id)
+        }
+
+        let pointers = project.pointerHighlights.compactMap { spot -> Item? in
+            guard let range = output(spot.start, spot.end) else { return nil }
+            return Item(id: spot.id, kind: .pointer, start: range.0, end: range.1,
+                        label: "Point", isSelected: selection.pointer == spot.id)
+        }
+
+        let captions = project.captions.compactMap { caption -> Item? in
+            guard let range = output(caption.start, caption.end) else { return nil }
+            return Item(id: caption.id, kind: .caption, start: range.0, end: range.1,
+                        label: caption.text)
+        }
+
+        let all: [Row] = [
+            Row(kind: .video, items: clips),
+            Row(kind: .text, items: text),
+            Row(kind: .camera, items: camera),
+            Row(kind: .zoom, items: zooms),
+            Row(kind: .mask, items: masks),
+            Row(kind: .pointer, items: pointers),
+            Row(kind: .caption, items: captions),
+        ]
+        // An empty row is noise; a row that appears when you add the first of something is how you
+        // learn the track exists.
+        return all.filter { !$0.items.isEmpty || $0.kind.isAlwaysShown }
+    }
+
+    /// What is selected, in one place, so `rows` needs one parameter rather than six.
+    struct Selection: Equatable {
+        var clip: Clip.ID?
+        var zoom: ZoomSegment.ID?
+        var text: TextOverlay.ID?
+        var camera: CameraSegment.ID?
+        var mask: StudioMask.ID?
+        var pointer: PointerHighlight.ID?
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/TimelineLayout.swift
+++ b/Sources/Sarvkrit/Features/Studio/TimelineLayout.swift
@@ -15,11 +15,12 @@ import Foundation
 enum TimelineLayout {
 
     enum RowKind: String, CaseIterable, Equatable {
-        case video, text, camera, zoom, mask, pointer, caption
+        case video, media, text, camera, zoom, mask, pointer, caption
 
         var name: String {
             switch self {
             case .video: return "Video"
+            case .media: return "Picture"
             case .text: return "Text"
             case .camera: return "Camera"
             case .zoom: return "Zoom"
@@ -105,6 +106,12 @@ enum TimelineLayout {
             elapsed += clip.outputDuration
         }
 
+        let media = project.mediaOverlays.compactMap { overlay -> Item? in
+            guard let range = output(overlay.start, overlay.end) else { return nil }
+            return Item(id: overlay.id, kind: .media, start: range.0, end: range.1,
+                        label: "Picture", isSelected: selection.media == overlay.id)
+        }
+
         let text = project.textOverlays.compactMap { overlay -> Item? in
             guard let range = output(overlay.start, overlay.end) else { return nil }
             return Item(id: overlay.id, kind: .text, start: range.0, end: range.1,
@@ -146,6 +153,7 @@ enum TimelineLayout {
 
         let all: [Row] = [
             Row(kind: .video, items: clips),
+            Row(kind: .media, items: media),
             Row(kind: .text, items: text),
             Row(kind: .camera, items: camera),
             Row(kind: .zoom, items: zooms),
@@ -166,5 +174,6 @@ enum TimelineLayout {
         var camera: CameraSegment.ID?
         var mask: StudioMask.ID?
         var pointer: PointerHighlight.ID?
+        var media: MediaOverlay.ID?
     }
 }

--- a/Sources/Sarvkrit/Features/Studio/Transcriber.swift
+++ b/Sources/Sarvkrit/Features/Studio/Transcriber.swift
@@ -1,0 +1,128 @@
+import AVFoundation
+import Foundation
+import Speech
+import os
+
+/// Turning the narration into captions, on this Mac and nowhere else.
+///
+/// **`requiresOnDeviceRecognition = true`, and when the device cannot do it the feature says so
+/// and offers nothing.** The README's promise is that the app contains no network code at all, and
+/// a caption feature that quietly posts somebody's audio to Apple when the local model is missing
+/// would break it in the least visible way possible.
+///
+/// The reference product bundles Whisper locally and gets better transcripts, particularly on
+/// technical vocabulary. It is equally private; the argument against is size — a Core ML Whisper
+/// model adds hundreds of megabytes to an app whose whole DMG is a few. That trade is written up
+/// in the design doc as an explicit later decision rather than left as a silent limitation, and
+/// `contextualStrings` below closes a good part of the gap for free.
+enum Transcriber {
+
+    enum TranscriptionError: Error, Equatable {
+        /// The local model for this language is not installed, and we will not fall back.
+        case onDeviceUnavailable(locale: String)
+        case notAuthorised
+        case noAudio
+        case failed(String)
+    }
+
+    /// Locales this Mac can actually run offline.
+    ///
+    /// Filtered rather than listed: showing a language we cannot run locally would be a promise
+    /// broken at the last moment, after the user has waited.
+    static func availableLocales() -> [Locale] {
+        SFSpeechRecognizer.supportedLocales()
+            .filter { SFSpeechRecognizer(locale: $0)?.supportsOnDeviceRecognition == true }
+            .sorted { ($0.identifier) < ($1.identifier) }
+    }
+
+    static func requestAuthorisation() async -> Bool {
+        await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status == .authorized)
+            }
+        }
+    }
+
+    /// - Parameter vocabulary: words to bias recognition towards — product names, library names,
+    ///   jargon. This is the difference between a transcript that says "Sarvkrit" and one that
+    ///   says "sav credit", and it costs three lines.
+    static func transcribe(url: URL,
+                           locale: Locale = .current,
+                           vocabulary: [String] = []) async throws -> [Caption] {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw TranscriptionError.noAudio
+        }
+        guard await requestAuthorisation() else { throw TranscriptionError.notAuthorised }
+
+        guard let recogniser = SFSpeechRecognizer(locale: locale),
+              recogniser.supportsOnDeviceRecognition else {
+            throw TranscriptionError.onDeviceUnavailable(locale: locale.identifier)
+        }
+
+        let request = SFSpeechURLRecognitionRequest(url: url)
+        request.requiresOnDeviceRecognition = true
+        request.shouldReportPartialResults = false
+        request.addsPunctuation = true
+        request.contextualStrings = vocabulary
+
+        let transcription: SFTranscription = try await withCheckedThrowingContinuation { done in
+            var finished = false
+            recogniser.recognitionTask(with: request) { result, error in
+                guard !finished else { return }
+                if let error {
+                    finished = true
+                    return done.resume(throwing:
+                        TranscriptionError.failed(error.localizedDescription))
+                }
+                guard let result, result.isFinal else { return }
+                finished = true
+                done.resume(returning: result.bestTranscription)
+            }
+        }
+
+        // Per-word `timestamp` and `duration` are the whole reason karaoke highlighting is
+        // possible; they are not something the app could work out for itself.
+        let words = transcription.segments.map {
+            TranscriptWord(text: $0.substring, start: $0.timestamp, duration: $0.duration)
+        }
+        return CaptionGrouper.lines(from: words)
+    }
+
+    /// Writes the transcript out beside the video.
+    ///
+    /// Cheap, and it is what makes a recording accessible somewhere other than the file we made.
+    static func subtitles(_ captions: [Caption], format: SubtitleFormat) -> String {
+        switch format {
+        case .srt:
+            return captions.enumerated().map { index, caption in
+                "\(index + 1)\n\(srtTime(caption.start)) --> \(srtTime(caption.end))\n"
+                    + "\(caption.text)\n"
+            }.joined(separator: "\n")
+        case .vtt:
+            let body = captions.map {
+                "\(vttTime($0.start)) --> \(vttTime($0.end))\n\($0.text)\n"
+            }.joined(separator: "\n")
+            return "WEBVTT\n\n" + body
+        }
+    }
+
+    enum SubtitleFormat: String, CaseIterable { case srt, vtt }
+
+    private static func srtTime(_ seconds: TimeInterval) -> String {
+        clock(seconds, millisecondSeparator: ",")
+    }
+
+    private static func vttTime(_ seconds: TimeInterval) -> String {
+        clock(seconds, millisecondSeparator: ".")
+    }
+
+    private static func clock(_ seconds: TimeInterval, millisecondSeparator: String) -> String {
+        let total = max(0, seconds)
+        let hours = Int(total) / 3600
+        let minutes = (Int(total) % 3600) / 60
+        let secs = Int(total) % 60
+        let millis = Int((total - Double(Int(total))) * 1000)
+        return String(format: "%02d:%02d:%02d\(millisecondSeparator)%03d",
+                      hours, minutes, secs, millis)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/TypingDetector.swift
+++ b/Sources/Sarvkrit/Features/Studio/TypingDetector.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Finding the stretches where somebody was typing.
+///
+/// The other half of removing dead air, and the half the reference product actually ships:
+/// **watching someone type is boring at 1× and fine at 4×.** Reading the keystroke log is enough
+/// to find those stretches, so this needs no audio at all.
+enum TypingDetector {
+
+    struct Tuning: Equatable {
+        /// Keys in a row before it counts as typing rather than a shortcut.
+        var minimumKeys: Int = 5
+        /// The longest pause allowed inside one run. Beyond this the user stopped to think, and
+        /// speeding up a pause is just cutting it badly.
+        var maximumGap: TimeInterval = 0.8
+        var suggestedSpeed: Double = 4
+
+        init() {}
+    }
+
+    /// One stretch worth offering to speed up.
+    struct Suggestion: Equatable, Identifiable {
+        var id = UUID()
+        var start: TimeInterval
+        var end: TimeInterval
+        var suggestedSpeed: Double
+
+        static func == (a: Suggestion, b: Suggestion) -> Bool {
+            a.start == b.start && a.end == b.end && a.suggestedSpeed == b.suggestedSpeed
+        }
+    }
+
+    /// **Suggestions, never applications.** Each is offered on the timeline with accept, adjust and
+    /// dismiss; none is applied on the user's behalf. A speed change that appears in someone's
+    /// edit without them asking is the kind of helpfulness that makes a tool untrustworthy.
+    static func runs(in keys: [KeyEvent], tuning: Tuning = Tuning()) -> [Suggestion] {
+        guard keys.count >= tuning.minimumKeys else { return [] }
+        let sorted = keys.sorted { $0.t < $1.t }
+
+        var suggestions: [Suggestion] = []
+        var run: [KeyEvent] = [sorted[0]]
+
+        func close() {
+            guard run.count >= tuning.minimumKeys,
+                  let first = run.first, let last = run.last else { return }
+            suggestions.append(Suggestion(start: first.t, end: last.t,
+                                          suggestedSpeed: tuning.suggestedSpeed))
+        }
+
+        for key in sorted.dropFirst() {
+            if key.t - (run.last?.t ?? key.t) <= tuning.maximumGap {
+                run.append(key)
+            } else {
+                close()
+                run = [key]
+            }
+        }
+        close()
+        return suggestions
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/ZoomEase.swift
+++ b/Sources/Sarvkrit/Features/Studio/ZoomEase.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// The curve a zoom travels along.
+///
+/// **A critically damped spring, not `easeInOut`.** The reference product's zooms feel like the
+/// frame has weight, and a symmetric cubic does not: it accelerates and decelerates equally, which
+/// reads as mechanical. A damped spring covers most of the distance early and settles into the
+/// target, which is what the eye expects of something being moved rather than animated.
+///
+/// Critically damped specifically — `ζ = 1` — so it never overshoots. A zoom that sails past its
+/// level and springs back is charming exactly once and seasickening over a five-minute demo.
+enum ZoomEase: String, Codable, CaseIterable, Equatable {
+    case smooth
+    case linear
+    /// Cut straight to the target. For a zoom that begins on a cut, where animating in would show
+    /// a moment of the wrong framing.
+    case instant
+
+    /// Stiffness. Higher settles sooner; 6 puts roughly 98% of the travel inside the duration,
+    /// which is why the normalisation below is needed at all.
+    private static let stiffness = 6.0
+
+    /// Eased progress for linear progress `t`.
+    ///
+    /// **Both ends land exactly.** The spring's natural value at `t = 1` is about 0.983, and
+    /// leaving it there would stop every zoom a fraction short of its level — with a visible jolt
+    /// when the next segment takes over from a different value. Dividing by that same constant is
+    /// exact in floating point (`x / x == 1`), so the endpoint is not merely close.
+    func value(_ progress: Double) -> Double {
+        let t = min(max(progress, 0), 1)
+        switch self {
+        case .linear:
+            return t
+        case .instant:
+            return t <= 0 ? 0 : 1
+        case .smooth:
+            return Self.spring(t) / Self.spring(1)
+        }
+    }
+
+    /// The step response of a critically damped second-order system, from 0 to ~1.
+    private static func spring(_ t: Double) -> Double {
+        1 - (1 + stiffness * t) * exp(-stiffness * t)
+    }
+
+    func interpolate(from: Double, to: Double, progress: Double) -> Double {
+        from + (to - from) * value(progress)
+    }
+
+    var title: String {
+        switch self {
+        case .smooth: return "Smooth"
+        case .linear: return "Linear"
+        case .instant: return "Instant"
+        }
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/ZoomPlanner.swift
+++ b/Sources/Sarvkrit/Features/Studio/ZoomPlanner.swift
@@ -40,7 +40,24 @@ enum ZoomPlanner {
         var mergeGap: TimeInterval = 0.8
         /// How much of the frame the activity should occupy once zoomed.
         var targetCoverage: Double = 0.6
-        var levelRange: ClosedRange<Double> = 1.2...2.5
+
+        /// **The ceiling used to be 2.5 and almost everything reached it.** Two reasons to bring
+        /// it down.
+        ///
+        /// A point-like activity — one click, or a typing run — has no extent to fit, so the
+        /// coverage arithmetic below asks for an enormous number and takes whatever the maximum
+        /// is. The maximum was doing the job of a default, which is how a recording ends up with
+        /// four zooms at exactly the same level.
+        ///
+        /// And 2.5× is more magnification than the source can pay for. A 3024-wide recording
+        /// cropped to 2.5× shows 1210 pixels; exported at its own native width those 1210 are
+        /// stretched back over 3024, so the close-up is visibly softer than the shot around it.
+        /// 2× keeps the crop nearer the output resolution, and matters more now that an export can
+        /// be full size rather than always 1080p.
+        ///
+        /// Hand-made zooms are unaffected: `ZoomSegment.levelRange` still allows up to 4×, so
+        /// anyone who wants a harder close-up can set one.
+        var levelRange: ClosedRange<Double> = 1.2...2.0
         /// An activity that moves less than this fraction of the frame is pinned rather than
         /// followed — following something that barely moves reads as drift.
         var followThreshold: Double = 0.15
@@ -57,6 +74,15 @@ enum ZoomPlanner {
         /// segment is dropped: barely zooming for eleven seconds is worse than not zooming.
         var levelFloorMargin: Double = 0.15
         /// Keystrokes needed before typing counts as an activity in its own right.
+        /// How slowly the pointer has to be moving to count as attending to something, in
+        /// fractions of the frame's width per second.
+        ///
+        /// **Where somebody moved the mouse from is not what they are showing you.** The cursor
+        /// track is the signal the planner needs to judge how wide a shot to take, but most of it
+        /// is transit — a fling across the screen to reach a button. Counting that would drag the
+        /// box out to the full width and cancel the zoom on almost every click. Below this the
+        /// pointer is working; above it, it is travelling.
+        var dwellSpeedFraction: Double = 0.35
         var typingRun: Int = 5
         /// …with no gap longer than this between them.
         var typingInterval: TimeInterval = 2.0
@@ -95,9 +121,14 @@ enum ZoomPlanner {
 
         // Dropped rather than kept-but-weak. A zoom that barely magnifies still costs the viewer
         // a movement to follow, and pays nothing back.
+        //
+        // Judged on the *tight* box — was there a specific thing here — rather than on the shot
+        // the pointer widened it to. Otherwise a slow sweep around a button deletes the zoom onto
+        // the button, which is widening a shot into no shot at all.
         return activities
-            .map { segment(for: $0, frameSize: frameSize, tuning: tuning) }
-            .filter { $0.level > tuning.levelRange.lowerBound + tuning.levelFloorMargin }
+            .map { segment(for: $0, events: events, frameSize: frameSize, tuning: tuning) }
+            .filter { $0.tightLevel > tuning.levelRange.lowerBound + tuning.levelFloorMargin }
+            .map(\.segment)
     }
 
     // MARK: - Finding activities
@@ -207,28 +238,80 @@ enum ZoomPlanner {
         return result
     }
 
-    /// The level comes from the activity's own extent: zoom until it fills `targetCoverage` of the
-    /// frame, and no further. A single click has no extent and gets the maximum; a drag across half
-    /// the screen gets almost nothing, because zooming into it would hide half of itself.
-    private static func segment(for activity: Activity, frameSize: CGSize,
-                                tuning: Tuning) -> ZoomSegment {
-        let box = bounds(of: activity.points, frameSize: frameSize)
+    /// **Two boxes, because "is this worth zooming to" and "how wide a shot" are different
+    /// questions.**
+    ///
+    /// The tight box is the clicks: it says whether there is a specific thing here at all, and it
+    /// is what the drop filter in `plan` judges. The shot box adds wherever the pointer *rested*
+    /// during the activity: it says how much has to stay in frame. Judging both from one box meant
+    /// that widening a shot could delete it — measured against real recordings, feeding the cursor
+    /// into a single box removed two zooms outright and changed no level by more than 0.03.
+    ///
+    /// Either way the rule is the same: zoom until the box fills `targetCoverage` of the frame and
+    /// no further. A drag across half the screen gets almost nothing, because zooming into it
+    /// would hide half of itself.
+    private static func segment(for activity: Activity, events: EventLog, frameSize: CGSize,
+                                tuning: Tuning) -> (segment: ZoomSegment, tightLevel: Double) {
+        let tight = bounds(of: activity.points, frameSize: frameSize)
+        let shot = bounds(of: activity.points
+                            + dwellPoints(in: activity, events: events, frameSize: frameSize,
+                                          tuning: tuning),
+                          frameSize: frameSize)
 
-        // Guarded against zero: a single point would divide by nothing, and the answer we want in
-        // that case — "as close as you are allowed" — falls out of the clamp anyway.
-        let byWidth = tuning.targetCoverage * Double(frameSize.width) / Double(max(box.width, 1))
-        let byHeight = tuning.targetCoverage * Double(frameSize.height) / Double(max(box.height, 1))
-        let level = min(max(min(byWidth, byHeight), tuning.levelRange.lowerBound),
-                        tuning.levelRange.upperBound)
-
-        let travel = max(Double(box.width) / Double(frameSize.width),
-                         Double(box.height) / Double(frameSize.height))
+        let travel = max(Double(shot.width) / Double(frameSize.width),
+                         Double(shot.height) / Double(frameSize.height))
         let anchor: ZoomSegment.Anchor = travel > tuning.followThreshold
             ? .followCursor
-            : .fixed(CGPoint(x: box.midX / frameSize.width, y: box.midY / frameSize.height))
+            : .fixed(CGPoint(x: shot.midX / frameSize.width, y: shot.midY / frameSize.height))
 
-        return ZoomSegment(start: activity.start, end: activity.end,
-                           level: level, anchor: anchor, isAutomatic: true)
+        // **Widening must not turn the shot into a drift.** The floor of the range is where a zoom
+        // stops being a close-up and becomes a slow movement the viewer follows for nothing — the
+        // thing `testAWideActivityGetsNoZoomAtAll` exists to prevent. The pointer may open the
+        // shot up, but only as far as still-a-zoom.
+        let usable = tuning.levelRange.lowerBound + tuning.levelFloorMargin
+        let shotLevel = max(level(fitting: shot, frameSize: frameSize, tuning: tuning), usable)
+
+        let segment = ZoomSegment(start: activity.start, end: activity.end,
+                                  level: shotLevel, anchor: anchor, isAutomatic: true)
+        // The tight level travels alongside rather than on the segment: it is what the planner
+        // used to decide, not something a saved project should carry.
+        return (segment, level(fitting: tight, frameSize: frameSize, tuning: tuning))
+    }
+
+    /// The zoom that makes `box` fill `targetCoverage` of the frame, inside the allowed range.
+    ///
+    /// Guarded against zero: a single point would divide by nothing, and the answer wanted in that
+    /// case — as close as the range allows — falls out of the clamp.
+    private static func level(fitting box: CGRect, frameSize: CGSize, tuning: Tuning) -> Double {
+        let byWidth = tuning.targetCoverage * Double(frameSize.width) / Double(max(box.width, 1))
+        let byHeight = tuning.targetCoverage * Double(frameSize.height) / Double(max(box.height, 1))
+        return min(max(min(byWidth, byHeight), tuning.levelRange.lowerBound),
+                   tuning.levelRange.upperBound)
+    }
+
+    /// The cursor positions inside an activity where the pointer was attending rather than
+    /// travelling.
+    ///
+    /// Speed is the whole distinction, and it is measured against the frame's own width so that a
+    /// Retina capture and a small window mean the same thing by "fast". A sample the recorder
+    /// marked as outside the recorded region is not evidence about anything on screen — the same
+    /// rule the click path already applies with its own `isInside`.
+    private static func dwellPoints(in activity: Activity, events: EventLog,
+                                    frameSize: CGSize, tuning: Tuning) -> [CGPoint] {
+        let samples = events.cursor.filter {
+            $0.t >= activity.start && $0.t <= activity.end && $0.isInside
+        }
+        guard samples.count > 1 else { return samples.map(\.point) }
+
+        let limit = tuning.dwellSpeedFraction * Double(frameSize.width)
+        return samples.enumerated().compactMap { index, sample in
+            // Forward difference, and backwards for the last one, so every sample has a speed.
+            let other = index + 1 < samples.count ? samples[index + 1] : samples[index - 1]
+            let seconds = abs(other.t - sample.t)
+            guard seconds > 0.0001 else { return sample.point }
+            let travelled = hypot(other.point.x - sample.point.x, other.point.y - sample.point.y)
+            return Double(travelled) / seconds <= limit ? sample.point : nil
+        }
     }
 
     private static func bounds(of points: [CGPoint], frameSize: CGSize) -> CGRect {

--- a/Sources/Sarvkrit/Features/Studio/ZoomPlanner.swift
+++ b/Sources/Sarvkrit/Features/Studio/ZoomPlanner.swift
@@ -25,8 +25,18 @@ enum ZoomPlanner {
         var leadOut: TimeInterval = 0.8
         /// Shorter than this and the zoom is over before it registers.
         var minimumActivity: TimeInterval = 1.0
-        /// Two activities closer than this would zoom out and straight back in, which is the most
-        /// nauseating thing this feature could do.
+        /// Two activities closer than this are one zoom rather than two.
+        ///
+        /// **This used to be the guard against nausea and could not keep the promise.** Zooming
+        /// out and straight back in is the worst thing this feature can do, but `maximumActivity`
+        /// refuses the merge whenever the pair would overrun and then trims the second activity to
+        /// start exactly where the first ends — manufacturing the very thing the merge was
+        /// avoiding. The two rules were in direct conflict and the cap won.
+        ///
+        /// `ZoomResolver.joinGap` is what keeps the promise now: neighbouring segments resolve as
+        /// one continuous move from one level to the next, so an abutting pair reads as a single
+        /// adjustment. This is left as a framing choice — whether two nearby bursts deserve one
+        /// shot or two — rather than as a defence.
         var mergeGap: TimeInterval = 0.8
         /// How much of the frame the activity should occupy once zoomed.
         var targetCoverage: Double = 0.6

--- a/Sources/Sarvkrit/Features/Studio/ZoomPlanner.swift
+++ b/Sources/Sarvkrit/Features/Studio/ZoomPlanner.swift
@@ -36,12 +36,30 @@ enum ZoomPlanner {
         var followThreshold: Double = 0.15
         /// At most one zoom per this many seconds. A click-heavy demo must not become a zoom storm.
         var minimumSpacing: TimeInterval = 4.0
+        /// **The cap that stops a zoom becoming a crop.**
+        ///
+        /// Merging is what keeps a busy stretch from flickering, but merged far enough it produces
+        /// one segment across the whole recording — which is not a zoom, it is a permanent change
+        /// of framing, and it is what a real twelve-second demo of twenty-eight clicks produced
+        /// before this existed.
+        var maximumActivity: TimeInterval = 7.0
+        /// A level this close to the floor is not a close-up, it is a slow drift. Below it the
+        /// segment is dropped: barely zooming for eleven seconds is worse than not zooming.
+        var levelFloorMargin: Double = 0.15
         /// Keystrokes needed before typing counts as an activity in its own right.
         var typingRun: Int = 5
         /// …with no gap longer than this between them.
         var typingInterval: TimeInterval = 2.0
 
         init() {}
+
+        /// The longest a *cluster* may run, so that once the lead-in and lead-out are added the
+        /// finished segment still respects `maximumActivity`.
+        ///
+        /// Capping the cluster at `maximumActivity` directly looks right and is not: the padding
+        /// is applied afterwards, so a seven-second cluster becomes a nine-second segment and the
+        /// limit quietly means something other than what it says.
+        var clusterBudget: TimeInterval { max(0.5, maximumActivity - leadIn - leadOut) }
     }
 
     /// A span of the recording where something was happening, and where on screen it happened.
@@ -65,7 +83,11 @@ enum ZoomPlanner {
 
         activities = merged(activities, tuning: tuning)
 
-        return activities.map { segment(for: $0, frameSize: frameSize, tuning: tuning) }
+        // Dropped rather than kept-but-weak. A zoom that barely magnifies still costs the viewer
+        // a movement to follow, and pays nothing back.
+        return activities
+            .map { segment(for: $0, frameSize: frameSize, tuning: tuning) }
+            .filter { $0.level > tuning.levelRange.lowerBound + tuning.levelFloorMargin }
     }
 
     // MARK: - Finding activities
@@ -83,7 +105,10 @@ enum ZoomPlanner {
         for press in presses.dropFirst() {
             let previous = current.points[current.points.count - 1]
             let apart = hypot(press.point.x - previous.x, press.point.y - previous.y)
-            if press.t - current.end <= tuning.clusterInterval && apart <= tuning.clusterRadius {
+            let wouldOverrun = press.t - current.start > tuning.clusterBudget
+            if press.t - current.end <= tuning.clusterInterval,
+               apart <= tuning.clusterRadius,
+               !wouldOverrun {
                 current.end = press.t
                 current.points.append(press.point)
             } else {
@@ -145,13 +170,28 @@ enum ZoomPlanner {
         for activity in activities.dropFirst() {
             let touches = activity.start - previous.end < tuning.mergeGap
             let tooSoon = activity.start - previous.start < tuning.minimumSpacing
-            if touches || tooSoon {
+            // Whatever the other two say, a merge that would push the span past `maximumActivity`
+            // is refused. Without this the rules compose into "merge everything".
+            let wouldOverrun = max(previous.end, activity.end) - previous.start
+                > tuning.maximumActivity
+
+            if (touches || tooSoon) && !wouldOverrun {
                 previous.end = max(previous.end, activity.end)
                 previous.points.append(contentsOf: activity.points)
-            } else {
-                result.append(previous)
-                previous = activity
+                continue
             }
+
+            // **Refusing to merge is not enough on its own.** The lead-in and lead-out are added
+            // before this runs, so two activities two seconds apart already overlap by the time
+            // they get here — and leaving them overlapping is worse than merging, because the
+            // renderer would pick one arbitrarily and the zoom would flicker between them.
+            // So the later one starts where the earlier one ends.
+            var trimmed = activity
+            trimmed.start = max(trimmed.start, previous.end)
+            guard trimmed.end - trimmed.start >= tuning.minimumActivity else { continue }
+
+            result.append(previous)
+            previous = trimmed
         }
         result.append(previous)
         return result

--- a/Sources/Sarvkrit/Features/Studio/ZoomPlanner.swift
+++ b/Sources/Sarvkrit/Features/Studio/ZoomPlanner.swift
@@ -1,0 +1,195 @@
+import CoreGraphics
+import Foundation
+
+/// Deciding where and when to zoom, from the event log alone.
+///
+/// **Taste as a pure function.** No video, no AV types, no main actor — the same shape
+/// `AutoBalance` uses for "which background suits this screenshot", and for the same reason: the
+/// judgement is the hard part, it needs iterating on, and it should be adjustable without touching
+/// a line of anything that draws.
+///
+/// The rule the whole thing serves: **a zoom that ends before the eye has arrived is worse than no
+/// zoom at all.** Most of the thresholds below exist to enforce that one idea.
+enum ZoomPlanner {
+
+    /// Every number the planner's judgement rests on, in one place with its reason.
+    struct Tuning: Equatable {
+        /// Clicks closer together than this in time join the same activity.
+        var clusterInterval: TimeInterval = 1.5
+        /// …and closer together than this in space. Chained, so a drag across the screen is one
+        /// activity rather than a dozen.
+        var clusterRadius: CGFloat = 200
+        /// You look before you click.
+        var leadIn: TimeInterval = 1.2
+        /// …and at what happened after.
+        var leadOut: TimeInterval = 0.8
+        /// Shorter than this and the zoom is over before it registers.
+        var minimumActivity: TimeInterval = 1.0
+        /// Two activities closer than this would zoom out and straight back in, which is the most
+        /// nauseating thing this feature could do.
+        var mergeGap: TimeInterval = 0.8
+        /// How much of the frame the activity should occupy once zoomed.
+        var targetCoverage: Double = 0.6
+        var levelRange: ClosedRange<Double> = 1.2...2.5
+        /// An activity that moves less than this fraction of the frame is pinned rather than
+        /// followed — following something that barely moves reads as drift.
+        var followThreshold: Double = 0.15
+        /// At most one zoom per this many seconds. A click-heavy demo must not become a zoom storm.
+        var minimumSpacing: TimeInterval = 4.0
+        /// Keystrokes needed before typing counts as an activity in its own right.
+        var typingRun: Int = 5
+        /// …with no gap longer than this between them.
+        var typingInterval: TimeInterval = 2.0
+
+        init() {}
+    }
+
+    /// A span of the recording where something was happening, and where on screen it happened.
+    private struct Activity {
+        var start: TimeInterval
+        var end: TimeInterval
+        var points: [CGPoint]
+    }
+
+    static func plan(events: EventLog,
+                     frameSize: CGSize,
+                     duration: TimeInterval,
+                     tuning: Tuning = Tuning()) -> [ZoomSegment] {
+        guard frameSize.width > 0, frameSize.height > 0, duration > 0 else { return [] }
+
+        var activities = clickActivities(events, tuning) + typingActivities(events, tuning)
+        activities.sort { $0.start < $1.start }
+
+        activities = activities.map { padded($0, duration: duration, tuning: tuning) }
+            .filter { $0.end - $0.start >= tuning.minimumActivity }
+
+        activities = merged(activities, tuning: tuning)
+
+        return activities.map { segment(for: $0, frameSize: frameSize, tuning: tuning) }
+    }
+
+    // MARK: - Finding activities
+
+    /// Chained clustering: a click joins the run if it is close to the *previous* click, not to the
+    /// run's first. That is what makes a drag across the screen one activity — measuring from the
+    /// start would break it into pieces at the radius boundary.
+    private static func clickActivities(_ events: EventLog, _ tuning: Tuning) -> [Activity] {
+        let presses = events.pressDowns.filter(\.isInside)
+        guard !presses.isEmpty else { return [] }
+
+        var activities: [Activity] = []
+        var current = Activity(start: presses[0].t, end: presses[0].t, points: [presses[0].point])
+
+        for press in presses.dropFirst() {
+            let previous = current.points[current.points.count - 1]
+            let apart = hypot(press.point.x - previous.x, press.point.y - previous.y)
+            if press.t - current.end <= tuning.clusterInterval && apart <= tuning.clusterRadius {
+                current.end = press.t
+                current.points.append(press.point)
+            } else {
+                activities.append(current)
+                current = Activity(start: press.t, end: press.t, points: [press.point])
+            }
+        }
+        activities.append(current)
+        return activities
+    }
+
+    /// Typing is activity too.
+    ///
+    /// Filling in a form or writing code produces no clicks at all, and a planner that only watches
+    /// the mouse ignores the most common thing in a software demo. Anchored where the caret most
+    /// likely is: the pointer, since that is where the user last put it.
+    private static func typingActivities(_ events: EventLog, _ tuning: Tuning) -> [Activity] {
+        guard events.keys.count >= tuning.typingRun else { return [] }
+
+        var runs: [[KeyEvent]] = []
+        var current: [KeyEvent] = [events.keys[0]]
+        for key in events.keys.dropFirst() {
+            if key.t - (current.last?.t ?? key.t) <= tuning.typingInterval {
+                current.append(key)
+            } else {
+                runs.append(current)
+                current = [key]
+            }
+        }
+        runs.append(current)
+
+        return runs.filter { $0.count >= tuning.typingRun }.map { run in
+            let start = run[0].t
+            let end = run[run.count - 1].t
+            let point = events.cursorPoint(at: (start + end) / 2)
+            return Activity(start: start, end: end, points: point.map { [$0] } ?? [])
+        }
+    }
+
+    // MARK: - Shaping
+
+    private static func padded(_ activity: Activity, duration: TimeInterval,
+                               tuning: Tuning) -> Activity {
+        var padded = activity
+        padded.start = max(0, activity.start - tuning.leadIn)
+        padded.end = min(duration, activity.end + tuning.leadOut)
+        return padded
+    }
+
+    /// Two passes, and they enforce different rules.
+    ///
+    /// The first closes gaps shorter than `mergeGap` — an out-and-straight-back-in. The second is
+    /// the density cap: even well-separated activities are merged if they *start* closer together
+    /// than `minimumSpacing`, which is what keeps a busy demo from zooming every two seconds.
+    private static func merged(_ activities: [Activity], tuning: Tuning) -> [Activity] {
+        guard var previous = activities.first else { return [] }
+        var result: [Activity] = []
+
+        for activity in activities.dropFirst() {
+            let touches = activity.start - previous.end < tuning.mergeGap
+            let tooSoon = activity.start - previous.start < tuning.minimumSpacing
+            if touches || tooSoon {
+                previous.end = max(previous.end, activity.end)
+                previous.points.append(contentsOf: activity.points)
+            } else {
+                result.append(previous)
+                previous = activity
+            }
+        }
+        result.append(previous)
+        return result
+    }
+
+    /// The level comes from the activity's own extent: zoom until it fills `targetCoverage` of the
+    /// frame, and no further. A single click has no extent and gets the maximum; a drag across half
+    /// the screen gets almost nothing, because zooming into it would hide half of itself.
+    private static func segment(for activity: Activity, frameSize: CGSize,
+                                tuning: Tuning) -> ZoomSegment {
+        let box = bounds(of: activity.points, frameSize: frameSize)
+
+        // Guarded against zero: a single point would divide by nothing, and the answer we want in
+        // that case — "as close as you are allowed" — falls out of the clamp anyway.
+        let byWidth = tuning.targetCoverage * Double(frameSize.width) / Double(max(box.width, 1))
+        let byHeight = tuning.targetCoverage * Double(frameSize.height) / Double(max(box.height, 1))
+        let level = min(max(min(byWidth, byHeight), tuning.levelRange.lowerBound),
+                        tuning.levelRange.upperBound)
+
+        let travel = max(Double(box.width) / Double(frameSize.width),
+                         Double(box.height) / Double(frameSize.height))
+        let anchor: ZoomSegment.Anchor = travel > tuning.followThreshold
+            ? .followCursor
+            : .fixed(CGPoint(x: box.midX / frameSize.width, y: box.midY / frameSize.height))
+
+        return ZoomSegment(start: activity.start, end: activity.end,
+                           level: level, anchor: anchor, isAutomatic: true)
+    }
+
+    private static func bounds(of points: [CGPoint], frameSize: CGSize) -> CGRect {
+        guard let first = points.first else {
+            return CGRect(x: frameSize.width / 2, y: frameSize.height / 2, width: 0, height: 0)
+        }
+        var minX = first.x, maxX = first.x, minY = first.y, maxY = first.y
+        for point in points.dropFirst() {
+            minX = min(minX, point.x); maxX = max(maxX, point.x)
+            minY = min(minY, point.y); maxY = max(maxY, point.y)
+        }
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/ZoomResolver.swift
+++ b/Sources/Sarvkrit/Features/Studio/ZoomResolver.swift
@@ -7,8 +7,13 @@ struct ZoomTransform: Equatable {
     var scale: Double = 1
     /// Normalised 0…1, and always already clamped so the visible rectangle is inside the frame.
     var center: CGPoint = CGPoint(x: 0.5, y: 0.5)
-    /// Whether the frame is travelling. The renderer blurs only while this is true, so a static
-    /// zoomed shot costs nothing.
+    /// Whether the frame is travelling.
+    ///
+    /// **Nothing reads this yet.** It claimed the renderer blurs while it is true, and the
+    /// renderer does not — there is no motion blur in the compositor at all. Kept, because it is
+    /// the honest answer to a question only the resolver can answer, and because a held join now
+    /// depends on the distinction: the frame between two joined segments is standing still rather
+    /// than moving. The claim is removed rather than the field.
     var isMoving = false
 
     static let identity = ZoomTransform()
@@ -27,6 +32,15 @@ enum ZoomResolver {
     /// seasick. Inside the zone the frame is perfectly still.
     static let deadZone: Double = 0.25
 
+    /// How close two segments have to be to become one continuous move.
+    ///
+    /// **Under this, the frame holds; over it, it zooms out and back in.** Both answers are right
+    /// for different gaps. A tenth of a second of identity between a 2.5× shot and a 1.4× one is
+    /// the "weird animation" — the picture travelling somewhere neither zoom asked to go — but
+    /// holding a close-up across three seconds of nothing happening is worse than the dip, because
+    /// the shot never breathes. A second is about where a pause stops reading as a pause.
+    static let joinGap: TimeInterval = 1.0
+
     /// - Parameter clipSource: the source range of the clip this frame came from, if the caller
     ///   knows it — which `Timeline.sourceTime(forOutput:)` always does, since it returns the clip
     ///   alongside the time.
@@ -40,31 +54,119 @@ enum ZoomResolver {
                           cursor: CGPoint?,
                           frameSize: CGSize,
                           clipSource: Range<TimeInterval>? = nil) -> ZoomTransform {
-        guard frameSize.width > 0, frameSize.height > 0,
-              let segment = segments.first(where: {
-                  !$0.isDisabled && t >= $0.start && t < $0.end
-              })
-        else { return .identity }
+        guard frameSize.width > 0, frameSize.height > 0 else { return .identity }
 
-        let (progress, moving) = envelope(for: segment, at: t, clipSource: clipSource)
-        let scale = segment.ease.interpolate(from: 1, to: segment.level, progress: progress)
+        // **Sorted, because the neighbours are what this function is now about.** Segments reach
+        // here in whatever order the project holds them, and `redetectZooms` concatenates
+        // hand-made ones onto planned ones without merging, so array order is not time order.
+        let live = segments.filter { !$0.isDisabled }.sorted { $0.start < $1.start }
 
-        let anchor = target(for: segment, cursor: cursor, frameSize: frameSize)
-        return ZoomTransform(scale: scale,
-                             center: clamp(anchor, scale: scale),
-                             isMoving: moving)
+        guard let index = live.firstIndex(where: { t >= $0.start && t < $0.end }) else {
+            return held(at: t, in: live, cursor: cursor, frameSize: frameSize,
+                        clipSource: clipSource)
+        }
+        let segment = live[index]
+
+        // A neighbour close enough to make this one move continuous. Anything on the far side of a
+        // cut is not a neighbour: the picture is about to jump to different material, and easing
+        // between two levels across that is the pop the clip-boundary logic exists to prevent.
+        let previous = index > 0 ? live[index - 1] : nil
+        let next = index + 1 < live.count ? live[index + 1] : nil
+        let joinedPrevious = previous.flatMap {
+            joins($0, before: segment, clipSource: clipSource) ? $0 : nil
+        }
+        let joinedNext = next.flatMap {
+            joins(segment, before: $0, clipSource: clipSource) ? $0 : nil
+        }
+
+        let phase = self.phase(for: segment, at: t, clipSource: clipSource,
+                               holdsToEnd: joinedNext != nil)
+        let own = target(for: segment, cursor: cursor, frameSize: frameSize)
+
+        switch phase {
+        case .easingIn(let progress):
+            // **The level it is coming *from*, not the literal 1.** This was the bug: every ramp
+            // was measured against identity, so a zoom following another one climbed back up from
+            // nothing instead of moving straight to its own level.
+            let from = joinedPrevious?.level ?? 1
+            let scale = segment.ease.interpolate(from: from, to: segment.level, progress: progress)
+            // The centre travels on the same curve. Without this the join is a smooth zoom with an
+            // instant jump sideways inside it, which reads worse than the dip did.
+            let entry = joinedPrevious.map { target(for: $0, cursor: cursor, frameSize: frameSize) }
+            let centre = entry.map {
+                interpolate(from: $0, to: own, fraction: segment.ease.value(progress))
+            } ?? own
+            return ZoomTransform(scale: scale, center: clamp(centre, scale: scale), isMoving: true)
+
+        case .holding:
+            return ZoomTransform(scale: segment.level,
+                                 center: clamp(own, scale: segment.level),
+                                 isMoving: false)
+
+        case .easingOut(let progress):
+            let scale = segment.ease.interpolate(from: 1, to: segment.level, progress: progress)
+            return ZoomTransform(scale: scale, center: clamp(own, scale: scale), isMoving: true)
+        }
     }
 
-    /// 0 at the edges of the segment, 1 while it holds — with the in and out ramps sized by the
-    /// segment's own ease durations, and squeezed if the segment is too short to fit both.
-    private static func envelope(for segment: ZoomSegment,
-                                 at t: TimeInterval,
-                                 clipSource: Range<TimeInterval>?)
-        -> (progress: Double, isMoving: Bool) {
+    /// The frame between two segments that are close enough to be one move: it holds where the
+    /// first one left it rather than resolving to identity because no segment covers the moment.
+    private static func held(at t: TimeInterval, in live: [ZoomSegment], cursor: CGPoint?,
+                             frameSize: CGSize,
+                             clipSource: Range<TimeInterval>?) -> ZoomTransform {
+        guard let previous = live.last(where: { $0.end <= t }),
+              let next = live.first(where: { $0.start > t }),
+              joins(previous, before: next, clipSource: clipSource)
+        else { return .identity }
+
+        let anchor = target(for: previous, cursor: cursor, frameSize: frameSize)
+        return ZoomTransform(scale: previous.level,
+                             center: clamp(anchor, scale: previous.level),
+                             isMoving: false)
+    }
+
+    /// Whether `earlier` and `later` are one continuous move rather than two shots.
+    ///
+    /// Both have to be inside the clip on screen. A segment on the far side of a cut is not a
+    /// neighbour however close its timestamps are, because source time is not monotonic in output
+    /// time once the edit has a cut in it.
+    private static func joins(_ earlier: ZoomSegment, before later: ZoomSegment,
+                              clipSource: Range<TimeInterval>?) -> Bool {
+        guard later.start - earlier.end <= joinGap, later.start >= earlier.end else { return false }
+        guard let clipSource else { return true }
+        return earlier.end > clipSource.lowerBound && later.start < clipSource.upperBound
+    }
+
+    private static func interpolate(from: CGPoint, to: CGPoint, fraction: Double) -> CGPoint {
+        CGPoint(x: from.x + (to.x - from.x) * CGFloat(fraction),
+                y: from.y + (to.y - from.y) * CGFloat(fraction))
+    }
+
+    /// Which part of its own life a segment is in at this moment.
+    private enum Phase {
+        /// Progress 0…1 through the in-ramp.
+        case easingIn(Double)
+        /// At its own level, standing still.
+        case holding
+        /// Progress 1…0 through the out-ramp, on its way back to identity.
+        case easingOut(Double)
+    }
+
+    /// The ramps sized by the segment's own ease durations, squeezed if the segment is too short to
+    /// fit both.
+    ///
+    /// - Parameter holdsToEnd: there is a neighbour immediately after this one, so **the out-ramp
+    ///   is suppressed** and the segment carries its level to its own end. The transition happens
+    ///   once, in the next segment's in-ramp, rather than twice — out to identity and back.
+    private static func phase(for segment: ZoomSegment,
+                              at t: TimeInterval,
+                              clipSource: Range<TimeInterval>?,
+                              holdsToEnd: Bool) -> Phase {
         // Clamped to the material actually on screen. See `transform`.
         let start = max(segment.start, clipSource?.lowerBound ?? -.greatestFiniteMagnitude)
         let end = min(segment.end, clipSource?.upperBound ?? .greatestFiniteMagnitude)
         let wasCutInto = start > segment.start
+        let wasCutOffAt = end < segment.end
 
         let elapsed = t - start
         let remaining = end - t
@@ -82,15 +184,19 @@ enum ZoomResolver {
         // holds for a clip that begins partway through a zoom — ramping in just after a cut reads
         // as a mistake, where cutting straight to the close-up reads as an edit.
         if segment.start <= 0 || wasCutInto, elapsed < easeIn {
-            return (1, false)
+            return .holding
         }
         if easeIn > 0, elapsed < easeIn {
-            return (elapsed / easeIn, true)
+            return .easingIn(elapsed / easeIn)
         }
-        if easeOut > 0, remaining < easeOut {
-            return (remaining / easeOut, true)
+        // **A cut still wins.** `holdsToEnd` suppresses the out-ramp at a join, where the next
+        // segment picks the movement up — but a segment truncated by a clip boundary is not at a
+        // join, it is about to be interrupted, and it has to be back at identity before the
+        // picture jumps.
+        if easeOut > 0, remaining < easeOut, !holdsToEnd || wasCutOffAt {
+            return .easingOut(remaining / easeOut)
         }
-        return (1, false)
+        return .holding
     }
 
     private static func target(for segment: ZoomSegment, cursor: CGPoint?,

--- a/Sources/Sarvkrit/Features/Studio/ZoomResolver.swift
+++ b/Sources/Sarvkrit/Features/Studio/ZoomResolver.swift
@@ -111,6 +111,12 @@ enum ZoomResolver {
 
     /// The frame between two segments that are close enough to be one move: it holds where the
     /// first one left it rather than resolving to identity because no segment covers the moment.
+    ///
+    /// **The neighbours are found without regard to the clip, and `joins` is what rejects one on
+    /// the far side of a cut.** Splitting the two steps is deliberate — the search wants the
+    /// nearest segments in time, and only then does it matter whether they are in the same shot —
+    /// but it means the clip boundary is enforced in exactly one place. Anyone adding a condition
+    /// here should add it to `joins` instead.
     private static func held(at t: TimeInterval, in live: [ZoomSegment], cursor: CGPoint?,
                              frameSize: CGSize,
                              clipSource: Range<TimeInterval>?) -> ZoomTransform {

--- a/Sources/Sarvkrit/Features/Studio/ZoomResolver.swift
+++ b/Sources/Sarvkrit/Features/Studio/ZoomResolver.swift
@@ -1,0 +1,126 @@
+import CoreGraphics
+import Foundation
+
+/// How the screen layer is framed at one instant.
+struct ZoomTransform: Equatable {
+    /// 1 means the whole recording.
+    var scale: Double = 1
+    /// Normalised 0…1, and always already clamped so the visible rectangle is inside the frame.
+    var center: CGPoint = CGPoint(x: 0.5, y: 0.5)
+    /// Whether the frame is travelling. The renderer blurs only while this is true, so a static
+    /// zoomed shot costs nothing.
+    var isMoving = false
+
+    static let identity = ZoomTransform()
+}
+
+/// Resolving the zoom track into the one transform a frame is drawn with.
+///
+/// Pure over the segments, and separate from anything that draws, so the whole of the framing
+/// behaviour can be asserted without a pixel.
+enum ZoomResolver {
+
+    /// Fraction of the frame the pointer may wander inside before the view follows it.
+    ///
+    /// **Without a dead zone, following is drift.** A pointer that twitches while somebody talks
+    /// would slide the whole picture, and over a five-minute demo that is what makes people feel
+    /// seasick. Inside the zone the frame is perfectly still.
+    static let deadZone: Double = 0.25
+
+    static func transform(at t: TimeInterval,
+                          segments: [ZoomSegment],
+                          cursor: CGPoint?,
+                          frameSize: CGSize) -> ZoomTransform {
+        guard frameSize.width > 0, frameSize.height > 0,
+              let segment = segments.first(where: {
+                  !$0.isDisabled && t >= $0.start && t < $0.end
+              })
+        else { return .identity }
+
+        let (progress, moving) = envelope(for: segment, at: t)
+        let scale = segment.ease.interpolate(from: 1, to: segment.level, progress: progress)
+
+        let anchor = target(for: segment, cursor: cursor, frameSize: frameSize)
+        return ZoomTransform(scale: scale,
+                             center: clamp(anchor, scale: scale),
+                             isMoving: moving)
+    }
+
+    /// 0 at the edges of the segment, 1 while it holds — with the in and out ramps sized by the
+    /// segment's own ease durations, and squeezed if the segment is too short to fit both.
+    private static func envelope(for segment: ZoomSegment,
+                                 at t: TimeInterval) -> (progress: Double, isMoving: Bool) {
+        let elapsed = t - segment.start
+        let remaining = segment.end - t
+        let duration = max(segment.duration, 0.0001)
+
+        // A segment shorter than its own ramps would otherwise ease in past its end and never
+        // reach its level. Sharing the available time keeps both ramps and simply shortens them.
+        let total = segment.easeIn + segment.easeOut
+        let squeeze = total > duration ? duration / total : 1
+        let easeIn = segment.easeIn * squeeze
+        let easeOut = segment.easeOut * squeeze
+
+        // A zoom that begins on frame zero opens already zoomed rather than animating in from
+        // nothing: if the first thing to show is a close-up, it should simply be there.
+        if segment.start <= 0, elapsed < easeIn {
+            return (1, false)
+        }
+        if easeIn > 0, elapsed < easeIn {
+            return (elapsed / easeIn, true)
+        }
+        if easeOut > 0, remaining < easeOut {
+            return (remaining / easeOut, true)
+        }
+        return (1, false)
+    }
+
+    private static func target(for segment: ZoomSegment, cursor: CGPoint?,
+                               frameSize: CGSize) -> CGPoint {
+        switch segment.anchor {
+        case .fixed(let point):
+            return point
+        case .followCursor:
+            // Nothing to follow is not an error — the pointer may simply have been outside the
+            // recorded region — and the middle is the only honest answer.
+            guard let cursor else { return CGPoint(x: 0.5, y: 0.5) }
+            let normalised = CGPoint(x: cursor.x / frameSize.width,
+                                     y: cursor.y / frameSize.height)
+            return settled(towards: normalised)
+        }
+    }
+
+    /// Quantises the pointer to the dead zone: the frame moves only once the pointer has left the
+    /// middle of it, and then lands on the position that puts it back in the middle.
+    private static func settled(towards point: CGPoint) -> CGPoint {
+        func axis(_ value: Double) -> Double {
+            let offset = value - 0.5
+            guard abs(offset) > deadZone / 2 else { return 0.5 }
+            return 0.5 + (offset - (offset > 0 ? deadZone / 2 : -deadZone / 2))
+        }
+        return CGPoint(x: axis(point.x), y: axis(point.y))
+    }
+
+    /// Pulls the centre in so the visible rectangle never leaves the recording.
+    ///
+    /// **This is the one that must not be wrong.** A centre that drifts past the edge shows the
+    /// background through the middle of the picture, which reads as a rendering fault rather than
+    /// a framing choice — and at 1× it collapses to the only legal answer, which is why zooming
+    /// out always lands exactly where the un-zoomed frame is.
+    private static func clamp(_ center: CGPoint, scale: Double) -> CGPoint {
+        let half = 0.5 / max(scale, 1)
+        func axis(_ value: CGFloat) -> CGFloat {
+            min(max(value, CGFloat(half)), CGFloat(1 - half))
+        }
+        return CGPoint(x: axis(center.x), y: axis(center.y))
+    }
+
+    /// The source rectangle, in recording pixels, that a transform is showing.
+    static func sourceRect(for transform: ZoomTransform, frameSize: CGSize) -> CGRect {
+        let width = frameSize.width / CGFloat(transform.scale)
+        let height = frameSize.height / CGFloat(transform.scale)
+        return CGRect(x: transform.center.x * frameSize.width - width / 2,
+                      y: transform.center.y * frameSize.height - height / 2,
+                      width: width, height: height)
+    }
+}

--- a/Sources/Sarvkrit/Features/Studio/ZoomResolver.swift
+++ b/Sources/Sarvkrit/Features/Studio/ZoomResolver.swift
@@ -27,17 +27,26 @@ enum ZoomResolver {
     /// seasick. Inside the zone the frame is perfectly still.
     static let deadZone: Double = 0.25
 
+    /// - Parameter clipSource: the source range of the clip this frame came from, if the caller
+    ///   knows it — which `Timeline.sourceTime(forOutput:)` always does, since it returns the clip
+    ///   alongside the time.
+    ///
+    ///   **Source time is not monotonic in output time once the edit has a cut in it.** The frame
+    ///   after a boundary can come from anywhere in the recording, so a ramp measured from the
+    ///   segment's own end is still mid-flight when the picture jumps, and the zoom pops. Ramping
+    ///   against the segment's *intersection with the clip* makes it ease out at the cut instead.
     static func transform(at t: TimeInterval,
                           segments: [ZoomSegment],
                           cursor: CGPoint?,
-                          frameSize: CGSize) -> ZoomTransform {
+                          frameSize: CGSize,
+                          clipSource: Range<TimeInterval>? = nil) -> ZoomTransform {
         guard frameSize.width > 0, frameSize.height > 0,
               let segment = segments.first(where: {
                   !$0.isDisabled && t >= $0.start && t < $0.end
               })
         else { return .identity }
 
-        let (progress, moving) = envelope(for: segment, at: t)
+        let (progress, moving) = envelope(for: segment, at: t, clipSource: clipSource)
         let scale = segment.ease.interpolate(from: 1, to: segment.level, progress: progress)
 
         let anchor = target(for: segment, cursor: cursor, frameSize: frameSize)
@@ -49,10 +58,17 @@ enum ZoomResolver {
     /// 0 at the edges of the segment, 1 while it holds — with the in and out ramps sized by the
     /// segment's own ease durations, and squeezed if the segment is too short to fit both.
     private static func envelope(for segment: ZoomSegment,
-                                 at t: TimeInterval) -> (progress: Double, isMoving: Bool) {
-        let elapsed = t - segment.start
-        let remaining = segment.end - t
-        let duration = max(segment.duration, 0.0001)
+                                 at t: TimeInterval,
+                                 clipSource: Range<TimeInterval>?)
+        -> (progress: Double, isMoving: Bool) {
+        // Clamped to the material actually on screen. See `transform`.
+        let start = max(segment.start, clipSource?.lowerBound ?? -.greatestFiniteMagnitude)
+        let end = min(segment.end, clipSource?.upperBound ?? .greatestFiniteMagnitude)
+        let wasCutInto = start > segment.start
+
+        let elapsed = t - start
+        let remaining = end - t
+        let duration = max(end - start, 0.0001)
 
         // A segment shorter than its own ramps would otherwise ease in past its end and never
         // reach its level. Sharing the available time keeps both ramps and simply shortens them.
@@ -62,8 +78,10 @@ enum ZoomResolver {
         let easeOut = segment.easeOut * squeeze
 
         // A zoom that begins on frame zero opens already zoomed rather than animating in from
-        // nothing: if the first thing to show is a close-up, it should simply be there.
-        if segment.start <= 0, elapsed < easeIn {
+        // nothing: if the first thing to show is a close-up, it should simply be there. The same
+        // holds for a clip that begins partway through a zoom — ramping in just after a cut reads
+        // as a mistake, where cutting straight to the close-up reads as an edit.
+        if segment.start <= 0 || wasCutInto, elapsed < easeIn {
             return (1, false)
         }
         if easeIn > 0, elapsed < easeIn {

--- a/Sources/Sarvkrit/Features/Studio/ZoomSegment.swift
+++ b/Sources/Sarvkrit/Features/Studio/ZoomSegment.swift
@@ -1,0 +1,86 @@
+import CoreGraphics
+import Foundation
+
+/// One stretch of the recording that is shown magnified.
+///
+/// **Stored in source time**, like every other track, and resolved for rendering through
+/// `Timeline.sourceTime(forOutput:)`. That is what makes trimming the first two seconds off a
+/// recording leave the zooms attached to the moments they were built for, rather than sliding
+/// them all two seconds early.
+struct ZoomSegment: Codable, Equatable, Identifiable {
+
+    /// What the frame is centred on while the zoom holds.
+    enum Anchor: Equatable {
+        /// Track a heavily damped version of the pointer. For an activity that moves.
+        case followCursor
+        /// Hold still, at a point normalised 0…1 across the frame.
+        ///
+        /// Normalised so the anchor survives a change of export resolution — the same project
+        /// exported at 1080p and 4K must frame the same thing.
+        case fixed(CGPoint)
+    }
+
+    var id = UUID()
+    /// Source time, seconds.
+    var start: TimeInterval
+    var end: TimeInterval
+    var level: Double
+    var anchor: Anchor
+    /// Seconds of *output* time spent arriving. Output rather than source, because a clip sped up
+    /// to 4× would otherwise compress a 0.6 s zoom-in into 0.15 s and turn it into a jump cut.
+    var easeIn: TimeInterval = 0.6
+    /// Shorter than `easeIn`: you can leave faster than you arrive without it feeling abrupt.
+    var easeOut: TimeInterval = 0.5
+    var ease: ZoomEase = .smooth
+    /// Whether `ZoomPlanner` made this one.
+    ///
+    /// **This flag is what lets "Re-detect zooms" be pressed twice.** Regeneration replaces the
+    /// automatic segments and leaves hand-made ones alone; without the distinction the button
+    /// destroys the user's own work every time it is used.
+    var isAutomatic: Bool = true
+    var isDisabled: Bool = false
+
+    static let levelRange: ClosedRange<Double> = 1...4
+    /// Below this a segment cannot be grabbed with a mouse.
+    static let minimumDuration: TimeInterval = 0.1
+
+    var duration: TimeInterval { max(0, end - start) }
+
+    func clamped() -> ZoomSegment {
+        var copy = self
+        copy.level = min(max(level, Self.levelRange.lowerBound), Self.levelRange.upperBound)
+        return copy
+    }
+}
+
+/// Hand-written rather than synthesised, so an anchor written by a newer build decodes to
+/// something drawable instead of throwing and taking the whole project with it.
+extension ZoomSegment.Anchor: Codable {
+    private enum CodingKeys: String, CodingKey { case type, x, y }
+    private enum Kind: String, Codable { case followCursor, fixed }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = (try? container.decode(Kind.self, forKey: .type)) ?? .followCursor
+        switch kind {
+        case .followCursor:
+            self = .followCursor
+        case .fixed:
+            let x = (try? container.decode(CGFloat.self, forKey: .x)) ?? 0.5
+            let y = (try? container.decode(CGFloat.self, forKey: .y)) ?? 0.5
+            self = .fixed(CGPoint(x: x, y: y))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .followCursor:
+            try container.encode(Kind.followCursor, forKey: .type)
+        case .fixed(let point):
+            try container.encode(Kind.fixed, forKey: .type)
+            try container.encode(point.x, forKey: .x)
+            try container.encode(point.y, forKey: .y)
+        }
+    }
+}

--- a/Sources/Sarvkrit/Resources/Info.plist
+++ b/Sources/Sarvkrit/Resources/Info.plist
@@ -39,6 +39,12 @@
 	<true/>
 	<key>NSAudioCaptureUsageDescription</key>
 	<string>Sarvkrit needs this to set the volume of individual apps. Their audio passes through Sarvkrit so it can be turned up or down, and is never recorded, stored or sent anywhere.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Sarvkrit needs the camera to record you alongside your screen. The video is written to your Mac and never sent anywhere.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Sarvkrit needs the microphone to record narration over your screen recording. The audio is written to your Mac and never sent anywhere.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Sarvkrit works out captions for your recordings on this Mac. macOS asks because it gates the recognition API, not because anything is uploaded — nothing leaves your machine.</string>
 	<key>NSDesktopFolderUsageDescription</key>
 	<string>Sarvkrit needs access to your Desktop to apply the file rules you create.</string>
 	<key>NSDocumentsFolderUsageDescription</key>

--- a/Sources/Sarvkrit/Resources/Info.plist
+++ b/Sources/Sarvkrit/Resources/Info.plist
@@ -4,6 +4,23 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Sarvkrit Recording</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>ai.psylief.sarvkrit.recording</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<true/>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -41,10 +58,6 @@
 	<string>Sarvkrit needs this to set the volume of individual apps. Their audio passes through Sarvkrit so it can be turned up or down, and is never recorded, stored or sent anywhere.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Sarvkrit needs the camera to record you alongside your screen. The video is written to your Mac and never sent anywhere.</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Sarvkrit needs the microphone to record narration over your screen recording. The audio is written to your Mac and never sent anywhere.</string>
-	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>Sarvkrit works out captions for your recordings on this Mac. macOS asks because it gates the recognition API, not because anything is uploaded — nothing leaves your machine.</string>
 	<key>NSDesktopFolderUsageDescription</key>
 	<string>Sarvkrit needs access to your Desktop to apply the file rules you create.</string>
 	<key>NSDocumentsFolderUsageDescription</key>
@@ -53,9 +66,33 @@
 	<string>Sarvkrit needs access to your Downloads folder to apply the file rules you create.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Sarvkrit</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Sarvkrit needs the microphone to record narration over your screen recording. The audio is written to your Mac and never sent anywhere.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Sarvkrit works out captions for your recordings on this Mac. macOS asks because it gates the recognition API, not because anything is uploaded — nothing leaves your machine.</string>
 	<key>NSSupportsAutomaticTermination</key>
 	<false/>
 	<key>NSSupportsSuddenTermination</key>
 	<false/>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>com.apple.package</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Sarvkrit Recording</string>
+			<key>UTTypeIdentifier</key>
+			<string>ai.psylief.sarvkrit.recording</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>sarvrec</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Sources/Sarvkrit/Resources/Info.plist
+++ b/Sources/Sarvkrit/Resources/Info.plist
@@ -22,7 +22,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 			<key>CFBundleURLName</key>
-			<string>ai.hercules.sarvkrit.capture</string>
+			<string>ai.psylief.sarvkrit.capture</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>sarvkrit</string>

--- a/Sources/Sarvkrit/Resources/Sarvkrit.entitlements
+++ b/Sources/Sarvkrit/Resources/Sarvkrit.entitlements
@@ -4,5 +4,27 @@
 <dict>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+
+	<!--
+	  Camera and microphone, for Screen Recording's optional camera and narration.
+
+	  **A usage string is necessary and not sufficient.** This build has Hardened Runtime on
+	  (project.yml, ENABLE_HARDENED_RUNTIME), and under it macOS refuses to even show the
+	  permission prompt unless the matching entitlement is present. The failure is silent from
+	  the app's side: requestAccess returns denied, authorizationStatus reports denied, and the
+	  user is told to check System Settings — where the app does not appear, because it was
+	  never allowed to ask. tccd says so plainly:
+
+	      Prompting policy for hardened runtime; service: kTCCServiceCamera requires
+	      entitlement com.apple.security.device.camera but it is missing
+
+	  These are hardened-runtime exceptions, NOT the App Sandbox. The sandbox must stay off —
+	  see the README — and it is off precisely because com.apple.security.app-sandbox is absent
+	  from this file. Adding either key below does not turn it on.
+	-->
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/Sources/Sarvkrit/UI/MainWindowView.swift
+++ b/Sources/Sarvkrit/UI/MainWindowView.swift
@@ -67,8 +67,15 @@ struct MainWindowView: View {
     /// cleared, so re-opening the window later lands wherever the user last was.
     private func consumePendingSelection() {
         guard let requested = app.pendingSidebarSelection else { return }
-        if requested == SidebarItem.generalID { selection = .general }
-        if requested == SidebarItem.aboutID { selection = .about }
+        if requested == SidebarItem.generalID {
+            selection = .general
+        } else if requested == SidebarItem.aboutID {
+            selection = .about
+        } else if app.features.contains(where: { $0.id == requested }) {
+            // A feature's own pane, so `sarvkrit://open-settings?pane=screen-recording` lands on
+            // the thing it is about rather than wherever the window was last left.
+            selection = .feature(requested)
+        }
         app.pendingSidebarSelection = nil
     }
 

--- a/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
+++ b/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
@@ -69,6 +69,7 @@ struct CaptureAutomationSection: View {
         case .stopRecording: return "Stop Recording"
         case .seek: return "Move the Playhead"
         case .playPause: return "Play / Pause"
+        case .exportEditor: return "Export the Recording"
         case .action(let action): return action.title
         }
     }

--- a/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
+++ b/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
@@ -72,6 +72,8 @@ struct CaptureAutomationSection: View {
         case .exportEditor: return "Export the Recording"
         case .editorCommand: return "Editor Action (split, undo, …)"
         case .addPicture: return "Add a Picture"
+        case .showRecordBar: return "Set Up a Recording"
+        case .aimRecording: return "Aim the Recording"
         case .action(let action): return action.title
         }
     }

--- a/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
+++ b/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
@@ -65,6 +65,8 @@ struct CaptureAutomationSection: View {
         case .openFromClipboard: return "Annotate Clipboard Image"
         case .openSettings: return "Open Settings"
         case .captureRect: return "Capture Area"
+        case .record: return "Start Recording"
+        case .stopRecording: return "Stop Recording"
         case .action(let action): return action.title
         }
     }

--- a/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
+++ b/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
@@ -68,6 +68,7 @@ struct CaptureAutomationSection: View {
         case .record: return "Start Recording"
         case .stopRecording: return "Stop Recording"
         case .seek: return "Move the Playhead"
+        case .playPause: return "Play / Pause"
         case .action(let action): return action.title
         }
     }

--- a/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
+++ b/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
@@ -70,6 +70,7 @@ struct CaptureAutomationSection: View {
         case .seek: return "Move the Playhead"
         case .playPause: return "Play / Pause"
         case .exportEditor: return "Export the Recording"
+        case .editorCommand: return "Editor Action (split, undo, …)"
         case .action(let action): return action.title
         }
     }

--- a/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
+++ b/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
@@ -71,6 +71,7 @@ struct CaptureAutomationSection: View {
         case .playPause: return "Play / Pause"
         case .exportEditor: return "Export the Recording"
         case .editorCommand: return "Editor Action (split, undo, …)"
+        case .addPicture: return "Add a Picture"
         case .action(let action): return action.title
         }
     }

--- a/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
+++ b/Sources/Sarvkrit/UI/Screenshots/CaptureAutomationSection.swift
@@ -67,6 +67,7 @@ struct CaptureAutomationSection: View {
         case .captureRect: return "Capture Area"
         case .record: return "Start Recording"
         case .stopRecording: return "Stop Recording"
+        case .seek: return "Move the Playhead"
         case .action(let action): return action.title
         }
     }

--- a/Sources/Sarvkrit/UI/Screenshots/CaptureOverlayGuard.swift
+++ b/Sources/Sarvkrit/UI/Screenshots/CaptureOverlayGuard.swift
@@ -66,6 +66,7 @@ final class CaptureOverlayGuard {
             || ScrollCaptureSession.shared.isRunning
             || PinnedShotController.shared.count > 0
             || CaptureHistoryWindowController.shared.isPresenting
+            || RecordingHUDController.shared.isShowing
     }
 
     /// Takes everything down. Safe to call at any time, including when nothing is up.
@@ -83,6 +84,7 @@ final class CaptureOverlayGuard {
         CaptureHistoryWindowController.shared.dismiss()
         TextResultController.shared.dismiss()
         WindowPickerListController.shared.dismiss()
+        RecordingHUDController.shared.dismiss()
         // System-wide, not just AppKit's: the overlay hides the pointer with CGDisplayHideCursor
         // because it runs from the background, and only the matching call brings it back.
         OverlayCursor.show()

--- a/Sources/Sarvkrit/UI/Screenshots/CaptureOverlayGuard.swift
+++ b/Sources/Sarvkrit/UI/Screenshots/CaptureOverlayGuard.swift
@@ -70,6 +70,12 @@ final class CaptureOverlayGuard {
             || PreRecordBarController.shared.isShowing
     }
 
+    /// Set by `AppDelegate`, because nothing in the UI layer knows about the recorder.
+    ///
+    /// Nil until then, and `dismissEverything()` tolerates that — a nil closure is how a
+    /// not-yet-wired half of the app is absent rather than crashing.
+    var stopRecording: (() -> Void)?
+
     /// Takes everything down. Safe to call at any time, including when nothing is up.
     ///
     /// Unlocks before closing so a pin that ignores mouse events cannot survive as an invisible
@@ -85,6 +91,11 @@ final class CaptureOverlayGuard {
         CaptureHistoryWindowController.shared.dismiss()
         TextResultController.shared.dismiss()
         WindowPickerListController.shared.dismiss()
+        // The recording is stopped, not merely un-displayed. Dismissing the HUD alone left
+        // `isRecording` true with nothing on screen saying so, and the next ⌃⇧R then hit the
+        // "already recording, so this is a stop" branch — a shortcut that silently did nothing
+        // visible, twice in a row.
+        if RecordingHUDController.shared.isShowing { stopRecording?() }
         RecordingHUDController.shared.dismiss()
         PreRecordBarController.shared.dismiss()
         // System-wide, not just AppKit's: the overlay hides the pointer with CGDisplayHideCursor

--- a/Sources/Sarvkrit/UI/Screenshots/CaptureOverlayGuard.swift
+++ b/Sources/Sarvkrit/UI/Screenshots/CaptureOverlayGuard.swift
@@ -67,6 +67,7 @@ final class CaptureOverlayGuard {
             || PinnedShotController.shared.count > 0
             || CaptureHistoryWindowController.shared.isPresenting
             || RecordingHUDController.shared.isShowing
+            || PreRecordBarController.shared.isShowing
     }
 
     /// Takes everything down. Safe to call at any time, including when nothing is up.
@@ -85,6 +86,7 @@ final class CaptureOverlayGuard {
         TextResultController.shared.dismiss()
         WindowPickerListController.shared.dismiss()
         RecordingHUDController.shared.dismiss()
+        PreRecordBarController.shared.dismiss()
         // System-wide, not just AppKit's: the overlay hides the pointer with CGDisplayHideCursor
         // because it runs from the background, and only the matching call brings it back.
         OverlayCursor.show()

--- a/Sources/Sarvkrit/UI/Screenshots/CaptureOverlayGuard.swift
+++ b/Sources/Sarvkrit/UI/Screenshots/CaptureOverlayGuard.swift
@@ -67,6 +67,7 @@ final class CaptureOverlayGuard {
             || PinnedShotController.shared.count > 0
             || CaptureHistoryWindowController.shared.isPresenting
             || RecordingHUDController.shared.isShowing
+            || CameraPreviewWindowController.shared.isShowing
             || PreRecordBarController.shared.isShowing
     }
 
@@ -97,6 +98,7 @@ final class CaptureOverlayGuard {
         // visible, twice in a row.
         if RecordingHUDController.shared.isShowing { stopRecording?() }
         RecordingHUDController.shared.dismiss()
+        CameraPreviewWindowController.shared.dismiss()
         PreRecordBarController.shared.dismiss()
         // System-wide, not just AppKit's: the overlay hides the pointer with CGDisplayHideCursor
         // because it runs from the background, and only the matching call brings it back.

--- a/Sources/Sarvkrit/UI/Studio/CameraPreviewSession.swift
+++ b/Sources/Sarvkrit/UI/Studio/CameraPreviewSession.swift
@@ -1,0 +1,55 @@
+import AVFoundation
+import AppKit
+import CoreImage
+import Foundation
+
+/// A live camera feed, for looking at rather than recording.
+///
+/// Deliberately separate from `CameraRecorder`: this one never writes a file, runs only while the
+/// pre-record bar is up, and is torn down the moment it closes. Sharing a session between "show me
+/// myself" and "record me" would mean the preview holds the camera open after the bar has gone.
+@MainActor
+final class CameraPreviewSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+
+    private let session = AVCaptureSession()
+    private let context = CIContext(options: [.useSoftwareRenderer: false])
+    private let onFrame: (CGImage?) -> Void
+
+    init(device: AVCaptureDevice, onFrame: @escaping (CGImage?) -> Void) {
+        self.onFrame = onFrame
+        super.init()
+
+        session.beginConfiguration()
+        // The preview is a 56-point square; anything above this is decoded and thrown away.
+        session.sessionPreset = .low
+        if let input = try? AVCaptureDeviceInput(device: device), session.canAddInput(input) {
+            session.addInput(input)
+        }
+        let output = AVCaptureVideoDataOutput()
+        output.alwaysDiscardsLateVideoFrames = true
+        output.setSampleBufferDelegate(self, queue: DispatchQueue(label: "ai.psylief.sarvkrit.preview"))
+        if session.canAddOutput(output) { session.addOutput(output) }
+        session.commitConfiguration()
+
+        // Off the main thread: starting a capture session blocks for a noticeable moment, and
+        // doing it inline stalls the bar as it appears.
+        Task.detached { [session] in session.startRunning() }
+    }
+
+    func stop() {
+        let session = self.session
+        Task.detached { session.stopRunning() }
+    }
+
+    nonisolated func captureOutput(_ output: AVCaptureOutput,
+                                   didOutput sampleBuffer: CMSampleBuffer,
+                                   from connection: AVCaptureConnection) {
+        guard let buffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+        let image = CIImage(cvPixelBuffer: buffer)
+        // Rendered here, on the capture queue, so the main thread only ever receives a finished
+        // bitmap — the same reason the recorder does its writing off the main actor.
+        guard let rendered = MainActor.assumeIsolated({ context })
+            .createCGImage(image, from: image.extent) else { return }
+        Task { @MainActor in self.onFrame(rendered) }
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/CameraPreviewSession.swift
+++ b/Sources/Sarvkrit/UI/Studio/CameraPreviewSession.swift
@@ -19,6 +19,11 @@ final class CameraPreviewSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
 
     private let session = AVCaptureSession()
     private let renderer = PreviewFrameRenderer()
+    /// Start and stop go through one queue, in order. Two unordered detached tasks meant a bar
+    /// dismissed quickly ran `stopRunning()` on a session that had not come up yet — a no-op —
+    /// and `startRunning()` afterwards, leaving the camera light on with nothing left holding a
+    /// reference to switch it off. That is the "green light and no window" report.
+    private let runner = CaptureSessionRunner(label: "ai.psylief.sarvkrit.preview.session")
     private let onFrame: @Sendable (CGImage) -> Void
 
     init(device: AVCaptureDevice, onFrame: @escaping @Sendable (CGImage) -> Void) {
@@ -41,12 +46,13 @@ final class CameraPreviewSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
         // Off the main thread: starting a capture session blocks for a noticeable moment, and
         // doing it inline stalls the bar as it appears.
         let session = self.session
-        Task.detached { session.startRunning() }
+        runner.submit { session.startRunning() }
     }
 
     func stop() {
         let session = self.session
-        Task.detached { session.stopRunning() }
+        // The same queue as the start above, so this can never overtake it.
+        runner.submit { session.stopRunning() }
     }
 
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer,

--- a/Sources/Sarvkrit/UI/Studio/CameraPreviewSession.swift
+++ b/Sources/Sarvkrit/UI/Studio/CameraPreviewSession.swift
@@ -8,14 +8,20 @@ import Foundation
 /// Deliberately separate from `CameraRecorder`: this one never writes a file, runs only while the
 /// pre-record bar is up, and is torn down the moment it closes. Sharing a session between "show me
 /// myself" and "record me" would mean the preview holds the camera open after the bar has gone.
-@MainActor
-final class CameraPreviewSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+///
+/// **Not main-actor, and that is deliberate.** `AVCaptureVideoDataOutput` delivers on its own
+/// serial queue. An earlier version was main-actor and reached back with
+/// `MainActor.assumeIsolated` to borrow its `CIContext` — which is an assertion, not a hop, and
+/// trapped on the first frame. `CIContext` is documented thread-safe, so the right answer is to
+/// render where the frame arrives and hop only to deliver the finished bitmap.
+final class CameraPreviewSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate,
+                                  @unchecked Sendable {
 
     private let session = AVCaptureSession()
-    private let context = CIContext(options: [.useSoftwareRenderer: false])
-    private let onFrame: (CGImage?) -> Void
+    private let renderer = PreviewFrameRenderer()
+    private let onFrame: @Sendable (CGImage) -> Void
 
-    init(device: AVCaptureDevice, onFrame: @escaping (CGImage?) -> Void) {
+    init(device: AVCaptureDevice, onFrame: @escaping @Sendable (CGImage) -> Void) {
         self.onFrame = onFrame
         super.init()
 
@@ -27,13 +33,15 @@ final class CameraPreviewSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
         }
         let output = AVCaptureVideoDataOutput()
         output.alwaysDiscardsLateVideoFrames = true
-        output.setSampleBufferDelegate(self, queue: DispatchQueue(label: "ai.psylief.sarvkrit.preview"))
+        output.setSampleBufferDelegate(
+            self, queue: DispatchQueue(label: "ai.psylief.sarvkrit.preview"))
         if session.canAddOutput(output) { session.addOutput(output) }
         session.commitConfiguration()
 
         // Off the main thread: starting a capture session blocks for a noticeable moment, and
         // doing it inline stalls the bar as it appears.
-        Task.detached { [session] in session.startRunning() }
+        let session = self.session
+        Task.detached { session.startRunning() }
     }
 
     func stop() {
@@ -41,15 +49,30 @@ final class CameraPreviewSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
         Task.detached { session.stopRunning() }
     }
 
-    nonisolated func captureOutput(_ output: AVCaptureOutput,
-                                   didOutput sampleBuffer: CMSampleBuffer,
-                                   from connection: AVCaptureConnection) {
-        guard let buffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
-        let image = CIImage(cvPixelBuffer: buffer)
-        // Rendered here, on the capture queue, so the main thread only ever receives a finished
-        // bitmap — the same reason the recorder does its writing off the main actor.
-        guard let rendered = MainActor.assumeIsolated({ context })
-            .createCGImage(image, from: image.extent) else { return }
-        Task { @MainActor in self.onFrame(rendered) }
+    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer,
+                       from connection: AVCaptureConnection) {
+        guard let image = renderer.image(from: sampleBuffer) else { return }
+        // The one hop, and a real one: a finished bitmap handed to the main actor to display.
+        let deliver = onFrame
+        Task { @MainActor in deliver(image) }
+    }
+}
+
+/// Turning a camera sample buffer into a bitmap, on whatever queue it arrived on.
+///
+/// Split out so the conversion can be exercised from a background queue in a test — which is the
+/// thing that was never covered, and the reason the crash reached the user rather than CI.
+/// `CIContext` is thread-safe; that is what makes this shape correct rather than merely convenient.
+final class PreviewFrameRenderer: @unchecked Sendable {
+    private let context = CIContext(options: [.useSoftwareRenderer: false])
+
+    func image(from sampleBuffer: CMSampleBuffer) -> CGImage? {
+        guard let buffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return nil }
+        return image(from: buffer)
+    }
+
+    func image(from pixelBuffer: CVPixelBuffer) -> CGImage? {
+        let image = CIImage(cvPixelBuffer: pixelBuffer)
+        return context.createCGImage(image, from: image.extent)
     }
 }

--- a/Sources/Sarvkrit/UI/Studio/CameraPreviewWindow.swift
+++ b/Sources/Sarvkrit/UI/Studio/CameraPreviewWindow.swift
@@ -1,0 +1,130 @@
+import AVFoundation
+import AppKit
+import SwiftUI
+
+/// The camera, on screen, while a recording is running.
+///
+/// **This is the thing that was missing.** The camera could be switched on and recorded, and the
+/// editor could composite it afterwards, but during the take there was nothing to see — so the
+/// only sign the camera was on at all was the green light in the menu bar, and "I cannot see my
+/// webcam circle while recording" is exactly what that looks like from the outside.
+///
+/// **It shows the recorder's own session rather than opening a second one.** Two `AVCaptureSession`s
+/// on one camera is how the pre-record bar's preview and the recorder ended up fighting over the
+/// device; an `AVCaptureVideoPreviewLayer` is a view of a session, not another claim on the camera.
+///
+/// Registered with `CaptureOverlayGuard`, because ⌃⇧⎋ is documented as always clearing the screen.
+@MainActor
+final class CameraPreviewWindowController {
+    static let shared = CameraPreviewWindowController()
+
+    private var panel: FloatingPanel?
+
+    var isShowing: Bool { panel != nil }
+
+    /// The side of the circle, in points. Large enough to see yourself in, small enough to leave
+    /// the screen you are demonstrating alone.
+    private static let side: CGFloat = 168
+    private static let margin: CGFloat = 24
+    private static let captionHeight: CGFloat = 26
+
+    func show(_ layer: AVCaptureVideoPreviewLayer, settings: CameraSettings = CameraSettings()) {
+        dismiss()
+
+        let side = Self.side
+        let size = NSSize(width: side, height: side + Self.captionHeight)
+        guard let visible = ScreenPlacement.screenUnderPointer()?.visibleFrame else { return }
+
+        // `unitPoint` runs 0…1 leading-to-trailing and top-to-bottom; AppKit's origin is at the
+        // bottom, so the vertical fraction is measured down from the top edge.
+        let point = settings.corner.unitPoint
+        let freeX = max(0, visible.width - size.width - Self.margin * 2)
+        let freeY = max(0, visible.height - size.height - Self.margin * 2)
+        let origin = CGPoint(
+            x: visible.minX + Self.margin + freeX * point.x,
+            y: visible.maxY - Self.margin - size.height - freeY * point.y)
+
+        // **Not key, and never activating.** Taking focus mid-recording would steal it from the
+        // app being demonstrated, which is the one thing a recording overlay must not do.
+        let panel = FloatingPanel(
+            contentRect: NSRect(origin: origin, size: size),
+            style: .init(level: .modalPanel, acceptsKey: false, clickThrough: false,
+                         joinsAllSpaces: true, hasShadow: false))
+        panel.contentView = NSHostingView(rootView: CameraPreviewWindowView(
+            layer: layer, settings: settings, side: side,
+            onHide: { [weak self] in self?.dismiss() }))
+        panel.orderFrontRegardless()
+        self.panel = panel
+    }
+
+    func dismiss() {
+        panel?.orderOut(nil)
+        panel = nil
+    }
+}
+
+private struct CameraPreviewWindowView: View {
+    let layer: AVCaptureVideoPreviewLayer
+    let settings: CameraSettings
+    let side: CGFloat
+    let onHide: () -> Void
+
+    var body: some View {
+        VStack(spacing: 4) {
+            CameraPreviewLayerView(layer: layer, mirrored: settings.mirrored)
+                .frame(width: side, height: side)
+                .clipShape(shape)
+                .overlay(shape.strokeBorder(Color.white.opacity(0.35), lineWidth: 2))
+                .shadow(color: .black.opacity(0.35), radius: 12, y: 4)
+
+            // **Said plainly, because the alternative is a confusing few minutes.** This window is
+            // excluded from the capture like every other window of ours, so it will not appear in
+            // the finished video — and without a label, the first question after a take is why
+            // there is a hole where the camera was.
+            Text("Preview · not in the video")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.top, 2)
+        .help("Right-click to hide. This preview is not part of the recording.")
+        .contextMenu {
+            Button("Hide Preview", action: onHide)
+        }
+    }
+
+    /// One shape for all three settings: a circle is a rounded rectangle whose radius is half its
+    /// side, and a rectangle one whose radius is zero.
+    private var shape: RoundedRectangle {
+        let radius: CGFloat
+        switch settings.shape {
+        case .circle: radius = side / 2
+        case .squircle: radius = side * CGFloat(settings.cornerRadiusFraction)
+        case .rectangle: radius = 0
+        }
+        return RoundedRectangle(cornerRadius: radius, style: .continuous)
+    }
+}
+
+/// Hosts the capture preview layer. The layer belongs to the recorder's session; this only draws it.
+private struct CameraPreviewLayerView: NSViewRepresentable {
+    let layer: AVCaptureVideoPreviewLayer
+    let mirrored: Bool
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        view.wantsLayer = true
+        layer.videoGravity = .resizeAspectFill
+        // Front cameras look wrong un-mirrored — you reach left and the reflection reaches right.
+        if let connection = layer.connection, connection.isVideoMirroringSupported {
+            connection.automaticallyAdjustsVideoMirroring = false
+            connection.isVideoMirrored = mirrored
+        }
+        view.layer = layer
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        layer.frame = nsView.bounds
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/CameraPreviewWindow.swift
+++ b/Sources/Sarvkrit/UI/Studio/CameraPreviewWindow.swift
@@ -26,13 +26,15 @@ final class CameraPreviewWindowController {
     /// the screen you are demonstrating alone.
     private static let side: CGFloat = 168
     private static let margin: CGFloat = 24
-    private static let captionHeight: CGFloat = 26
 
     func show(_ layer: AVCaptureVideoPreviewLayer, settings: CameraSettings = CameraSettings()) {
         dismiss()
 
         let side = Self.side
-        let size = NSSize(width: side, height: side + Self.captionHeight)
+        // Exactly the picture, nothing around it. It carried a white outline and a caption strip
+        // before, and against a busy screen the pair read as a box drawn over the work rather than
+        // as a camera. What the caption said now lives in the right-click menu.
+        let size = NSSize(width: side, height: side)
         guard let visible = ScreenPlacement.screenUnderPointer()?.visibleFrame else { return }
 
         // `unitPoint` runs 0…1 leading-to-trailing and top-to-bottom; AppKit's origin is at the
@@ -70,27 +72,19 @@ private struct CameraPreviewWindowView: View {
     let onHide: () -> Void
 
     var body: some View {
-        VStack(spacing: 4) {
-            CameraPreviewLayerView(layer: layer, mirrored: settings.mirrored)
-                .frame(width: side, height: side)
-                .clipShape(shape)
-                .overlay(shape.strokeBorder(Color.white.opacity(0.35), lineWidth: 2))
-                .shadow(color: .black.opacity(0.35), radius: 12, y: 4)
-
-            // **Said plainly, because the alternative is a confusing few minutes.** This window is
-            // excluded from the capture like every other window of ours, so it will not appear in
-            // the finished video — and without a label, the first question after a take is why
-            // there is a hole where the camera was.
-            Text("Preview · not in the video")
-                .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-        }
-        .padding(.top, 2)
-        .help("Right-click to hide. This preview is not part of the recording.")
-        .contextMenu {
-            Button("Hide Preview", action: onHide)
-        }
+        CameraPreviewLayerView(layer: layer, mirrored: settings.mirrored)
+            .frame(width: side, height: side)
+            .clipShape(shape)
+            .shadow(color: .black.opacity(0.35), radius: 12, y: 4)
+            .help("This preview is not part of the recording. Right-click to hide it.")
+            .contextMenu {
+                // **Where the caption went.** The point still has to be reachable — "why is there a
+                // hole where the camera was" is a confusing few minutes otherwise — but it does not
+                // have to sit on screen through the whole take.
+                Text("This preview is not in the recording")
+                Divider()
+                Button("Hide Preview", action: onHide)
+            }
     }
 
     /// One shape for all three settings: a circle is a rounded rectangle whose radius is half its

--- a/Sources/Sarvkrit/UI/Studio/ExportOptionsSheet.swift
+++ b/Sources/Sarvkrit/UI/Studio/ExportOptionsSheet.swift
@@ -1,0 +1,184 @@
+import AppKit
+import SwiftUI
+
+/// What the export will be, before the save panel asks where to put it.
+///
+/// **There was no such thing.** Export went straight to a save panel whose message read
+/// *"1080p H.264 — plays everywhere"* — a hardcoded string that was true only because one call
+/// site passed `preset: .web`. A 3024×1964 recording came out at 1662×1080 and nothing in the app
+/// offered any other answer.
+struct ExportOptionsSheet: View {
+
+    /// Everything the sheet needs to name real pixel sizes and a real file size.
+    struct Subject {
+        let canvas: CGSize
+        /// The recording's own pixels, which are smaller than the canvas whenever the project has
+        /// background padding.
+        let recording: CGSize
+        let seconds: TimeInterval
+        let recordingFPS: Int
+    }
+
+    let subject: Subject
+    let onCancel: () -> Void
+    let onExport: (ExportPreset) -> Void
+
+    /// Nil means Custom.
+    @State private var presetID: String? = ExportPreset.web.id
+    @State private var resolution: ExportResolution.Choice = .height(1080)
+    @State private var codec: ExportPreset.Codec = .h264
+    /// Nil follows the recording.
+    @State private var fps: Int?
+
+    private var resolutions: [ExportResolution] {
+        ExportResolution.offered(forCanvas: subject.canvas)
+    }
+
+    private var chosen: ExportPreset {
+        guard let presetID, let preset = ExportPreset.all.first(where: { $0.id == presetID }) else {
+            var custom = ExportPreset(id: "custom", name: "Custom", purpose: "",
+                                      codec: codec, height: nil, fps: fps)
+            if case .height(let height) = resolution {
+                custom.height = height
+                custom.allowsUpscale = resolutions
+                    .first { $0.resolution == resolution }?.upscales ?? false
+            }
+            return custom
+        }
+        return preset
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Space.lg) {
+            Text("Export")
+                .font(.system(size: Theme.Typography.title, weight: .semibold))
+
+            VStack(alignment: .leading, spacing: Theme.Space.sm) {
+                ForEach(ExportPreset.all) { preset in
+                    presetRow(preset)
+                }
+                Divider()
+                customRow
+            }
+
+            Divider()
+
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(summary)
+                        .font(.system(size: Theme.Typography.body))
+                    if let note = contentNote {
+                        // Said, because the number in the menu is not the number the picture gets.
+                        Text(note)
+                            .font(.system(size: Theme.Typography.caption))
+                            .foregroundStyle(.orange)
+                    }
+                }
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button("Export…") { onExport(chosen) }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(Theme.Space.xl)
+        .frame(width: 460)
+    }
+
+    private func presetRow(_ preset: ExportPreset) -> some View {
+        let size = preset.outputSize(forCanvas: subject.canvas)
+        return Button {
+            presetID = preset.id
+        } label: {
+            HStack(spacing: Theme.Space.md) {
+                Image(systemName: presetID == preset.id
+                      ? "largecircle.fill.circle" : "circle")
+                    .foregroundStyle(presetID == preset.id ? Color.accentColor : .secondary)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(preset.name).font(.system(size: Theme.Typography.body))
+                    Text(preset.purpose)
+                        .font(.system(size: Theme.Typography.caption))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text("\(Int(size.width)) × \(Int(size.height))")
+                    .font(.system(size: Theme.Typography.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var customRow: some View {
+        VStack(alignment: .leading, spacing: Theme.Space.sm) {
+            Button {
+                presetID = nil
+            } label: {
+                HStack(spacing: Theme.Space.md) {
+                    Image(systemName: presetID == nil ? "largecircle.fill.circle" : "circle")
+                        .foregroundStyle(presetID == nil ? Color.accentColor : .secondary)
+                    Text("Custom").font(.system(size: Theme.Typography.body))
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if presetID == nil {
+                Picker("Resolution", selection: $resolution) {
+                    ForEach(resolutions) { offered in
+                        // The upscale is marked rather than hidden: 4K is offered because it was
+                        // asked for, and because a 4K container is sometimes what a downstream
+                        // tool needs.
+                        Text(offered.upscales
+                             ? "\(offered.name) — \(offered.pixels)  ⚠︎ upscaled"
+                             : "\(offered.name) — \(offered.pixels)")
+                            .tag(offered.resolution)
+                    }
+                }
+                Picker("Format", selection: $codec) {
+                    ForEach([ExportPreset.Codec.h264, .hevc, .proRes422], id: \.self) {
+                        Text($0.title).tag($0)
+                    }
+                }
+                Picker("Frame rate", selection: $fps) {
+                    Text("Same as the recording (\(subject.recordingFPS) fps)")
+                        .tag(Int?.none)
+                    Text("60 fps").tag(Int?.some(60))
+                    Text("30 fps").tag(Int?.some(30))
+                }
+                if let caveat = codec.caveat {
+                    Label(caveat, systemImage: "exclamationmark.triangle")
+                        .font(.system(size: Theme.Typography.caption))
+                        .foregroundStyle(.orange)
+                }
+            }
+        }
+    }
+
+    private var summary: String {
+        let size = chosen.outputSize(forCanvas: subject.canvas)
+        let rate = chosen.frameRate(forRecording: subject.recordingFPS)
+        let bytes = chosen.estimatedBytes(forCanvas: subject.canvas, seconds: subject.seconds,
+                                          recordingFPS: subject.recordingFPS)
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useMB, .useGB]
+        formatter.countStyle = .file
+        return "\(Int(size.width)) × \(Int(size.height)) · \(chosen.codec.title) · \(rate) fps "
+            + "· about \(formatter.string(fromByteCount: Int64(bytes)))"
+    }
+
+    /// **Padding costs resolution off the picture**, and only the dialog can say so: the height
+    /// applies to the composited canvas, so a padded project puts the recording itself well below
+    /// the number that was chosen. Silent when there is nothing worth mentioning.
+    private var contentNote: String? {
+        let size = chosen.outputSize(forCanvas: subject.canvas)
+        guard subject.canvas.height > 0, subject.recording.height > 0 else { return nil }
+        let content = (subject.recording.height * (size.height / subject.canvas.height)).rounded()
+        guard content < size.height - 24 else { return nil }
+        return "The background padding takes some of that — your recording lands "
+            + "\(Int(content)) pixels tall."
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/ExportOptionsSheet.swift
+++ b/Sources/Sarvkrit/UI/Studio/ExportOptionsSheet.swift
@@ -126,7 +126,11 @@ struct ExportOptionsSheet: View {
             }
             .buttonStyle(.plain)
 
-            if presetID == nil {
+            // **Always in the layout, disabled until chosen.** The sheet is sized once, when it
+            // opens on a preset — so pickers that appeared only after clicking Custom would push
+            // the frame rate and the codec caveat off the bottom of a panel that does not resize.
+            // Showing them greyed also says what Custom offers before committing to it.
+            VStack(alignment: .leading, spacing: Theme.Space.sm) {
                 Picker("Resolution", selection: $resolution) {
                     ForEach(resolutions) { offered in
                         // The upscale is marked rather than hidden: 4K is offered because it was
@@ -149,12 +153,13 @@ struct ExportOptionsSheet: View {
                     Text("60 fps").tag(Int?.some(60))
                     Text("30 fps").tag(Int?.some(30))
                 }
-                if let caveat = codec.caveat {
-                    Label(caveat, systemImage: "exclamationmark.triangle")
-                        .font(.system(size: Theme.Typography.caption))
-                        .foregroundStyle(.orange)
-                }
+                Label(codec.caveat ?? "Plays everywhere.", systemImage: codec.caveat == nil
+                      ? "checkmark.circle" : "exclamationmark.triangle")
+                    .font(.system(size: Theme.Typography.caption))
+                    .foregroundStyle(codec.caveat == nil ? Color.secondary : Color.orange)
             }
+            .disabled(presetID != nil)
+            .padding(.leading, Theme.Space.xl)
         }
     }
 

--- a/Sources/Sarvkrit/UI/Studio/PreRecordBar.swift
+++ b/Sources/Sarvkrit/UI/Studio/PreRecordBar.swift
@@ -83,6 +83,8 @@ final class PreRecordModel: ObservableObject {
                          microphoneIDs: microphones.map(\.uniqueID))
         cameraDenied = AVCaptureDevice.authorizationStatus(for: .video) == .denied
         microphoneDenied = AVCaptureDevice.authorizationStatus(for: .audio) == .denied
+        // Re-read every time the bar appears, so granting the permission in System Settings and
+        // coming back shows the camera rather than the stale refusal.
     }
 
     func startPreview() {
@@ -182,7 +184,7 @@ private struct PreRecordBarView: View {
                 .frame(width: 140)
             }
             if model.cameraDenied {
-                deniedNote("Camera access is off in System Settings.")
+                deniedNote("Camera access is off.", requirement: .camera)
             }
         }
     }
@@ -201,7 +203,7 @@ private struct PreRecordBarView: View {
             .labelsHidden()
             .frame(width: 150)
             if model.microphoneDenied {
-                deniedNote("Microphone access is off in System Settings.")
+                deniedNote("Microphone access is off.", requirement: .microphone)
             }
         }
     }
@@ -241,11 +243,21 @@ private struct PreRecordBarView: View {
         }
     }
 
-    private func deniedNote(_ text: String) -> some View {
-        Text(text)
+    /// **A refusal with a way out of it.** Saying "check System Settings" and stopping there is
+    /// the failure the README names: a control that reports a problem it will not help you fix.
+    /// `Requirement` already knows which pane each grant lives in.
+    private func deniedNote(_ text: String, requirement: Requirement) -> some View {
+        HStack(spacing: 4) {
+            Text(text)
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.orange)
+            Button("Open Settings") {
+                NSWorkspace.shared.open(requirement.settingsURL)
+            }
+            .buttonStyle(.link)
             .font(.system(size: Theme.Typography.caption))
-            .foregroundStyle(.orange)
-            .frame(maxWidth: 160, alignment: .leading)
+        }
+        .frame(maxWidth: 190, alignment: .leading)
     }
 }
 

--- a/Sources/Sarvkrit/UI/Studio/PreRecordBar.swift
+++ b/Sources/Sarvkrit/UI/Studio/PreRecordBar.swift
@@ -1,0 +1,277 @@
+import AVFoundation
+import AppKit
+import SwiftUI
+
+/// The bar that appears before a recording starts.
+///
+/// **This is the feature's front door, and it was missing.** Without it ⌃⇧R could only ever record
+/// the whole display with no camera, no microphone and no countdown — every one of those choices
+/// existed in the model and none of them was reachable.
+///
+/// The live camera preview is the point of the whole surface. Discovering that the camera was off,
+/// or pointed at the ceiling, *after* a ten-minute take is the most expensive failure this feature
+/// has; seeing yourself before you press Record costs nothing and prevents all of it.
+///
+/// Registered with `CaptureOverlayGuard`, like every other floating thing: ⌃⇧⎋ is documented as
+/// always clearing the screen and this must not be the exception that makes that untrue.
+@MainActor
+final class PreRecordBarController {
+    static let shared = PreRecordBarController()
+
+    private var panel: FloatingPanel?
+    private let model = PreRecordModel()
+
+    var isShowing: Bool { panel != nil }
+
+    /// Called when the user presses Record, with everything they chose.
+    var onRecord: ((RecordingSetup) -> Void)?
+
+    func show(setup: RecordingSetup) {
+        dismiss()
+        model.setup = setup
+        model.refreshDevices()
+        model.startPreview()
+
+        let size = NSSize(width: 660, height: 128)
+        let frame = ScreenPlacement.screenUnderPointer()?.visibleFrame ?? .zero
+        let panel = FloatingPanel(
+            contentRect: NSRect(x: frame.midX - size.width / 2,
+                                y: frame.minY + 80,
+                                width: size.width, height: size.height),
+            // Key, so Escape works without clicking first.
+            style: .init(level: .modalPanel, acceptsKey: true, clickThrough: false,
+                         joinsAllSpaces: true, hasShadow: true))
+        panel.contentView = NSHostingView(rootView: PreRecordBarView(
+            model: model,
+            onRecord: { [weak self] in
+                guard let self, let setup = self.model.setup else { return }
+                self.dismiss()
+                self.onRecord?(setup)
+            },
+            onCancel: { [weak self] in self?.dismiss() }))
+        panel.orderFrontRegardless()
+        panel.makeKey()
+        self.panel = panel
+    }
+
+    func dismiss() {
+        model.stopPreview()
+        panel?.orderOut(nil)
+        panel = nil
+    }
+}
+
+/// The bar's live state: which devices exist, and what the camera currently sees.
+@MainActor
+final class PreRecordModel: ObservableObject {
+    @Published var cameras: [AVCaptureDevice] = []
+    @Published var microphones: [AVCaptureDevice] = []
+    /// The most recent camera frame, so the user can see themselves before committing.
+    @Published var previewFrame: CGImage?
+    @Published var micLevel: Float = 0
+    @Published var cameraDenied = false
+    @Published var microphoneDenied = false
+
+    var setup: RecordingSetup?
+
+    private var preview: CameraPreviewSession?
+
+    func refreshDevices() {
+        cameras = CameraRecorder.devices()
+        microphones = CameraRecorder.microphones()
+        setup?.reconcile(cameraIDs: cameras.map(\.uniqueID),
+                         microphoneIDs: microphones.map(\.uniqueID))
+        cameraDenied = AVCaptureDevice.authorizationStatus(for: .video) == .denied
+        microphoneDenied = AVCaptureDevice.authorizationStatus(for: .audio) == .denied
+    }
+
+    func startPreview() {
+        stopPreview()
+        guard let id = setup?.cameraID,
+              let device = cameras.first(where: { $0.uniqueID == id }) else { return }
+        preview = CameraPreviewSession(device: device) { [weak self] image in
+            self?.previewFrame = image
+        }
+    }
+
+    func stopPreview() {
+        preview?.stop()
+        preview = nil
+        previewFrame = nil
+    }
+
+    /// Asks for the grant, then starts the preview — so choosing a camera *shows* you the camera
+    /// rather than silently doing nothing until the next launch.
+    func chooseCamera(_ device: AVCaptureDevice?) {
+        setup?.cameraID = device?.uniqueID
+        guard device != nil else { return stopPreview() }
+        Task {
+            _ = await CameraRecorder.requestAccess(for: .video)
+            refreshDevices()
+            startPreview()
+        }
+    }
+
+    func chooseMicrophone(_ device: AVCaptureDevice?) {
+        setup?.microphoneID = device?.uniqueID
+        guard device != nil else { return }
+        Task {
+            _ = await CameraRecorder.requestAccess(for: .audio)
+            refreshDevices()
+        }
+    }
+}
+
+private struct PreRecordBarView: View {
+    @ObservedObject var model: PreRecordModel
+    let onRecord: () -> Void
+    let onCancel: () -> Void
+
+    private var setup: RecordingSetup? { model.setup }
+
+    var body: some View {
+        HStack(spacing: Theme.Space.lg) {
+            source
+            Divider().frame(height: 48)
+            camera
+            Divider().frame(height: 48)
+            microphone
+            Divider().frame(height: 48)
+            options
+            Spacer(minLength: 0)
+            record
+        }
+        .padding(.horizontal, Theme.Space.lg)
+        .frame(height: 128)
+        .background(.regularMaterial)
+        .onExitCommand(perform: onCancel)
+    }
+
+    private var source: some View {
+        VStack(alignment: .leading, spacing: Theme.Space.xs) {
+            SectionHeader("Record")
+            Picker("", selection: Binding(
+                get: { setup?.source ?? .display },
+                set: { setup?.source = $0 })) {
+                ForEach(RecordingSource.allCases) { source in
+                    Label(source.title, systemImage: source.symbolName).tag(source)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+            .frame(width: 210)
+        }
+    }
+
+    private var camera: some View {
+        VStack(alignment: .leading, spacing: Theme.Space.xs) {
+            SectionHeader("Camera")
+            HStack(spacing: Theme.Space.sm) {
+                // **The reason this bar exists.** Seeing yourself before pressing Record is what
+                // stops a ten-minute take of the ceiling.
+                CameraThumbnail(image: model.previewFrame, isOn: setup?.cameraID != nil)
+                Picker("", selection: Binding(
+                    get: { setup?.cameraID ?? "" },
+                    set: { id in
+                        model.chooseCamera(model.cameras.first { $0.uniqueID == id })
+                    })) {
+                    Text("Off").tag("")
+                    ForEach(model.cameras, id: \.uniqueID) { Text($0.localizedName).tag($0.uniqueID) }
+                }
+                .labelsHidden()
+                .frame(width: 140)
+            }
+            if model.cameraDenied {
+                deniedNote("Camera access is off in System Settings.")
+            }
+        }
+    }
+
+    private var microphone: some View {
+        VStack(alignment: .leading, spacing: Theme.Space.xs) {
+            SectionHeader("Microphone")
+            Picker("", selection: Binding(
+                get: { setup?.microphoneID ?? "" },
+                set: { id in
+                    model.chooseMicrophone(model.microphones.first { $0.uniqueID == id })
+                })) {
+                Text("Off").tag("")
+                ForEach(model.microphones, id: \.uniqueID) { Text($0.localizedName).tag($0.uniqueID) }
+            }
+            .labelsHidden()
+            .frame(width: 150)
+            if model.microphoneDenied {
+                deniedNote("Microphone access is off in System Settings.")
+            }
+        }
+    }
+
+    private var options: some View {
+        VStack(alignment: .leading, spacing: Theme.Space.xs) {
+            Toggle("System audio", isOn: Binding(
+                get: { setup?.capturesSystemAudio ?? false },
+                set: { setup?.capturesSystemAudio = $0 }))
+            .toggleStyle(.switch)
+            .controlSize(.small)
+
+            Picker("", selection: Binding(
+                get: { setup?.countdownSeconds ?? 0 },
+                set: { setup?.countdownSeconds = $0 })) {
+                ForEach(RecordingSetup.countdownChoices, id: \.self) { seconds in
+                    Text(seconds == 0 ? "No countdown" : "\(seconds)s").tag(seconds)
+                }
+            }
+            .labelsHidden()
+            .frame(width: 130)
+        }
+    }
+
+    private var record: some View {
+        VStack(spacing: Theme.Space.xs) {
+            Button(action: onRecord) {
+                Label("Record", systemImage: "record.circle")
+                    .frame(width: 84)
+            }
+            .keyboardShortcut(.defaultAction)
+            .controlSize(.large)
+
+            Text("⎋ to cancel")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func deniedNote(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: Theme.Typography.caption))
+            .foregroundStyle(.orange)
+            .frame(maxWidth: 160, alignment: .leading)
+    }
+}
+
+/// The little live square.
+private struct CameraThumbnail: View {
+    let image: CGImage?
+    let isOn: Bool
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(Color(nsColor: .quaternaryLabelColor).opacity(0.5))
+            .frame(width: 56, height: 56)
+            .overlay {
+                if let image {
+                    Image(decorative: image, scale: 1)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        // Mirrored, because a preview of yourself that is not is disorienting —
+                        // it is the reflection people rehearse in.
+                        .scaleEffect(x: -1, y: 1)
+                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                } else {
+                    Image(systemName: isOn ? "video.slash" : "video")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .accessibilityLabel(image == nil ? "No camera preview" : "Camera preview")
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/PreRecordBar.swift
+++ b/Sources/Sarvkrit/UI/Studio/PreRecordBar.swift
@@ -32,12 +32,10 @@ final class PreRecordBarController {
         model.refreshDevices()
         model.startPreview()
 
-        let size = NSSize(width: 660, height: 128)
         let frame = ScreenPlacement.screenUnderPointer()?.visibleFrame ?? .zero
         let panel = FloatingPanel(
-            contentRect: NSRect(x: frame.midX - size.width / 2,
-                                y: frame.minY + 80,
-                                width: size.width, height: size.height),
+            contentRect: NSRect(x: frame.midX - 330, y: frame.minY + 80,
+                                width: 660, height: 64),
             // Key, so Escape works without clicking first.
             style: .init(level: .modalPanel, acceptsKey: true, clickThrough: false,
                          joinsAllSpaces: true, hasShadow: true))
@@ -49,6 +47,14 @@ final class PreRecordBarController {
                 self.onRecord?(setup)
             },
             onCancel: { [weak self] in self?.dismiss() }))
+        // Sized to its contents rather than to a number picked in advance. The rounded corners
+        // would otherwise be clipped by a panel still the shape of the old slab, and the row's
+        // width now depends on how long the device names are.
+        if let fitting = panel.contentView?.fittingSize {
+            panel.setContentSize(fitting)
+            panel.setFrameOrigin(NSPoint(x: frame.midX - fitting.width / 2,
+                                         y: frame.minY + 80))
+        }
         panel.orderFrontRegardless()
         panel.makeKey()
         self.panel = panel
@@ -132,115 +138,142 @@ private struct PreRecordBarView: View {
     private var setup: RecordingSetup? { model.setup }
 
     var body: some View {
-        HStack(spacing: Theme.Space.lg) {
-            source
-            Divider().frame(height: 48)
-            camera
-            Divider().frame(height: 48)
-            microphone
-            Divider().frame(height: 48)
-            options
-            Spacer(minLength: 0)
-            record
-        }
-        .padding(.horizontal, Theme.Space.lg)
-        .frame(height: 128)
-        .background(.regularMaterial)
-        .onExitCommand(perform: onCancel)
-    }
-
-    private var source: some View {
-        VStack(alignment: .leading, spacing: Theme.Space.xs) {
-            SectionHeader("Record")
-            Picker("", selection: Binding(
-                get: { setup?.source ?? .display },
-                set: { setup?.source = $0 })) {
-                ForEach(RecordingSource.allCases) { source in
-                    Label(source.title, systemImage: source.symbolName).tag(source)
-                }
+        VStack(alignment: .leading, spacing: Theme.Space.sm) {
+            HStack(spacing: Theme.Space.md) {
+                source
+                Divider().frame(height: 22)
+                camera
+                microphone
+                options
+                Divider().frame(height: 22)
+                record
+                close
             }
-            .labelsHidden()
-            .pickerStyle(.segmented)
-            .frame(width: 210)
-        }
-    }
-
-    private var camera: some View {
-        VStack(alignment: .leading, spacing: Theme.Space.xs) {
-            SectionHeader("Camera")
-            HStack(spacing: Theme.Space.sm) {
-                // **The reason this bar exists.** Seeing yourself before pressing Record is what
-                // stops a ten-minute take of the ceiling.
-                CameraThumbnail(image: model.previewFrame, isOn: setup?.cameraID != nil)
-                Picker("", selection: Binding(
-                    get: { setup?.cameraID ?? "" },
-                    set: { id in
-                        model.chooseCamera(model.cameras.first { $0.uniqueID == id })
-                    })) {
-                    Text("Off").tag("")
-                    ForEach(model.cameras, id: \.uniqueID) { Text($0.localizedName).tag($0.uniqueID) }
-                }
-                .labelsHidden()
-                .frame(width: 140)
-            }
+            // A second line only when there is something wrong to say. The compact row is the
+            // normal case; a refused grant is not, and it gets said in words rather than reduced
+            // to an icon — a control that reports a problem it will not help you fix is the
+            // failure the README names.
             if model.cameraDenied {
                 deniedNote("Camera access is off.", requirement: .camera)
             }
-        }
-    }
-
-    private var microphone: some View {
-        VStack(alignment: .leading, spacing: Theme.Space.xs) {
-            SectionHeader("Microphone")
-            Picker("", selection: Binding(
-                get: { setup?.microphoneID ?? "" },
-                set: { id in
-                    model.chooseMicrophone(model.microphones.first { $0.uniqueID == id })
-                })) {
-                Text("Off").tag("")
-                ForEach(model.microphones, id: \.uniqueID) { Text($0.localizedName).tag($0.uniqueID) }
-            }
-            .labelsHidden()
-            .frame(width: 150)
             if model.microphoneDenied {
                 deniedNote("Microphone access is off.", requirement: .microphone)
             }
         }
+        .padding(.horizontal, Theme.Space.lg)
+        .padding(.vertical, Theme.Space.md)
+        // Shaped the way the app's own toast is shaped. This used to end in a bare
+        // `.background(.regularMaterial)` with no shape, which on a borderless
+        // clear-backgrounded panel fills a hard-edged rectangle.
+        .background(.regularMaterial,
+                    in: RoundedRectangle(cornerRadius: Theme.Radius.card + 6, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: Theme.Radius.card + 6, style: .continuous)
+            .strokeBorder(.separator.opacity(0.5), lineWidth: 0.5))
+        .onExitCommand(perform: onCancel)
     }
 
-    private var options: some View {
-        VStack(alignment: .leading, spacing: Theme.Space.xs) {
-            Toggle("System audio", isOn: Binding(
-                get: { setup?.capturesSystemAudio ?? false },
-                set: { setup?.capturesSystemAudio = $0 }))
-            .toggleStyle(.switch)
-            .controlSize(.small)
+    /// Icons rather than words, with the words in the tooltips: three segments carrying "Display",
+    /// "Window" and "Area" cost 210pt of a row that has to fit on a laptop screen.
+    private var source: some View {
+        Picker("", selection: Binding(
+            get: { setup?.source ?? .display },
+            set: { setup?.source = $0 })) {
+            ForEach(RecordingSource.allCases) { source in
+                Image(systemName: source.symbolName)
+                    .help(source.title)
+                    .accessibilityLabel(source.title)
+                    .tag(source)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .fixedSize()
+    }
 
+    private var camera: some View {
+        HStack(spacing: Theme.Space.sm) {
+            // **The reason this bar exists.** Seeing yourself before pressing Record is what
+            // stops a ten-minute take of the ceiling. Kept at full size while everything around
+            // it shrank, because it is the only thing here that cannot be read from a label.
+            CameraThumbnail(image: model.previewFrame, isOn: setup?.cameraID != nil)
             Picker("", selection: Binding(
-                get: { setup?.countdownSeconds ?? 0 },
-                set: { setup?.countdownSeconds = $0 })) {
-                ForEach(RecordingSetup.countdownChoices, id: \.self) { seconds in
-                    Text(seconds == 0 ? "No countdown" : "\(seconds)s").tag(seconds)
-                }
+                get: { setup?.cameraID ?? "" },
+                set: { id in
+                    model.chooseCamera(model.cameras.first { $0.uniqueID == id })
+                })) {
+                Label("No camera", systemImage: "video.slash").tag("")
+                ForEach(model.cameras, id: \.uniqueID) { Text($0.localizedName).tag($0.uniqueID) }
             }
             .labelsHidden()
             .frame(width: 130)
+            .help("Camera")
         }
     }
 
-    private var record: some View {
-        VStack(spacing: Theme.Space.xs) {
-            Button(action: onRecord) {
-                Label("Record", systemImage: "record.circle")
-                    .frame(width: 84)
-            }
-            .keyboardShortcut(.defaultAction)
-            .controlSize(.large)
-
-            Text("⎋ to cancel")
-                .font(.system(size: Theme.Typography.caption))
-                .foregroundStyle(.secondary)
+    private var microphone: some View {
+        Picker("", selection: Binding(
+            get: { setup?.microphoneID ?? "" },
+            set: { id in
+                model.chooseMicrophone(model.microphones.first { $0.uniqueID == id })
+            })) {
+            Label("No microphone", systemImage: "mic.slash").tag("")
+            ForEach(model.microphones, id: \.uniqueID) { Text($0.localizedName).tag($0.uniqueID) }
         }
+        .labelsHidden()
+        .frame(width: 130)
+        .help("Microphone")
+    }
+
+    /// The two settings that are set once and then left alone, behind a menu.
+    ///
+    /// **Not hidden — deferred.** Both are remembered between launches, so they are a decision
+    /// somebody makes on their first recording and never revisits, while the camera and the
+    /// microphone are checked before every single take. Ranking them equally in one row is what
+    /// made the bar feel like a form.
+    private var options: some View {
+        Menu {
+            Toggle("Record system audio", isOn: Binding(
+                get: { setup?.capturesSystemAudio ?? false },
+                set: { setup?.capturesSystemAudio = $0 }))
+
+            Picker("Countdown", selection: Binding(
+                get: { setup?.countdownSeconds ?? 0 },
+                set: { setup?.countdownSeconds = $0 })) {
+                ForEach(RecordingSetup.countdownChoices, id: \.self) { seconds in
+                    Text(seconds == 0 ? "None" : "\(seconds) seconds").tag(seconds)
+                }
+            }
+        } label: {
+            Image(systemName: "slider.horizontal.3")
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help("System audio and countdown")
+    }
+
+    private var record: some View {
+        Button(action: onRecord) {
+            Label("Record", systemImage: "record.circle")
+        }
+        .keyboardShortcut(.defaultAction)
+        .controlSize(.large)
+        .fixedSize()
+    }
+
+    /// **A way out you can see.**
+    ///
+    /// Escape already worked, twice over — `onExitCommand` here and `CaptureOverlayGuard`'s own
+    /// monitor. But the only thing that said so was one line of caption-sized secondary text on a
+    /// panel with no title bar and no window controls, and "I cannot close it until I record
+    /// something" is what that looks like from the outside. The hint stays, in the tooltip.
+    private var close: some View {
+        Button(action: onCancel) {
+            Image(systemName: "xmark")
+        }
+        .buttonStyle(.borderless)
+        .clickableCursor()
+        .help("Cancel (⎋)")
+        .accessibilityLabel("Cancel")
     }
 
     /// **A refusal with a way out of it.** Saying "check System Settings" and stopping there is
@@ -257,7 +290,7 @@ private struct PreRecordBarView: View {
             .buttonStyle(.link)
             .font(.system(size: Theme.Typography.caption))
         }
-        .frame(maxWidth: 190, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -267,9 +300,9 @@ private struct CameraThumbnail: View {
     let isOn: Bool
 
     var body: some View {
-        RoundedRectangle(cornerRadius: 8, style: .continuous)
+        RoundedRectangle(cornerRadius: Theme.Radius.control, style: .continuous)
             .fill(Color(nsColor: .quaternaryLabelColor).opacity(0.5))
-            .frame(width: 56, height: 56)
+            .frame(width: 34, height: 34)
             .overlay {
                 if let image {
                     Image(decorative: image, scale: 1)
@@ -278,7 +311,7 @@ private struct CameraThumbnail: View {
                         // Mirrored, because a preview of yourself that is not is disorienting —
                         // it is the reflection people rehearse in.
                         .scaleEffect(x: -1, y: 1)
-                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.control, style: .continuous))
                 } else {
                     Image(systemName: isOn ? "video.slash" : "video")
                         .foregroundStyle(.secondary)

--- a/Sources/Sarvkrit/UI/Studio/PreRecordBar.swift
+++ b/Sources/Sarvkrit/UI/Studio/PreRecordBar.swift
@@ -201,11 +201,13 @@ private struct PreRecordBarView: View {
                 set: { id in
                     model.chooseCamera(model.cameras.first { $0.uniqueID == id })
                 })) {
-                Label("No camera", systemImage: "video.slash").tag("")
+                Label("Off", systemImage: "video.slash").tag("")
                 ForEach(model.cameras, id: \.uniqueID) { Text($0.localizedName).tag($0.uniqueID) }
             }
             .labelsHidden()
-            .frame(width: 130)
+            // Wide enough for a real device name. "FaceTime HD Camera" truncated at
+            // 130, which reads as a bug rather than as a long name.
+            .frame(width: 168)
             .help("Camera")
         }
     }
@@ -216,11 +218,11 @@ private struct PreRecordBarView: View {
             set: { id in
                 model.chooseMicrophone(model.microphones.first { $0.uniqueID == id })
             })) {
-            Label("No microphone", systemImage: "mic.slash").tag("")
+            Label("Off", systemImage: "mic.slash").tag("")
             ForEach(model.microphones, id: \.uniqueID) { Text($0.localizedName).tag($0.uniqueID) }
         }
         .labelsHidden()
-        .frame(width: 130)
+        .frame(width: 168)
         .help("Microphone")
     }
 

--- a/Sources/Sarvkrit/UI/Studio/PreRecordBar.swift
+++ b/Sources/Sarvkrit/UI/Studio/PreRecordBar.swift
@@ -92,7 +92,7 @@ final class PreRecordModel: ObservableObject {
         guard let id = setup?.cameraID,
               let device = cameras.first(where: { $0.uniqueID == id }) else { return }
         preview = CameraPreviewSession(device: device) { [weak self] image in
-            self?.previewFrame = image
+            Task { @MainActor in self?.previewFrame = image }
         }
     }
 

--- a/Sources/Sarvkrit/UI/Studio/RecordingHUD.swift
+++ b/Sources/Sarvkrit/UI/Studio/RecordingHUD.swift
@@ -1,0 +1,134 @@
+import AppKit
+import SwiftUI
+
+/// The small panel that floats while a recording is running.
+///
+/// Modelled on `ScrollCaptureSession`'s HUD, and like it, **registered with
+/// `CaptureOverlayGuard`** — ⌃⇧⎋ is documented as always clearing the screen, and this feature
+/// must not be the exception that makes that promise false.
+@MainActor
+final class RecordingHUDController {
+    static let shared = RecordingHUDController()
+
+    private var panel: FloatingPanel?
+    private var timer: Timer?
+    private let model = RecordingHUDModel()
+
+    var isShowing: Bool { panel != nil }
+
+    var onStop: (() -> Void)?
+    var onPauseResume: (() -> Void)?
+    var onDiscard: (() -> Void)?
+
+    func show(elapsed: @escaping () -> TimeInterval, dropped: @escaping () -> Int) {
+        dismiss()
+        model.elapsed = 0
+        model.dropped = 0
+
+        let size = NSSize(width: 300, height: 56)
+        let frame = ScreenPlacement.screenUnderPointer()?.visibleFrame ?? .zero
+        let panel = FloatingPanel(
+            contentRect: NSRect(x: frame.midX - size.width / 2,
+                                y: frame.minY + 40,
+                                width: size.width, height: size.height),
+            style: .init(level: .modalPanel, acceptsKey: true, clickThrough: false,
+                         joinsAllSpaces: true, hasShadow: true))
+        panel.contentView = NSHostingView(rootView: RecordingHUDView(
+            model: model,
+            onStop: { [weak self] in self?.onStop?() },
+            onPauseResume: { [weak self] in
+                self?.model.isPaused.toggle()
+                self?.onPauseResume?()
+            },
+            onDiscard: { [weak self] in self?.onDiscard?() }))
+        panel.orderFrontRegardless()
+        self.panel = panel
+
+        // Built once and updated through the model, not rebuilt per tick: rebuilding the hosting
+        // view every second destroys any mouse-down in progress on its own buttons.
+        timer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { _ in
+            MainActor.assumeIsolated {
+                self.model.elapsed = elapsed()
+                self.model.dropped = dropped()
+            }
+        }
+        if let timer { RunLoop.main.add(timer, forMode: .common) }
+    }
+
+    func dismiss() {
+        timer?.invalidate()
+        timer = nil
+        panel?.orderOut(nil)
+        panel = nil
+    }
+}
+
+@MainActor
+final class RecordingHUDModel: ObservableObject {
+    @Published var elapsed: TimeInterval = 0
+    @Published var dropped = 0
+    @Published var isPaused = false
+}
+
+private struct RecordingHUDView: View {
+    @ObservedObject var model: RecordingHUDModel
+    let onStop: () -> Void
+    let onPauseResume: () -> Void
+    let onDiscard: () -> Void
+
+    var body: some View {
+        HStack(spacing: Theme.Space.md) {
+            Circle()
+                .fill(model.isPaused ? Color.secondary : Color.red)
+                .frame(width: 10, height: 10)
+
+            // Recorded time, not wall-clock: a paused recording must not look like it is running.
+            Text(Self.clock(model.elapsed))
+                .font(.system(size: Theme.Typography.metric, weight: .medium,
+                              design: .monospaced))
+                .monospacedDigit()
+
+            if model.dropped > 0 {
+                // Shown only when non-zero. Producing a stuttering file in silence is the failure
+                // this exists to prevent.
+                Text("\(model.dropped) dropped")
+                    .font(.system(size: Theme.Typography.caption))
+                    .foregroundStyle(.orange)
+            }
+
+            Spacer()
+
+            Button(action: onPauseResume) {
+                Image(systemName: model.isPaused ? "play.fill" : "pause.fill")
+            }
+            .buttonStyle(.plain)
+            .clickableCursor()
+            .help(model.isPaused ? "Resume" : "Pause")
+            .accessibilityLabel(model.isPaused ? "Resume recording" : "Pause recording")
+
+            Button(action: onStop) {
+                Image(systemName: "stop.fill").foregroundStyle(.red)
+            }
+            .buttonStyle(.plain)
+            .clickableCursor()
+            .help("Stop")
+            .accessibilityLabel("Stop recording")
+
+            Button(action: onDiscard) {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.plain)
+            .clickableCursor()
+            .help("Discard this take")
+            .accessibilityLabel("Discard this recording")
+        }
+        .padding(.horizontal, Theme.Space.lg)
+        .frame(height: 56)
+        .background(.regularMaterial)
+    }
+
+    static func clock(_ seconds: TimeInterval) -> String {
+        let total = max(0, Int(seconds))
+        return String(format: "%02d:%02d", total / 60, total % 60)
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/RecordingHUD.swift
+++ b/Sources/Sarvkrit/UI/Studio/RecordingHUD.swift
@@ -25,12 +25,13 @@ final class RecordingHUDController {
         model.elapsed = 0
         model.dropped = 0
 
-        let size = NSSize(width: 300, height: 56)
+        model.sinceWake = 0
+        model.isHovered = false
+
         let frame = ScreenPlacement.screenUnderPointer()?.visibleFrame ?? .zero
         let panel = FloatingPanel(
-            contentRect: NSRect(x: frame.midX - size.width / 2,
-                                y: frame.minY + 40,
-                                width: size.width, height: size.height),
+            contentRect: NSRect(x: frame.midX - 150, y: frame.minY + 40,
+                                width: 300, height: 44),
             style: .init(level: .modalPanel, acceptsKey: true, clickThrough: false,
                          joinsAllSpaces: true, hasShadow: true))
         panel.contentView = NSHostingView(rootView: RecordingHUDView(
@@ -41,6 +42,18 @@ final class RecordingHUDController {
                 self?.onPauseResume?()
             },
             onDiscard: { [weak self] in self?.onDiscard?() }))
+        // Sized to its contents rather than to a number picked in advance, and re-centred after,
+        // so the pill is as wide as what is in it and no wider.
+        if let fitting = panel.contentView?.fittingSize {
+            panel.setContentSize(fitting)
+            panel.setFrameOrigin(NSPoint(x: frame.midX - fitting.width / 2,
+                                         y: frame.minY + 40))
+        }
+        // **Without this the pill never wakes.** `mouseMoved` is not delivered unless the window
+        // asks for it, and SwiftUI's `.onHover` is built on it — the same default that once left
+        // the capture overlay with no crosshair. The panel stays non-activating, so hovering it
+        // cannot take focus from the app being recorded.
+        panel.acceptsMouseMovedEvents = true
         panel.orderFrontRegardless()
         self.panel = panel
 
@@ -50,6 +63,7 @@ final class RecordingHUDController {
             MainActor.assumeIsolated {
                 self.model.elapsed = elapsed()
                 self.model.dropped = dropped()
+                if !self.model.isHovered { self.model.sinceWake += 0.25 }
             }
         }
         if let timer { RunLoop.main.add(timer, forMode: .common) }
@@ -68,6 +82,34 @@ final class RecordingHUDModel: ObservableObject {
     @Published var elapsed: TimeInterval = 0
     @Published var dropped = 0
     @Published var isPaused = false
+    /// Seconds since the pill last had a reason to be at full strength.
+    @Published var sinceWake: TimeInterval = 0
+    @Published var isHovered = false
+
+    var opacity: Double {
+        HUDDimming.opacity(sinceWake: sinceWake, isHovered: isHovered,
+                           isPaused: isPaused, isWarning: dropped > 0)
+    }
+}
+
+/// When the recording pill gets out of the way.
+///
+/// **It sits over the thing being demonstrated**, so at full strength it is in every frame of the
+/// finished video. It fades back once the recording is under way and comes straight back when the
+/// pointer arrives — stopping must never involve a hunt, which is why it never disappears.
+enum HUDDimming {
+    /// Visible enough to find at a glance, faint enough not to compete with the demo.
+    static let restingOpacity = 0.35
+    /// Long enough to read the timer and see that recording actually started.
+    static let wakeSeconds: TimeInterval = 4
+
+    static func opacity(sinceWake: TimeInterval, isHovered: Bool = false,
+                        isPaused: Bool = false, isWarning: Bool = false) -> Double {
+        // A paused recording is where somebody has stepped away and needs to find their way back,
+        // and a warning that fades out is not a warning.
+        if isHovered || isPaused || isWarning { return 1 }
+        return sinceWake < wakeSeconds ? 1 : restingOpacity
+    }
 }
 
 private struct RecordingHUDView: View {
@@ -80,7 +122,7 @@ private struct RecordingHUDView: View {
         HStack(spacing: Theme.Space.md) {
             Circle()
                 .fill(model.isPaused ? Color.secondary : Color.red)
-                .frame(width: 10, height: 10)
+                .frame(width: 8, height: 8)
 
             // Recorded time, not wall-clock: a paused recording must not look like it is running.
             Text(Self.clock(model.elapsed))
@@ -95,8 +137,6 @@ private struct RecordingHUDView: View {
                     .font(.system(size: Theme.Typography.caption))
                     .foregroundStyle(.orange)
             }
-
-            Spacer()
 
             Button(action: onPauseResume) {
                 Image(systemName: model.isPaused ? "play.fill" : "pause.fill")
@@ -123,8 +163,19 @@ private struct RecordingHUDView: View {
             .accessibilityLabel("Discard this recording")
         }
         .padding(.horizontal, Theme.Space.lg)
-        .frame(height: 56)
-        .background(.regularMaterial)
+        .padding(.vertical, Theme.Space.sm)
+        // Shaped the way the app's own toast is shaped. Both panels used to end in a bare
+        // `.background(.regularMaterial)` with no shape at all, which on a borderless
+        // clear-backgrounded panel fills a hard-edged rectangle — the "not really beautiful"
+        // report, in one missing argument.
+        .background(.regularMaterial, in: Capsule())
+        .overlay(Capsule().strokeBorder(.separator.opacity(0.5), lineWidth: 0.5))
+        .opacity(model.opacity)
+        .animation(.easeInOut(duration: 0.45), value: model.opacity)
+        .onHover { hovering in
+            model.isHovered = hovering
+            if hovering { model.sinceWake = 0 }
+        }
     }
 
     static func clock(_ seconds: TimeInterval) -> String {

--- a/Sources/Sarvkrit/UI/Studio/RecordingsList.swift
+++ b/Sources/Sarvkrit/UI/Studio/RecordingsList.swift
@@ -1,0 +1,136 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// The recordings already on disk, and the way back into one.
+///
+/// **The gap this closes.** A recording autosaves its project on every edit and again as its
+/// window closes, so closing an editor loses nothing — but until now there was no way to open one
+/// again. This is that way, along with the Finder, which can do it too now that a `.sarvrec` is
+/// declared as a package.
+struct RecordingsList: View {
+    @State private var entries: [RecordingLibrary.Entry] = []
+    /// Which row is waiting for its second click on Delete. Deleting a take is not undoable.
+    @State private var confirmingDelete: URL?
+
+    var body: some View {
+        Section {
+            if entries.isEmpty {
+                Text("Recordings you make appear here. They stay editable — reopen one to change "
+                     + "the zooms, add text, or export it again at another size.")
+                    .font(.system(size: Theme.Typography.caption))
+                    .foregroundStyle(.secondary)
+            }
+
+            ForEach(entries) { entry in
+                row(entry)
+            }
+
+            HStack(spacing: Theme.Space.md) {
+                Button("Open Recording…") { openPanel() }
+                Button("Show in Finder") {
+                    NSWorkspace.shared.selectFile(
+                        nil, inFileViewerRootedAtPath: RecordingBundle.defaultDirectory().path)
+                }
+                Spacer()
+                Button("Refresh") { reload() }
+            }
+        } header: {
+            Text("Your recordings")
+        }
+        .onAppear(perform: reload)
+    }
+
+    private func row(_ entry: RecordingLibrary.Entry) -> some View {
+        HStack(spacing: Theme.Space.md) {
+            Image(systemName: entry.needsRecovery
+                  ? "exclamationmark.triangle" : "film")
+                .foregroundStyle(entry.needsRecovery ? .orange : .secondary)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(entry.name)
+                    .font(.system(size: Theme.Typography.body))
+                HStack(spacing: Theme.Space.sm) {
+                    Text(entry.lengthDescription)
+                    if entry.hasCamera {
+                        Label("Camera", systemImage: "person.crop.circle")
+                            .labelStyle(.iconOnly)
+                    }
+                    if entry.needsRecovery {
+                        // The flag was written faithfully all along and read by nothing, so a take
+                        // the app died inside was indistinguishable from no take at all.
+                        Text("Interrupted — may be incomplete")
+                    } else if !entry.canOpen {
+                        Text("Unreadable")
+                    }
+                }
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if entry.canOpen {
+                Button("Open") { StudioEditorController.shared.open(fileAt: entry.url) }
+            }
+            Button {
+                NSWorkspace.shared.activateFileViewerSelecting([entry.url])
+            } label: {
+                Image(systemName: "folder")
+            }
+            .buttonStyle(.borderless)
+            .help("Show in Finder")
+
+            // Two clicks, because a take took ten minutes to make and there is no undo here.
+            Button {
+                if confirmingDelete == entry.url {
+                    delete(entry)
+                } else {
+                    confirmingDelete = entry.url
+                }
+            } label: {
+                if confirmingDelete == entry.url {
+                    Text("Really?").font(.system(size: Theme.Typography.caption))
+                } else {
+                    Image(systemName: "trash")
+                }
+            }
+            .buttonStyle(.borderless)
+            .help("Move this recording to the Trash")
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func reload() {
+        entries = RecordingLibrary.entries()
+        confirmingDelete = nil
+    }
+
+    /// To the Trash rather than erased, whatever the button says — a mistake here would otherwise
+    /// cost somebody a take that took ten minutes to make.
+    private func delete(_ entry: RecordingLibrary.Entry) {
+        do {
+            try FileManager.default.trashItem(at: entry.url, resultingItemURL: nil)
+        } catch {
+            ToastPresenter.shared.show("Couldn't delete that recording",
+                                       symbolName: "exclamationmark.triangle")
+        }
+        reload()
+    }
+
+    private func openPanel() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = true
+        // A `.sarvrec` is a package, so the panel treats it as a file the moment the type is
+        // declared — but `canChooseDirectories` keeps it selectable on a Mac whose Launch
+        // Services database has not caught up with a freshly installed build.
+        if let type = UTType(filenameExtension: RecordingBundle.fileExtension) {
+            panel.allowedContentTypes = [type]
+        }
+        panel.directoryURL = RecordingBundle.defaultDirectory()
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        StudioEditorController.shared.open(fileAt: url)
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/ScreenRecordingDetailView.swift
+++ b/Sources/Sarvkrit/UI/Studio/ScreenRecordingDetailView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+/// The Screen Recording pane in the window.
+struct ScreenRecordingDetailView: View {
+    @EnvironmentObject private var app: AppState
+    @ObservedObject var feature: ScreenRecordingFeature
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Enable", isOn: app.binding(for: feature))
+            } header: {
+                header
+            }
+
+            if let requirement = app.blockingRequirement(for: feature) {
+                Section {
+                    PermissionBanner(requirement: requirement) {
+                        app.permissions.request(requirement)
+                    }
+                }
+            }
+
+            Section("Recording") {
+                Picker("Frame rate", selection: Binding(
+                    get: { feature.framesPerSecond },
+                    set: { feature.framesPerSecond = $0 })) {
+                    Text("60 fps").tag(60)
+                    Text("30 fps").tag(30)
+                }
+                Toggle("Record system audio", isOn: Binding(
+                    get: { feature.capturesSystemAudio },
+                    set: { feature.capturesSystemAudio = $0 }))
+                Toggle("Hide desktop icons", isOn: Binding(
+                    get: { feature.hidesDesktopIcons },
+                    set: { feature.hidesDesktopIcons = $0 }))
+            }
+
+            Section {
+                Toggle("Show keystrokes", isOn: Binding(
+                    get: { feature.showsKeystrokes },
+                    set: { feature.showsKeystrokes = $0 }))
+            } header: {
+                Text("Keystrokes")
+            } footer: {
+                // Said plainly rather than buried: this is the one sub-toggle that starts watching
+                // the keyboard, and it should be a decision rather than a discovery.
+                Text("Off until you ask for it. Needs Accessibility, records the keys you press "
+                     + "as labels rather than as text, and never records anything typed into a "
+                     + "password field.")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+            }
+
+            Section("Shortcuts") {
+                ForEach(RecordingAction.allCases) { action in
+                    LabeledContent(action.title) {
+                        Text(action.defaultShortcut.displayString)
+                            .font(.system(size: Theme.Typography.body, design: .rounded))
+                            .foregroundStyle(feature.failedRegistrations.contains(action)
+                                             ? Color.orange : .secondary)
+                    }
+                }
+                if !feature.failedRegistrations.isEmpty {
+                    Text("Something else on this Mac already owns the ones in orange.")
+                        .font(.system(size: Theme.Typography.caption))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("How it works") {
+                Text(feature.details)
+                    .font(.system(size: Theme.Typography.body))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle(feature.title)
+    }
+
+    private var header: some View {
+        HStack(spacing: Theme.Space.md) {
+            FeatureIconTile(symbolName: feature.symbolName, isOn: app.isEnabled(feature))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(feature.title).font(.system(size: Theme.Typography.title, weight: .semibold))
+                Text(feature.summary)
+                    .font(.system(size: Theme.Typography.caption))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.bottom, Theme.Space.sm)
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/ScreenRecordingDetailView.swift
+++ b/Sources/Sarvkrit/UI/Studio/ScreenRecordingDetailView.swift
@@ -52,6 +52,8 @@ struct ScreenRecordingDetailView: View {
                 .foregroundStyle(.secondary)
             }
 
+            RecordingsList()
+
             Section("Shortcuts") {
                 ForEach(RecordingAction.allCases) { action in
                     LabeledContent(action.title) {

--- a/Sources/Sarvkrit/UI/Studio/ScreenRecordingDetailView.swift
+++ b/Sources/Sarvkrit/UI/Studio/ScreenRecordingDetailView.swift
@@ -21,6 +21,10 @@ struct ScreenRecordingDetailView: View {
                 }
             }
 
+            // Above the settings, not below them. Getting back into a recording is what somebody
+            // opens this pane to do; frame rate is set once and forgotten.
+            RecordingsList()
+
             Section("Recording") {
                 Picker("Frame rate", selection: Binding(
                     get: { feature.framesPerSecond },
@@ -51,8 +55,6 @@ struct ScreenRecordingDetailView: View {
                 .font(.system(size: Theme.Typography.caption))
                 .foregroundStyle(.secondary)
             }
-
-            RecordingsList()
 
             Section("Shortcuts") {
                 ForEach(RecordingAction.allCases) { action in

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
@@ -103,7 +103,7 @@ struct StudioEditorView: View {
     private func isAvailable(_ tab: StudioDocumentModel.Inspector) -> Bool {
         switch tab {
         case .canvas, .cursor, .masks: return true
-        case .camera, .audio: return true
+        case .camera, .audio, .text: return true
         // Enabled whenever there is audio to work from — the tab is where you *make* captions,
         // so gating it on already having them would hide the only way to get any.
         case .captions:
@@ -124,6 +124,7 @@ struct StudioEditorView: View {
                 case .cursor: CursorInspector(model: model)
                 case .masks: MaskInspector(model: model)
                 case .camera: CameraInspector(model: model)
+                case .text: TextInspector(model: model)
                 case .captions: CaptionsInspector(model: model)
                 case .keystrokes: KeystrokesInspector(model: model)
                 case .audio: AudioInspector(model: model)
@@ -172,6 +173,7 @@ struct StudioEditorView: View {
 
             Menu {
                 Button("Zoom") { model.addZoomAtPlayhead() }
+                Button("Text") { model.addTextAtPlayhead() }
                 Button("Click") { model.addClickAtPlayhead() }
                 Button("Pointer Highlight") { model.addPointerHighlightAtPlayhead() }
                 Button("Blur or Highlight") { model.addMaskAtPlayhead() }

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
@@ -93,11 +93,15 @@ struct StudioEditorView: View {
 
     private func isAvailable(_ tab: StudioDocumentModel.Inspector) -> Bool {
         switch tab {
-        case .canvas, .cursor: return true
+        case .canvas, .cursor, .masks: return true
         case .camera: return FileManager.default.fileExists(atPath: model.bundle.cameraURL.path)
         case .audio: return FileManager.default.fileExists(atPath: model.bundle.microphoneURL.path)
             || FileManager.default.fileExists(atPath: model.bundle.systemAudioURL.path)
-        case .captions: return !model.project.captions.isEmpty
+        // Enabled whenever there is audio to work from — the tab is where you *make* captions,
+        // so gating it on already having them would hide the only way to get any.
+        case .captions:
+            return FileManager.default.fileExists(atPath: model.bundle.microphoneURL.path)
+                || !model.project.captions.isEmpty
         case .keystrokes: return !model.events.keys.isEmpty
         }
     }
@@ -107,10 +111,16 @@ struct StudioEditorView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: Theme.Space.lg) {
                 switch model.inspector {
-                case .canvas: CanvasInspector(model: model)
+                case .canvas:
+                    CanvasInspector(model: model)
+                    DeviceFrameInspector(model: model)
                 case .cursor: CursorInspector(model: model)
-                default:
-                    SectionHeader(model.inspector.title)
+                case .masks: MaskInspector(model: model)
+                case .camera: CameraInspector(model: model)
+                case .captions: CaptionsInspector(model: model)
+                case .keystrokes: KeystrokesInspector(model: model)
+                case .audio:
+                    SectionHeader("Audio")
                     Text("Nothing was recorded for this.")
                         .font(.system(size: Theme.Typography.body))
                         .foregroundStyle(.secondary)

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
@@ -30,6 +30,9 @@ struct StudioEditorView: View {
                 .frame(height: StudioTimelineView.preferredHeight)
         }
         .background(Color(nsColor: .windowBackgroundColor))
+        .sheet(isPresented: $model.isShowingShortcuts) {
+            StudioShortcutsSheet { model.isShowingShortcuts = false }
+        }
     }
 
     // MARK: - Chrome
@@ -158,14 +161,31 @@ struct StudioEditorView: View {
 
             Spacer()
 
-            Button { model.split() } label: { Image(systemName: "scissors") }
-                .buttonStyle(.plain).clickableCursor().help("Split at the playhead (⌘B)")
-                .accessibilityLabel("Split at the playhead")
-            Button { model.addZoomAtPlayhead() } label: {
-                Image(systemName: "plus.magnifyingglass")
+            // **Named, not guessed at.** These were two unlabelled glyphs side by side, and the
+            // right-hand one was the only way to add a zoom short of knowing about the `Z` key.
+            // "There is no way to add a zoom manually" was the result, which is a fair reading of
+            // an editor that never said otherwise.
+            Button { model.split() } label: {
+                Label("Split", systemImage: "scissors").labelStyle(.titleAndIcon)
             }
-            .buttonStyle(.plain).clickableCursor().help("Add a zoom here (Z)")
-            .accessibilityLabel("Add a zoom at the playhead")
+            .buttonStyle(.plain).clickableCursor().help("Split the clip at the playhead (⌘B)")
+
+            Menu {
+                Button("Zoom") { model.addZoomAtPlayhead() }
+                Button("Click") { model.addClickAtPlayhead() }
+                Button("Pointer Highlight") { model.addPointerHighlightAtPlayhead() }
+                Button("Blur or Highlight") { model.addMaskAtPlayhead() }
+                Divider()
+                Button("Camera Full Frame") { model.addCameraSegment(.fullFrame) }
+                Button("Hide Camera") { model.addCameraSegment(.hidden) }
+                Divider()
+                Button("Keyboard Shortcuts…") { model.isShowingShortcuts = true }
+            } label: {
+                Label("Add Here", systemImage: "plus.circle")
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .help("Add something at the playhead — the same list as right-clicking the timeline")
 
             Text(Self.clock(player.playhead) + " / " + Self.clock(model.duration))
                 .font(.system(size: Theme.Typography.caption, design: .monospaced))

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
@@ -14,6 +14,10 @@ struct StudioEditorView: View {
         VStack(spacing: 0) {
             titleBar
             Divider()
+            if let seconds = model.leadInNotice {
+                leadInBanner(seconds)
+                Divider()
+            }
             HStack(spacing: 0) {
                 PreviewHost(model: model, onScrub: onScrub)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -38,6 +42,32 @@ struct StudioEditorView: View {
     }
 
     // MARK: - Chrome
+
+    /// Says what was hidden at the head of the take, and undoes it in one click.
+    ///
+    /// **A trim nobody is told about is a silent decision**, which is the complaint this whole
+    /// round is about. A toast would have said it once and vanished; this stays until it is either
+    /// acted on or waved away.
+    private func leadInBanner(_ seconds: TimeInterval) -> some View {
+        HStack(spacing: Theme.Space.md) {
+            Image(systemName: "scissors")
+                .foregroundStyle(.secondary)
+            Text("Trimmed \(seconds, format: .number.precision(.fractionLength(1)))s of start-up, before the camera and microphone were running.")
+                .font(.system(size: Theme.Typography.body))
+            Spacer(minLength: Theme.Space.sm)
+            Button("Put It Back") { model.putBackLeadIn() }
+            Button {
+                model.dismissLeadInNotice()
+            } label: {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.borderless)
+            .help("Keep the trim and hide this")
+        }
+        .padding(.horizontal, Theme.Space.lg)
+        .padding(.vertical, Theme.Space.sm)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
 
     private var titleBar: some View {
         HStack(spacing: Theme.Space.md) {

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
@@ -26,8 +26,10 @@ struct StudioEditorView: View {
             Divider()
             transport
             Divider()
+            // Tall enough for however many rows the project has: a row appears when you add the
+            // first of something, which is how you learn the track is there.
             TimelineHost(model: model, onScrub: onScrub)
-                .frame(height: StudioTimelineView.preferredHeight)
+                .frame(height: TimelineLayout.preferredHeight(rowCount: model.timelineRowCount))
         }
         .background(Color(nsColor: .windowBackgroundColor))
         .sheet(isPresented: $model.isShowingShortcuts) {

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
@@ -4,7 +4,9 @@ import SwiftUI
 /// The editor window's contents: preview, rail, inspector, transport, timeline.
 struct StudioEditorView: View {
     @ObservedObject var model: StudioDocumentModel
+    @ObservedObject var player: StudioPlayer
     let onExport: () -> Void
+    let onCancelExport: () -> Void
     let onPlayPause: () -> Void
     let onScrub: (TimeInterval) -> Void
 
@@ -50,6 +52,10 @@ struct StudioEditorView: View {
                     .font(.system(size: Theme.Typography.caption))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
+                // A progress bar with no way to stop it is a hostage situation, and an export of a
+                // long recording is exactly when somebody realises they picked the wrong preset.
+                Button("Cancel", action: onCancelExport)
+                    .accessibilityLabel("Cancel the export")
             }
 
             Button(action: onExport) {
@@ -148,11 +154,11 @@ struct StudioEditorView: View {
             Button { model.step(seconds: -1) } label: { Image(systemName: "backward.end") }
                 .buttonStyle(.plain).clickableCursor().accessibilityLabel("Back a second")
             Button(action: onPlayPause) {
-                Image(systemName: model.isPlaying ? "pause.circle" : "play.circle")
+                Image(systemName: player.isPlaying ? "pause.circle" : "play.circle")
                     .font(.system(size: 22))
             }
             .buttonStyle(.plain).clickableCursor()
-            .accessibilityLabel(model.isPlaying ? "Pause" : "Play")
+            .accessibilityLabel(player.isPlaying ? "Pause" : "Play")
             Button { model.step(seconds: 1) } label: { Image(systemName: "forward.end") }
                 .buttonStyle(.plain).clickableCursor().accessibilityLabel("Forward a second")
 
@@ -167,7 +173,7 @@ struct StudioEditorView: View {
             .buttonStyle(.plain).clickableCursor().help("Add a zoom here (Z)")
             .accessibilityLabel("Add a zoom at the playhead")
 
-            Text(Self.clock(model.playhead) + " / " + Self.clock(model.duration))
+            Text(Self.clock(player.playhead) + " / " + Self.clock(model.duration))
                 .font(.system(size: Theme.Typography.caption, design: .monospaced))
                 .monospacedDigit()
                 .foregroundStyle(.secondary)

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
@@ -105,7 +105,7 @@ struct StudioEditorView: View {
     private func isAvailable(_ tab: StudioDocumentModel.Inspector) -> Bool {
         switch tab {
         case .canvas, .cursor, .masks: return true
-        case .camera, .audio, .text: return true
+        case .camera, .audio, .text, .media: return true
         // Enabled whenever there is audio to work from — the tab is where you *make* captions,
         // so gating it on already having them would hide the only way to get any.
         case .captions:
@@ -127,6 +127,7 @@ struct StudioEditorView: View {
                 case .masks: MaskInspector(model: model)
                 case .camera: CameraInspector(model: model)
                 case .text: TextInspector(model: model)
+                case .media: MediaInspector(model: model)
                 case .captions: CaptionsInspector(model: model)
                 case .keystrokes: KeystrokesInspector(model: model)
                 case .audio: AudioInspector(model: model)
@@ -176,6 +177,7 @@ struct StudioEditorView: View {
             Menu {
                 Button("Zoom") { model.addZoomAtPlayhead() }
                 Button("Text") { model.addTextAtPlayhead() }
+                Button("Picture…") { model.inspector = .media }
                 Button("Click") { model.addClickAtPlayhead() }
                 Button("Pointer Highlight") { model.addPointerHighlightAtPlayhead() }
                 Button("Blur or Highlight") { model.addMaskAtPlayhead() }

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
@@ -100,9 +100,7 @@ struct StudioEditorView: View {
     private func isAvailable(_ tab: StudioDocumentModel.Inspector) -> Bool {
         switch tab {
         case .canvas, .cursor, .masks: return true
-        case .camera: return FileManager.default.fileExists(atPath: model.bundle.cameraURL.path)
-        case .audio: return FileManager.default.fileExists(atPath: model.bundle.microphoneURL.path)
-            || FileManager.default.fileExists(atPath: model.bundle.systemAudioURL.path)
+        case .camera, .audio: return true
         // Enabled whenever there is audio to work from — the tab is where you *make* captions,
         // so gating it on already having them would hide the only way to get any.
         case .captions:
@@ -125,11 +123,7 @@ struct StudioEditorView: View {
                 case .camera: CameraInspector(model: model)
                 case .captions: CaptionsInspector(model: model)
                 case .keystrokes: KeystrokesInspector(model: model)
-                case .audio:
-                    SectionHeader("Audio")
-                    Text("Nothing was recorded for this.")
-                        .font(.system(size: Theme.Typography.body))
-                        .foregroundStyle(.secondary)
+                case .audio: AudioInspector(model: model)
                 }
             }
             .padding(Theme.Space.lg)

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorView.swift
@@ -1,0 +1,196 @@
+import AppKit
+import SwiftUI
+
+/// The editor window's contents: preview, rail, inspector, transport, timeline.
+struct StudioEditorView: View {
+    @ObservedObject var model: StudioDocumentModel
+    let onExport: () -> Void
+    let onPlayPause: () -> Void
+    let onScrub: (TimeInterval) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            titleBar
+            Divider()
+            HStack(spacing: 0) {
+                PreviewHost(model: model, onScrub: onScrub)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                Divider()
+                rail
+                Divider()
+                inspector
+                    .frame(width: 260)
+            }
+            Divider()
+            transport
+            Divider()
+            TimelineHost(model: model, onScrub: onScrub)
+                .frame(height: StudioTimelineView.preferredHeight)
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    // MARK: - Chrome
+
+    private var titleBar: some View {
+        HStack(spacing: Theme.Space.md) {
+            Button { model.undo() } label: { Image(systemName: "arrow.uturn.backward") }
+                .buttonStyle(.plain).clickableCursor().disabled(!model.canUndo)
+                .accessibilityLabel("Undo")
+            Button { model.redo() } label: { Image(systemName: "arrow.uturn.forward") }
+                .buttonStyle(.plain).clickableCursor().disabled(!model.canRedo)
+                .accessibilityLabel("Redo")
+
+            Spacer()
+
+            if let progress = model.exportProgress {
+                ProgressView(value: progress)
+                    .frame(width: 120)
+                Text("\(Int(progress * 100))%")
+                    .font(.system(size: Theme.Typography.caption))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+
+            Button(action: onExport) {
+                Label("Export", systemImage: "square.and.arrow.up")
+            }
+            .disabled(model.exportProgress != nil)
+        }
+        .padding(.horizontal, Theme.Space.lg)
+        .frame(height: 44)
+    }
+
+    /// Tabs whose source the recording does not have are **disabled with a reason on hover**,
+    /// never hidden. A control that vanishes teaches nothing.
+    private var rail: some View {
+        VStack(spacing: Theme.Space.xs) {
+            ForEach(StudioDocumentModel.Inspector.allCases) { tab in
+                Button { model.inspector = tab } label: {
+                    Image(systemName: tab.symbolName)
+                        .font(.system(size: Theme.Metrics.tabIcon))
+                        .frame(width: Theme.Metrics.tabSquare, height: Theme.Metrics.tabSquare)
+                        .background {
+                            RoundedRectangle(cornerRadius: Theme.Metrics.tabRadius,
+                                             style: .continuous)
+                                .fill(model.inspector == tab
+                                      ? Color.accentColor.opacity(0.15) : .clear)
+                        }
+                        .foregroundStyle(model.inspector == tab ? Color.accentColor : .secondary)
+                }
+                .buttonStyle(.plain)
+                .clickableCursor()
+                .disabled(!isAvailable(tab))
+                .help(isAvailable(tab) ? tab.title : "\(tab.title) — nothing was recorded for this")
+                .accessibilityLabel(tab.title)
+                .accessibilityAddTraits(model.inspector == tab ? [.isSelected] : [])
+            }
+            Spacer()
+        }
+        .padding(.vertical, Theme.Space.sm)
+        .padding(.horizontal, Theme.Space.xs)
+    }
+
+    private func isAvailable(_ tab: StudioDocumentModel.Inspector) -> Bool {
+        switch tab {
+        case .canvas, .cursor: return true
+        case .camera: return FileManager.default.fileExists(atPath: model.bundle.cameraURL.path)
+        case .audio: return FileManager.default.fileExists(atPath: model.bundle.microphoneURL.path)
+            || FileManager.default.fileExists(atPath: model.bundle.systemAudioURL.path)
+        case .captions: return !model.project.captions.isEmpty
+        case .keystrokes: return !model.events.keys.isEmpty
+        }
+    }
+
+    @ViewBuilder
+    private var inspector: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Theme.Space.lg) {
+                switch model.inspector {
+                case .canvas: CanvasInspector(model: model)
+                case .cursor: CursorInspector(model: model)
+                default:
+                    SectionHeader(model.inspector.title)
+                    Text("Nothing was recorded for this.")
+                        .font(.system(size: Theme.Typography.body))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(Theme.Space.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var transport: some View {
+        HStack(spacing: Theme.Space.lg) {
+            Picker("", selection: Binding(
+                get: { model.project.aspect },
+                set: { value in model.edit { $0.aspect = value } })) {
+                ForEach(AspectRatio.allCases) { ratio in
+                    Text(ratio.title).tag(ratio)
+                }
+            }
+            .labelsHidden()
+            .frame(width: 120)
+
+            Spacer()
+
+            Button { model.step(seconds: -1) } label: { Image(systemName: "backward.end") }
+                .buttonStyle(.plain).clickableCursor().accessibilityLabel("Back a second")
+            Button(action: onPlayPause) {
+                Image(systemName: model.isPlaying ? "pause.circle" : "play.circle")
+                    .font(.system(size: 22))
+            }
+            .buttonStyle(.plain).clickableCursor()
+            .accessibilityLabel(model.isPlaying ? "Pause" : "Play")
+            Button { model.step(seconds: 1) } label: { Image(systemName: "forward.end") }
+                .buttonStyle(.plain).clickableCursor().accessibilityLabel("Forward a second")
+
+            Spacer()
+
+            Button { model.split() } label: { Image(systemName: "scissors") }
+                .buttonStyle(.plain).clickableCursor().help("Split at the playhead (⌘B)")
+                .accessibilityLabel("Split at the playhead")
+            Button { model.addZoomAtPlayhead() } label: {
+                Image(systemName: "plus.magnifyingglass")
+            }
+            .buttonStyle(.plain).clickableCursor().help("Add a zoom here (Z)")
+            .accessibilityLabel("Add a zoom at the playhead")
+
+            Text(Self.clock(model.playhead) + " / " + Self.clock(model.duration))
+                .font(.system(size: Theme.Typography.caption, design: .monospaced))
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, Theme.Space.lg)
+        .frame(height: 44)
+    }
+
+    static func clock(_ seconds: TimeInterval) -> String {
+        let total = max(0, Int(seconds))
+        return String(format: "%d:%02d", total / 60, total % 60)
+    }
+}
+
+// MARK: - Hosts
+
+private struct PreviewHost: NSViewRepresentable {
+    let model: StudioDocumentModel
+    let onScrub: (TimeInterval) -> Void
+
+    func makeNSView(context: Context) -> StudioPreviewView { StudioPreviewView(model: model) }
+    func updateNSView(_ view: StudioPreviewView, context: Context) { view.needsDisplay = true }
+}
+
+private struct TimelineHost: NSViewRepresentable {
+    let model: StudioDocumentModel
+    let onScrub: (TimeInterval) -> Void
+
+    func makeNSView(context: Context) -> StudioTimelineView {
+        let view = StudioTimelineView(model: model)
+        view.onScrub = onScrub
+        return view
+    }
+
+    func updateNSView(_ view: StudioTimelineView, context: Context) { view.needsDisplay = true }
+}

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -71,6 +71,23 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
 
     private func togglePlayback() { model.player.toggle() }
 
+    /// The composited frame, as a PNG on the pasteboard.
+    ///
+    /// Rendered through `model.frameSources`, the same one the canvas uses, so what you paste is
+    /// what you were looking at.
+    private func copyFrame() {
+        guard let frame = StudioRenderer.frame(of: model.project, atSource: model.sourceTime,
+                                               events: model.events,
+                                               sources: model.frameSources),
+              let data = CaptureWriter.pngData(from: frame) else {
+            ToastPresenter.shared.show("Nothing to copy yet", symbolName: "photo.badge.exclamationmark")
+            return
+        }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setData(data, forType: .png)
+        ToastPresenter.shared.show("Frame copied", symbolName: "doc.on.clipboard")
+    }
+
     // MARK: - Keys
 
     private func installKeyMonitor() {
@@ -108,9 +125,18 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
         case .save: model.markSaved()
         case .export: export()
         case .close: window?.performClose(nil)
-        case .setIn, .setOut, .fitTimeline, .loopPlayback, .copyFrame,
-             .resetEdits, .showShortcuts, .commandMenu:
-            // Not yet wired. Deliberately silent rather than half-done.
+        case .showShortcuts: model.isShowingShortcuts = true
+        case .loopPlayback:
+            model.player.loops.toggle()
+            ToastPresenter.shared.show(model.player.loops ? "Looping" : "Not looping",
+                                       symbolName: "repeat")
+        case .copyFrame: copyFrame()
+        case .resetEdits: model.resetEdits()
+        case .setIn, .setOut, .fitTimeline, .commandMenu:
+            // Still not wired, and now said out loud rather than silently: ⌘/ lists In and Out as
+            // not built, instead of leaving two keys that look live and do nothing. `fitTimeline`
+            // has nothing to fit — the timeline always shows the whole project — and the command
+            // menu is its own piece of work.
             break
         }
     }

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -1,0 +1,204 @@
+import AppKit
+import SwiftUI
+import os
+
+/// One editor window.
+///
+/// Modelled on `ScreenshotEditorWindowController`: a real `NSWindow`, through
+/// `ActivationPolicyLease`, with keys intercepted by a local monitor because a `MenuBarExtra`
+/// accessory has no main menu to hang items on — ⌘W in particular does nothing without one, so
+/// intercepting it is mandatory rather than a nicety.
+@MainActor
+final class StudioEditorWindowController: NSObject, NSWindowDelegate {
+    private let log = Logger(subsystem: AppIdentity.logSubsystem, category: "Studio")
+
+    let model: StudioDocumentModel
+    private var window: NSWindow?
+    private var monitor: Any?
+    private var preview: StudioPreviewView?
+    private let exporter = StudioExporter()
+    private let onClose: (StudioEditorWindowController) -> Void
+
+    /// Below this the timeline and the inspector both start hiding controls silently, which is the
+    /// one thing this window must not do.
+    static let minimumSize = NSSize(width: 1100, height: 700)
+
+    init(model: StudioDocumentModel, onClose: @escaping (StudioEditorWindowController) -> Void) {
+        self.model = model
+        self.onClose = onClose
+        super.init()
+    }
+
+    func show() {
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: NSSize(width: 1240, height: 820)),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered, defer: false)
+        window.title = "Recording"
+        window.isReleasedWhenClosed = false
+        window.contentMinSize = Self.minimumSize
+
+        let root = StudioEditorView(
+            model: model,
+            onExport: { [weak self] in self?.export() },
+            onPlayPause: { [weak self] in self?.togglePlayback() },
+            onScrub: { [weak self] time in self?.preview?.scrub(to: time) })
+        let hosting = NSHostingView(rootView: root)
+        window.contentView = hosting
+        window.delegate = self
+        window.center()
+        // Cascade, so a second editor does not land exactly on the first and look like one window.
+        window.setFrameOrigin(NSPoint(x: window.frame.minX + CGFloat(Self.openCount % 6) * 24,
+                                      y: window.frame.minY - CGFloat(Self.openCount % 6) * 24))
+        self.window = window
+        self.preview = hosting.findPreview()
+
+        // Through the lease: another window may also be open, and an unconditional drop back to
+        // .accessory when it closes would leave this one refusing input.
+        ActivationPolicyLease.shared.acquire()
+        Self.openCount += 1
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+        installKeyMonitor()
+    }
+
+    private static var openCount = 0
+
+    // MARK: - Playback
+
+    private func togglePlayback() {
+        guard let preview else { return }
+        if model.isPlaying { preview.pause() } else { preview.play() }
+    }
+
+    // MARK: - Keys
+
+    private func installKeyMonitor() {
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self, event.window === self.window else { return event }
+            guard let action = StudioKeyRouting.action(
+                forCharacters: event.charactersIgnoringModifiers ?? "",
+                modifiers: event.modifierFlags,
+                // No text field in this window yet; when the transcript editor lands this becomes
+                // the check that stops a caption edit splitting the timeline.
+                isEditingText: false) else { return event }
+            self.perform(action)
+            return nil
+        }
+    }
+
+    private func perform(_ action: StudioKeyRouting.Action) {
+        switch action {
+        case .playPause: togglePlayback()
+        case .stepFrames(let count): model.step(frames: count)
+        case .stepSeconds(let count): model.step(seconds: Double(count))
+        case .shuttle(let direction):
+            preview?.setRate(Float(direction))
+        case .split: model.split()
+        case .rippleDelete, .deleteSelection:
+            if model.selectedZoom != nil { model.deleteSelectedZoom() } else {
+                model.deleteSelectedClip()
+            }
+        case .addZoom: model.addZoomAtPlayhead()
+        case .setZoomLevel(let digit):
+            // 1 is 1x and each step is a quarter, which puts the useful range on the home row.
+            model.setLevelOfSelectedZoom(1 + Double(max(0, digit - 1)) * 0.25)
+        case .undo: model.undo()
+        case .redo: model.redo()
+        case .save: model.markSaved()
+        case .export: export()
+        case .close: window?.performClose(nil)
+        case .setIn, .setOut, .fitTimeline, .loopPlayback, .copyFrame,
+             .resetEdits, .showShortcuts, .commandMenu:
+            // Not yet wired. Deliberately silent rather than half-done.
+            break
+        }
+    }
+
+    // MARK: - Export
+
+    private func export() {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "Recording.mp4"
+        panel.allowedContentTypes = [.mpeg4Movie]
+        panel.message = "1080p H.264 — plays everywhere."
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        model.exportProgress = 0
+        let project = model.project
+        let events = model.events
+        let bundle = model.bundle
+
+        Task { [exporter, weak self] in
+            do {
+                try await exporter.export(
+                    project: project, events: events, recording: bundle,
+                    preset: .web, to: url,
+                    onProgress: { progress in
+                        Task { @MainActor in self?.model.exportProgress = progress.fraction }
+                    })
+                await MainActor.run {
+                    self?.model.exportProgress = nil
+                    NSWorkspace.shared.activateFileViewerSelecting([url])
+                    ToastPresenter.shared.show("Exported", symbolName: "square.and.arrow.up")
+                }
+            } catch {
+                await MainActor.run {
+                    self?.model.exportProgress = nil
+                    ToastPresenter.shared.show("Export failed",
+                                               symbolName: "exclamationmark.triangle")
+                }
+            }
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        // The project autosaves into the bundle continuously, so there is nothing to lose and
+        // nothing to ask about. A dialog here would be ceremony over a decision already made.
+        model.markSaved()
+        return true
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        if let monitor { NSEvent.removeMonitor(monitor) }
+        monitor = nil
+        preview?.pause()
+        ActivationPolicyLease.shared.release()
+        onClose(self)
+    }
+}
+
+private extension NSView {
+    /// The hosting view builds the tree, so the preview has to be found rather than held.
+    func findPreview() -> StudioPreviewView? {
+        if let preview = self as? StudioPreviewView { return preview }
+        for child in subviews {
+            if let found = child.findPreview() { return found }
+        }
+        return nil
+    }
+}
+
+/// Every open editor.
+@MainActor
+final class StudioEditorController {
+    static let shared = StudioEditorController()
+
+    private var controllers: [StudioEditorWindowController] = []
+
+    var openCount: Int { controllers.count }
+
+    /// Opens a finished recording.
+    func open(_ bundle: RecordingBundle) {
+        guard let manifest = try? bundle.readManifest() else { return }
+        let events = (try? bundle.readEvents()) ?? EventLog()
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: events)
+        let controller = StudioEditorWindowController(model: model) { [weak self] finished in
+            self?.controllers.removeAll { $0 === finished }
+        }
+        controllers.append(controller)
+        controller.show()
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -67,6 +67,12 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
 
     private static var openCount = 0
 
+    /// Brings an already-open editor forward.
+    func focus() {
+        NSApp.activate(ignoringOtherApps: true)
+        window?.makeKeyAndOrderFront(nil)
+    }
+
     // MARK: - Playback
 
     private func togglePlayback() { model.player.toggle() }
@@ -222,6 +228,11 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
         monitor = nil
         model.player.pause()
         ActivationPolicyLease.shared.release()
+        // **Say that it was kept.** The autosave was always real and always silent, and "if I
+        // close a recording without editing, what happens is not clear" is exactly what silence
+        // buys. Named after the file, so the sentence points at something findable.
+        ToastPresenter.shared.show("\(model.bundle.root.deletingPathExtension().lastPathComponent) saved — reopen it any time",
+                                   symbolName: "tray.and.arrow.down")
         onClose(self)
     }
 }
@@ -281,8 +292,16 @@ final class StudioEditorController {
     }
 
     /// Opens a finished recording.
-    func open(_ bundle: RecordingBundle) {
-        guard let manifest = try? bundle.readManifest() else { return }
+    @discardableResult
+    func open(_ bundle: RecordingBundle) -> Bool {
+        // **The same recording twice is the same window.** Double-clicking a file twice, or
+        // opening from the list what is already on screen, must not produce two editors over one
+        // bundle — they would autosave over each other, and the last one to close would win.
+        if let existing = controllers.first(where: { $0.model.bundle.root == bundle.root }) {
+            existing.focus()
+            return true
+        }
+        guard let manifest = try? bundle.readManifest() else { return false }
         let events = (try? bundle.readEvents()) ?? EventLog()
         let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: events)
         let controller = StudioEditorWindowController(model: model) { [weak self] finished in
@@ -290,5 +309,22 @@ final class StudioEditorController {
         }
         controllers.append(controller)
         controller.show()
+        return true
+    }
+
+    /// Opens a `.sarvrec` from the Finder, the recordings list, or an Open panel.
+    ///
+    /// Says so when it cannot, rather than returning quietly: a double-click that does nothing at
+    /// all is the state this whole change exists to end.
+    func open(fileAt url: URL) {
+        guard RecordingBundle(root: url).canBeOpened else {
+            ToastPresenter.shared.show("That recording can't be opened",
+                                       symbolName: "exclamationmark.triangle")
+            return
+        }
+        if !open(RecordingBundle(root: url)) {
+            ToastPresenter.shared.show("That recording can't be opened",
+                                       symbolName: "exclamationmark.triangle")
+        }
     }
 }

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -149,7 +149,10 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
         panel.allowedContentTypes = [.mpeg4Movie]
         panel.message = "1080p H.264 — plays everywhere."
         guard panel.runModal() == .OK, let url = panel.url else { return }
+        export(to: url)
+    }
 
+    func export(to url: URL) {
         model.exportProgress = 0
         let project = model.project
         let events = model.events
@@ -222,6 +225,17 @@ final class StudioEditorController {
     func seek(to output: TimeInterval) -> Bool {
         guard let controller = controllers.last else { return false }
         controller.model.player.scrub(to: output)
+        return true
+    }
+
+    /// Exports the newest editor to a file, without the save panel.
+    ///
+    /// The same call the Export button makes, minus the panel — which is what makes "does the
+    /// export have sound" answerable without a mouse.
+    @discardableResult
+    func export(to url: URL) -> Bool {
+        guard let controller = controllers.last else { return false }
+        controller.export(to: url)
         return true
     }
 

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -136,6 +136,7 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
         case .save: model.markSaved()
         case .export: export()
         case .close: window?.performClose(nil)
+        case .export: export()
         case .showShortcuts: model.isShowingShortcuts = true
         case .loopPlayback:
             model.player.loops.toggle()
@@ -168,6 +169,7 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
         case .addPointerHighlight: model.addPointerHighlightAtPlayhead()
         case .addMask: model.addMaskAtPlayhead()
         case .close: window?.performClose(nil)
+        case .export: export()
         case .undo: model.undo()
         case .redo: model.redo()
         case .resetEdits: model.resetEdits()

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -174,16 +174,56 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
         }
     }
 
+    /// Asks what the export should be, then where to put it.
+    ///
+    /// **The quality question comes first.** It decides the container and therefore the file
+    /// extension, so a save panel shown before it would have to guess — which is how the panel
+    /// ended up offering only `.mp4` while the exporter wrote `.mov` for ProRes.
     private func export() {
-        let panel = NSSavePanel()
-        panel.nameFieldStringValue = "Recording.mp4"
-        panel.allowedContentTypes = [.mpeg4Movie]
-        panel.message = "1080p H.264 — plays everywhere."
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        export(to: url)
+        let manifest = try? model.bundle.readManifest()
+        let (canvas, _) = StudioRenderer.layout(for: model.project)
+        let subject = ExportOptionsSheet.Subject(
+            canvas: canvas,
+            recording: model.project.cropRect?.size ?? model.project.canvasSize,
+            seconds: model.duration,
+            recordingFPS: manifest?.fps ?? 60)
+
+        let sheet = NSPanel(contentRect: .zero,
+                            styleMask: [.titled, .fullSizeContentView],
+                            backing: .buffered, defer: false)
+        sheet.titleVisibility = .hidden
+        sheet.titlebarAppearsTransparent = true
+        sheet.contentView = NSHostingView(rootView: ExportOptionsSheet(
+            subject: subject,
+            onCancel: { [weak self] in self?.window?.endSheet(sheet, returnCode: .cancel) },
+            onExport: { [weak self] preset in
+                self?.chosenPreset = preset
+                self?.window?.endSheet(sheet, returnCode: .OK)
+            }))
+        sheet.setContentSize(sheet.contentView?.fittingSize ?? NSSize(width: 460, height: 420))
+
+        window?.beginSheet(sheet) { [weak self] response in
+            guard let self, response == .OK, let preset = self.chosenPreset else { return }
+            self.chosenPreset = nil
+            self.askWhereToPutIt(preset)
+        }
     }
 
-    func export(to url: URL) {
+    /// Carries the choice from the sheet's completion out to the save panel.
+    private var chosenPreset: ExportPreset?
+
+    private func askWhereToPutIt(_ preset: ExportPreset) {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "Recording.\(preset.fileExtension)"
+        // Follows the codec, so choosing ProRes does not offer to save it as an mp4.
+        panel.allowedContentTypes = [preset.contentType]
+        let size = preset.outputSize(forCanvas: StudioRenderer.layout(for: model.project).canvas)
+        panel.message = "\(Int(size.width)) × \(Int(size.height)) · \(preset.codec.title)"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        export(to: url, preset: preset)
+    }
+
+    func export(to url: URL, preset: ExportPreset = .web) {
         model.exportProgress = 0
         let project = model.project
         let events = model.events
@@ -195,7 +235,7 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
             do {
                 try await exporter.export(
                     project: project, events: events, recording: bundle,
-                    preset: .web, to: url,
+                    preset: preset, to: url,
                     onProgress: { progress in
                         Task { @MainActor in self?.model.exportProgress = progress.fraction }
                     })
@@ -279,14 +319,14 @@ final class StudioEditorController {
         return true
     }
 
-    /// Exports the newest editor to a file, without the save panel.
+    /// Exports the newest editor to a file, without either dialog.
     ///
-    /// The same call the Export button makes, minus the panel — which is what makes "does the
-    /// export have sound" answerable without a mouse.
+    /// The same call the Export button makes, minus the panels — which is what makes "does the
+    /// export have sound, and at what size" answerable without a mouse.
     @discardableResult
-    func export(to url: URL) -> Bool {
+    func export(to url: URL, preset: ExportPreset = .web) -> Bool {
         guard let controller = controllers.last else { return false }
-        controller.export(to: url)
+        controller.export(to: url, preset: preset)
         return true
     }
 

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -246,6 +246,13 @@ final class StudioEditorController {
         return true
     }
 
+    /// Brings a picture into the newest editor.
+    @discardableResult
+    func addPicture(from url: URL) -> Bool {
+        guard let controller = controllers.last else { return false }
+        return controller.model.addMediaAtPlayhead(from: url)
+    }
+
     /// Performs one of the editor's own actions on the newest editor.
     @discardableResult
     func perform(_ command: StudioEditorCommand) -> Bool {

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -161,6 +161,8 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
         case .addText: model.addTextAtPlayhead()
         case .addClick: model.addClickAtPlayhead()
         case .addPointerHighlight: model.addPointerHighlightAtPlayhead()
+        case .addMask: model.addMaskAtPlayhead()
+        case .close: window?.performClose(nil)
         case .undo: model.undo()
         case .redo: model.redo()
         case .resetEdits: model.resetEdits()
@@ -297,7 +299,9 @@ final class StudioEditorController {
         // **The same recording twice is the same window.** Double-clicking a file twice, or
         // opening from the list what is already on screen, must not produce two editors over one
         // bundle — they would autosave over each other, and the last one to close would win.
-        if let existing = controllers.first(where: { $0.model.bundle.root == bundle.root }) {
+        if let existing = controllers.first(where: {
+            $0.model.bundle.identity == bundle.identity
+        }) {
             existing.focus()
             return true
         }

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -143,6 +143,24 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
 
     // MARK: - Export
 
+    func perform(_ command: StudioEditorCommand) {
+        switch command {
+        case .split: model.split()
+        case .duplicateClip: model.duplicateSelectedClip()
+        case .deleteSelection:
+            if model.selectedZoom != nil { model.deleteSelectedZoom() } else {
+                model.deleteSelectedClip()
+            }
+        case .addZoom: model.addZoomAtPlayhead()
+        case .addText: model.addTextAtPlayhead()
+        case .addClick: model.addClickAtPlayhead()
+        case .addPointerHighlight: model.addPointerHighlightAtPlayhead()
+        case .undo: model.undo()
+        case .redo: model.redo()
+        case .resetEdits: model.resetEdits()
+        }
+    }
+
     private func export() {
         let panel = NSSavePanel()
         panel.nameFieldStringValue = "Recording.mp4"
@@ -225,6 +243,14 @@ final class StudioEditorController {
     func seek(to output: TimeInterval) -> Bool {
         guard let controller = controllers.last else { return false }
         controller.model.player.scrub(to: output)
+        return true
+    }
+
+    /// Performs one of the editor's own actions on the newest editor.
+    @discardableResult
+    func perform(_ command: StudioEditorCommand) -> Bool {
+        guard let controller = controllers.last else { return false }
+        controller.perform(command)
         return true
     }
 

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -199,6 +199,14 @@ final class StudioEditorController {
         return true
     }
 
+    /// Starts or stops playback in the newest editor.
+    @discardableResult
+    func togglePlayback() -> Bool {
+        guard let controller = controllers.last else { return false }
+        controller.model.player.toggle()
+        return true
+    }
+
     /// Opens a finished recording.
     func open(_ bundle: RecordingBundle) {
         guard let manifest = try? bundle.readManifest() else { return }

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -15,8 +15,8 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
     let model: StudioDocumentModel
     private var window: NSWindow?
     private var monitor: Any?
-    private var preview: StudioPreviewView?
-    private let exporter = StudioExporter()
+    /// Made fresh per export, so a Cancel always applies to the run it was pressed for.
+    private var activeExport: StudioExporter?
     private let onClose: (StudioEditorWindowController) -> Void
 
     /// Below this the timeline and the inspector both start hiding controls silently, which is the
@@ -40,18 +40,21 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
 
         let root = StudioEditorView(
             model: model,
+            player: model.player,
             onExport: { [weak self] in self?.export() },
+            onCancelExport: { [weak self] in
+                guard let exporter = self?.activeExport else { return }
+                Task { await exporter.cancel() }
+            },
             onPlayPause: { [weak self] in self?.togglePlayback() },
-            onScrub: { [weak self] time in self?.preview?.scrub(to: time) })
-        let hosting = NSHostingView(rootView: root)
-        window.contentView = hosting
+            onScrub: { [weak model] time in model?.player.scrub(to: time) })
+        window.contentView = NSHostingView(rootView: root)
         window.delegate = self
         window.center()
         // Cascade, so a second editor does not land exactly on the first and look like one window.
         window.setFrameOrigin(NSPoint(x: window.frame.minX + CGFloat(Self.openCount % 6) * 24,
                                       y: window.frame.minY - CGFloat(Self.openCount % 6) * 24))
         self.window = window
-        self.preview = hosting.findPreview()
 
         // Through the lease: another window may also be open, and an unconditional drop back to
         // .accessory when it closes would leave this one refusing input.
@@ -66,10 +69,7 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
 
     // MARK: - Playback
 
-    private func togglePlayback() {
-        guard let preview else { return }
-        if model.isPlaying { preview.pause() } else { preview.play() }
-    }
+    private func togglePlayback() { model.player.toggle() }
 
     // MARK: - Keys
 
@@ -93,7 +93,7 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
         case .stepFrames(let count): model.step(frames: count)
         case .stepSeconds(let count): model.step(seconds: Double(count))
         case .shuttle(let direction):
-            preview?.setRate(Float(direction))
+            model.player.shuttle(direction)
         case .split: model.split()
         case .rippleDelete, .deleteSelection:
             if model.selectedZoom != nil { model.deleteSelectedZoom() } else {
@@ -128,8 +128,10 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
         let project = model.project
         let events = model.events
         let bundle = model.bundle
+        let exporter = StudioExporter()
+        activeExport = exporter
 
-        Task { [exporter, weak self] in
+        Task { [weak self] in
             do {
                 try await exporter.export(
                     project: project, events: events, recording: bundle,
@@ -139,12 +141,19 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
                     })
                 await MainActor.run {
                     self?.model.exportProgress = nil
+                    self?.activeExport = nil
                     NSWorkspace.shared.activateFileViewerSelecting([url])
                     ToastPresenter.shared.show("Exported", symbolName: "square.and.arrow.up")
+                }
+            } catch StudioExporter.ExportError.cancelled {
+                await MainActor.run {
+                    self?.model.exportProgress = nil
+                    self?.activeExport = nil
                 }
             } catch {
                 await MainActor.run {
                     self?.model.exportProgress = nil
+                    self?.activeExport = nil
                     ToastPresenter.shared.show("Export failed",
                                                symbolName: "exclamationmark.triangle")
                 }
@@ -164,20 +173,9 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
         if let monitor { NSEvent.removeMonitor(monitor) }
         monitor = nil
-        preview?.pause()
+        model.player.pause()
         ActivationPolicyLease.shared.release()
         onClose(self)
-    }
-}
-
-private extension NSView {
-    /// The hosting view builds the tree, so the preview has to be found rather than held.
-    func findPreview() -> StudioPreviewView? {
-        if let preview = self as? StudioPreviewView { return preview }
-        for child in subviews {
-            if let found = child.findPreview() { return found }
-        }
-        return nil
     }
 }
 

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -188,6 +188,17 @@ final class StudioEditorController {
 
     var openCount: Int { controllers.count }
 
+    /// The most recently opened editor, for `sarvkrit://seek`.
+    var newest: StudioEditorWindowController? { controllers.last }
+
+    /// Moves the newest editor's playhead. Returns false when there is no editor open.
+    @discardableResult
+    func seek(to output: TimeInterval) -> Bool {
+        guard let controller = controllers.last else { return false }
+        controller.model.player.scrub(to: output)
+        return true
+    }
+
     /// Opens a finished recording.
     func open(_ bundle: RecordingBundle) {
         guard let manifest = try? bundle.readManifest() else { return }

--- a/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioEditorWindowController.swift
@@ -63,6 +63,11 @@ final class StudioEditorWindowController: NSObject, NSWindowDelegate {
         NSApp.activate(ignoringOtherApps: true)
         window.makeKeyAndOrderFront(nil)
         installKeyMonitor()
+
+        // **Composed after the window is up, not before it.** Reading the audio off disk takes long
+        // enough to be felt, and an editor that opens a second late is worse than one whose sound
+        // arrives a moment after the picture.
+        Task { [model] in await model.prepareSoundtrack() }
     }
 
     private static var openCount = 0

--- a/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
@@ -241,6 +241,92 @@ struct MaskInspector: View {
     }
 }
 
+/// Pictures brought in and composited over the recording.
+struct MediaInspector: View {
+    @ObservedObject var model: StudioDocumentModel
+
+    private var selected: MediaOverlay? {
+        model.project.mediaOverlays.first { $0.id == model.selectedMedia }
+            ?? model.project.mediaOverlays.first { $0.covers(model.sourceTime) }
+    }
+
+    var body: some View {
+        Button {
+            let panel = NSOpenPanel()
+            panel.allowsMultipleSelection = false
+            panel.canChooseDirectories = false
+            panel.allowedContentTypes = [.image]
+            panel.message = "The picture is copied into the recording, so the project keeps "
+                + "working if you move the original."
+            guard panel.runModal() == .OK, let url = panel.url else { return }
+            if !model.addMediaAtPlayhead(from: url) {
+                ToastPresenter.shared.show("Couldn't bring that picture in",
+                                           symbolName: "photo.badge.exclamationmark")
+            }
+        } label: {
+            Label("Bring in a Picture…", systemImage: "photo.badge.plus")
+        }
+
+        if model.project.mediaOverlays.isEmpty {
+            Text("A logo, a screenshot, a diagram. It is copied into the recording so the project "
+                 + "opens anywhere, and sits below any text.")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+
+        if let overlay = selected {
+            SectionHeader("The Selected Picture")
+            seconds("Size", value: Binding(
+                get: { overlay.rect.width },
+                set: { value in
+                    model.updateMedia(overlay.id, live: true) {
+                        // Kept square in canvas terms; the picture is fitted inside, never
+                        // stretched, so the box only decides how much room it has.
+                        $0.rect.size = CGSize(width: value, height: value)
+                    }
+                }),
+                    range: 0.05...1)
+            seconds("Across", value: Binding(
+                get: { overlay.rect.minX },
+                set: { value in model.updateMedia(overlay.id, live: true) { $0.rect.origin.x = value } }),
+                    range: 0...1)
+            seconds("Down", value: Binding(
+                get: { overlay.rect.minY },
+                set: { value in model.updateMedia(overlay.id, live: true) { $0.rect.origin.y = value } }),
+                    range: 0...1)
+            seconds("Opacity", value: Binding(
+                get: { overlay.opacity },
+                set: { value in model.updateMedia(overlay.id, live: true) { $0.opacity = value } }),
+                    range: 0.05...1)
+            seconds("Rounded corners", value: Binding(
+                get: { overlay.cornerRadiusFraction },
+                set: { value in
+                    model.updateMedia(overlay.id, live: true) { $0.cornerRadiusFraction = value }
+                }),
+                    range: 0...0.5)
+
+            Button(role: .destructive) {
+                model.removeMedia(overlay.id)
+            } label: {
+                Label("Remove This Picture", systemImage: "trash")
+            }
+        }
+    }
+
+    private func seconds(_ title: String, value: Binding<Double>,
+                         range: ClosedRange<Double>) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+            Slider(value: value, in: range) { editing in
+                if editing { model.beginGesture() } else { model.endGesture() }
+            }
+        }
+    }
+}
+
 /// Text put on the video by hand.
 ///
 /// **Every measurement is a fraction of the canvas**, so a title keeps its framing when the aspect

--- a/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
@@ -188,13 +188,38 @@ struct CameraInspector: View {
     @ObservedObject var model: StudioDocumentModel
 
     var body: some View {
-        SectionHeader("Camera")
+        SectionHeader("Shape")
         Picker("Shape", selection: Binding(
             get: { model.project.camera.shape },
             set: { value in model.edit { $0.camera.shape = value } })) {
             ForEach(CameraSettings.Shape.allCases, id: \.self) { Text($0.title).tag($0) }
         }
 
+        if model.project.camera.shape == .squircle {
+            slider("Roundness", value: Binding(
+                get: { model.project.camera.cornerRadiusFraction },
+                set: { value in model.editLive { $0.camera.cornerRadiusFraction = value } }),
+                   range: 0...0.5)
+        }
+
+        slider("Size", value: Binding(
+            get: { model.project.camera.sizeFraction },
+            set: { value in model.editLive { $0.camera.sizeFraction = value } }),
+               range: 0.1...0.4)
+
+        slider("Margin", value: Binding(
+            get: { model.project.camera.marginFraction },
+            set: { value in model.editLive { $0.camera.marginFraction = value } }),
+               range: 0...0.1)
+
+        SectionHeader("Corner")
+        // Nine positions as a grid rather than a menu: where the camera goes is a spatial
+        // question, and a list of nine phrases is a worse way to answer one.
+        CornerGrid(selection: Binding(
+            get: { model.project.camera.corner },
+            set: { value in model.edit { $0.camera.corner = value } }))
+
+        SectionHeader("Behaviour")
         Picker("While zoomed", selection: Binding(
             get: { model.project.camera.sizeDuringZoom },
             set: { value in model.edit { $0.camera.sizeDuringZoom = value } })) {
@@ -205,20 +230,155 @@ struct CameraInspector: View {
             .font(.system(size: Theme.Typography.caption))
             .foregroundStyle(.secondary)
 
-        VStack(alignment: .leading, spacing: 2) {
-            Text("Size").font(.system(size: Theme.Typography.caption)).foregroundStyle(.secondary)
-            Slider(value: Binding(
-                get: { model.project.camera.sizeFraction },
-                set: { value in model.editLive { $0.camera.sizeFraction = value } }),
-                   in: 0.1...0.4) { editing in
-                if editing { model.beginGesture() } else { model.endGesture() }
-            }
-        }
-
         Toggle("Mirror", isOn: Binding(
             get: { model.project.camera.mirrored },
             set: { value in model.edit { $0.camera.mirrored = value } }))
         .toggleStyle(.switch).controlSize(.small)
+
+        Toggle("Shadow", isOn: Binding(
+            get: { model.project.camera.shadow != nil },
+            set: { on in
+                model.edit { $0.camera.shadow = on ? CaptureBackground.Shadow() : nil }
+            }))
+        .toggleStyle(.switch).controlSize(.small)
+
+        slider("Fade in and out", value: Binding(
+            get: { model.project.camera.fadeSeconds },
+            set: { value in model.editLive { $0.camera.fadeSeconds = value } }),
+               range: 0...2)
+
+        SectionHeader("Layout over time")
+        HStack {
+            Button("Full frame here") { model.addCameraSegment(.fullFrame) }
+            Button("Hide here") { model.addCameraSegment(.hidden) }
+        }
+        Text("A demo usually wants the camera full-frame for the intro and small for the rest.")
+            .font(.system(size: Theme.Typography.caption))
+            .foregroundStyle(.secondary)
+
+        ForEach(model.project.cameraSegments) { segment in
+            HStack {
+                Text("\(segment.layout.title) · \(String(format: "%.1f", segment.start))s")
+                    .font(.system(size: Theme.Typography.caption))
+                Spacer()
+                Button { model.removeCameraSegment(segment.id) } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.plain).clickableCursor()
+                .accessibilityLabel("Remove this camera layout")
+            }
+        }
+    }
+
+    private func slider(_ title: String, value: Binding<Double>,
+                        range: ClosedRange<Double>) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+            Slider(value: value, in: range) { editing in
+                if editing { model.beginGesture() } else { model.endGesture() }
+            }
+        }
+    }
+}
+
+/// Nine positions, laid out where they mean.
+struct CornerGrid: View {
+    @Binding var selection: CaptureBackground.Alignment
+
+    private let rows: [[CaptureBackground.Alignment]] = [
+        [.topLeading, .top, .topTrailing],
+        [.leading, .centre, .trailing],
+        [.bottomLeading, .bottom, .bottomTrailing],
+    ]
+
+    var body: some View {
+        VStack(spacing: 4) {
+            ForEach(rows.indices, id: \.self) { row in
+                HStack(spacing: 4) {
+                    ForEach(rows[row], id: \.self) { corner in
+                        Button { selection = corner } label: {
+                            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                .fill(selection == corner
+                                      ? Color.accentColor.opacity(0.7)
+                                      : Color(nsColor: .quaternaryLabelColor).opacity(0.5))
+                                .frame(width: 26, height: 20)
+                        }
+                        .buttonStyle(.plain)
+                        .clickableCursor()
+                        .accessibilityLabel(corner.rawValue)
+                        .accessibilityAddTraits(selection == corner ? [.isSelected] : [])
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Audio levels for whichever tracks the recording has.
+struct AudioInspector: View {
+    @ObservedObject var model: StudioDocumentModel
+
+    private var hasMicrophone: Bool {
+        FileManager.default.fileExists(atPath: model.bundle.microphoneURL.path)
+    }
+
+    private var hasSystemAudio: Bool {
+        FileManager.default.fileExists(atPath: model.bundle.systemAudioURL.path)
+    }
+
+    var body: some View {
+        SectionHeader("Audio")
+
+        if !hasMicrophone && !hasSystemAudio {
+            Text("This recording has no audio. Choose a microphone, or switch on system audio, "
+                 + "before you record.")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+            return AnyView(EmptyView())
+        }
+
+        return AnyView(VStack(alignment: .leading, spacing: Theme.Space.md) {
+            if hasMicrophone {
+                // Two volumes, because "mute the video I was demonstrating but keep my narration"
+                // is the common case and one number cannot say it.
+                clipSlider("Narration", value: { $0.volume }, set: { $0.volume = $1 })
+            }
+            if hasSystemAudio {
+                clipSlider("System audio", value: { $0.systemAudioVolume },
+                           set: { $0.systemAudioVolume = $1 })
+            }
+            if hasMicrophone {
+                Button("Remove silences") { model.removeSilencesFromMicrophone() }
+                Text("Inserts real cuts you can undo — not a filter, so the timeline still shows "
+                     + "exactly what will be exported.")
+                    .font(.system(size: Theme.Typography.caption))
+                    .foregroundStyle(.secondary)
+            }
+        })
+    }
+
+    private func clipSlider(_ title: String,
+                            value: @escaping (Clip) -> Double,
+                            set: @escaping (inout Clip, Double) -> Void) -> some View {
+        let current = model.project.timeline.clips.first.map(value) ?? 1
+        return VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+            Slider(value: Binding(
+                get: { current },
+                set: { level in
+                    model.editLive { project in
+                        for index in project.timeline.clips.indices {
+                            set(&project.timeline.clips[index], level)
+                        }
+                    }
+                }), in: 0...2) { editing in
+                if editing { model.beginGesture() } else { model.endGesture() }
+            }
+        }
     }
 }
 

--- a/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
@@ -8,11 +8,55 @@ import SwiftUI
 struct CanvasInspector: View {
     @ObservedObject var model: StudioDocumentModel
 
+    private var selectedClip: Clip? {
+        model.project.timeline.clips.first { $0.id == model.selectedClip }
+    }
+
     private var shortSide: CGFloat {
         min(model.project.canvasSize.width, model.project.canvasSize.height)
     }
 
     var body: some View {
+        SectionHeader("Fades")
+        seconds("Fade in", value: Binding(
+            get: { model.project.fadeIn },
+            set: { value in model.editLive { $0.fadeIn = value } }),
+               range: 0...3)
+        seconds("Fade out", value: Binding(
+            get: { model.project.fadeOut },
+            set: { value in model.editLive { $0.fadeOut = value } }),
+               range: 0...3)
+        Text("The picture fades up from black and down to it, and the sound fades with it.")
+            .font(.system(size: Theme.Typography.caption))
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+        if let clip = selectedClip {
+            SectionHeader("The Selected Clip")
+            seconds("Speed", value: Binding(
+                get: { clip.speed },
+                set: { value in model.updateClip(clip.id, live: true) { $0.speed = value } }),
+                   range: Clip.speedRange)
+            seconds("Hold last frame", value: Binding(
+                get: { clip.hold },
+                set: { value in model.updateClip(clip.id, live: true) { $0.hold = value } }),
+                   range: 0...5)
+            // Only meaningful where there is a cut before this clip.
+            if model.project.timeline.clips.first?.id != clip.id {
+                seconds("Dip to black at its cut", value: Binding(
+                    get: { clip.dipToBlack },
+                    set: { value in
+                        model.updateClip(clip.id, live: true) { $0.dipToBlack = value }
+                    }),
+                       range: 0...1.5)
+            }
+            Text("Hold keeps the last frame on screen — useful for pausing on a result while you "
+                 + "talk over it.")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+
         SectionHeader("Background")
         LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 5),
                   spacing: 6) {
@@ -68,6 +112,20 @@ struct CanvasInspector: View {
 
     private func slider(_ title: String, value: Binding<CGFloat>,
                         range: ClosedRange<CGFloat>) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+            Slider(value: value, in: range) { editing in
+                if editing { model.beginGesture() } else { model.endGesture() }
+            }
+        }
+    }
+
+    /// The same, for the timings — `Binding<CGFloat>` and `Binding<Double>` are not
+    /// interchangeable even though the values are.
+    private func seconds(_ title: String, value: Binding<Double>,
+                         range: ClosedRange<Double>) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(title)
                 .font(.system(size: Theme.Typography.caption))

--- a/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+/// The canvas tab: background, padding, radius, shadow.
+///
+/// Deliberately the same vocabulary as `BackgroundInspector` on the screenshot side, because it is
+/// the same model underneath — a person who has styled a screenshot already knows this panel.
+struct CanvasInspector: View {
+    @ObservedObject var model: StudioDocumentModel
+
+    private var shortSide: CGFloat {
+        min(model.project.canvasSize.width, model.project.canvasSize.height)
+    }
+
+    var body: some View {
+        SectionHeader("Background")
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 5),
+                  spacing: 6) {
+            ForEach(BackgroundCatalogue.entries) { entry in
+                Button {
+                    model.edit { $0.background.fill = .builtIn(id: entry.id) }
+                } label: {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(LinearGradient(colors: entry.mesh.colours.prefix(3).map {
+                            Color(nsColor: NSColor(cgColor: $0.cgColor) ?? .gray)
+                        }, startPoint: .topLeading, endPoint: .bottomTrailing))
+                        .aspectRatio(1, contentMode: .fit)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .strokeBorder(isSelected(entry.id)
+                                              ? Color.accentColor : .clear, lineWidth: 2)
+                        }
+                }
+                .buttonStyle(.plain)
+                .clickableCursor()
+                .help(entry.name)
+                .accessibilityLabel(entry.name)
+            }
+        }
+
+        SectionHeader("Shape")
+        slider("Padding", value: Binding(
+            get: { model.project.background.padding },
+            set: { value in model.editLive { $0.background.padding = value } }),
+               range: 0...(shortSide / 2))
+        slider("Corner radius", value: Binding(
+            get: { model.project.background.cornerRadius },
+            set: { value in model.editLive { $0.background.cornerRadius = value } }),
+               range: 0...(shortSide / 4))
+        slider("Inset", value: Binding(
+            get: { model.project.background.inset },
+            set: { value in model.editLive { $0.background.inset = value } }),
+               range: 0...(shortSide / 6))
+
+        Toggle("Shadow", isOn: Binding(
+            get: { model.project.background.shadow != nil },
+            set: { on in
+                model.edit { $0.background.shadow = on ? CaptureBackground.Shadow() : nil }
+            }))
+        .toggleStyle(.switch)
+        .controlSize(.small)
+    }
+
+    private func isSelected(_ id: String) -> Bool {
+        if case .builtIn(let current) = model.project.background.fill { return current == id }
+        return false
+    }
+
+    private func slider(_ title: String, value: Binding<CGFloat>,
+                        range: ClosedRange<CGFloat>) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+            Slider(value: value, in: range) { editing in
+                if editing { model.beginGesture() } else { model.endGesture() }
+            }
+        }
+    }
+}
+
+/// The cursor tab.
+struct CursorInspector: View {
+    @ObservedObject var model: StudioDocumentModel
+
+    var body: some View {
+        SectionHeader("Cursor")
+
+        Toggle("Hide the cursor", isOn: Binding(
+            get: { model.project.cursor.isHidden },
+            set: { value in model.edit { $0.cursor.isHidden = value } }))
+        .toggleStyle(.switch).controlSize(.small)
+
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Size").font(.system(size: Theme.Typography.caption)).foregroundStyle(.secondary)
+            Slider(value: Binding(
+                get: { model.project.cursor.size },
+                set: { value in model.editLive { $0.cursor.size = value } }),
+                   in: 0.5...3) { editing in
+                if editing { model.beginGesture() } else { model.endGesture() }
+            }
+        }
+
+        Picker("Smoothing", selection: Binding(
+            get: { model.project.cursor.smoothing },
+            set: { value in model.edit { $0.cursor.smoothing = value } })) {
+            ForEach(CursorSmoothing.allCases, id: \.self) { Text($0.title).tag($0) }
+        }
+
+        Picker("Click effect", selection: Binding(
+            get: { model.project.cursor.clickEffect },
+            set: { value in model.edit { $0.cursor.clickEffect = value } })) {
+            ForEach(ClickEffectStyle.allCases, id: \.self) { Text($0.title).tag($0) }
+        }
+
+        Toggle("Hide when it stops moving", isOn: Binding(
+            get: { model.project.cursor.hidesWhenIdle },
+            set: { value in model.edit { $0.cursor.hidesWhenIdle = value } }))
+        .toggleStyle(.switch).controlSize(.small)
+
+        SectionHeader("Zooms")
+        HStack {
+            Button("Re-detect") { model.redetectZooms() }
+            Spacer()
+            Text("\(model.project.zooms.count)")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+        }
+        // Says what the button will and will not touch, because a destructive-sounding action with
+        // no explanation is one people never press.
+        Text("Replaces the zooms Sarvkrit found. Ones you made or edited are left alone.")
+            .font(.system(size: Theme.Typography.caption))
+            .foregroundStyle(.secondary)
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// The canvas tab: background, padding, radius, shadow.
@@ -130,5 +131,233 @@ struct CursorInspector: View {
         Text("Replaces the zooms Sarvkrit found. Ones you made or edited are left alone.")
             .font(.system(size: Theme.Typography.caption))
             .foregroundStyle(.secondary)
+    }
+}
+
+/// Masks and highlights.
+struct MaskInspector: View {
+    @ObservedObject var model: StudioDocumentModel
+
+    var body: some View {
+        SectionHeader("Masks")
+        Button("Add one here") { model.addMaskAtPlayhead() }
+
+        if model.project.masks.isEmpty {
+            Text("Cover something you don't want in the recording — an API key, a customer name, "
+                 + "a sidebar.")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+        }
+
+        ForEach(model.project.masks) { mask in
+            VStack(alignment: .leading, spacing: Theme.Space.xs) {
+                Picker("", selection: Binding(
+                    get: { mask.mode },
+                    set: { value in model.setMaskMode(mask.id, value) })) {
+                    ForEach(StudioMask.Mode.allCases, id: \.self) { Text($0.title).tag($0) }
+                }
+                .labelsHidden()
+
+                // **Said, not implied.** A person choosing "Blur" over a password should be told
+                // that it comes back — the README makes this argument at length and the UI is
+                // where it has to land.
+                if let caveat = mask.mode.caveat {
+                    Label(caveat, systemImage: "exclamationmark.triangle")
+                        .font(.system(size: Theme.Typography.caption))
+                        .foregroundStyle(.orange)
+                }
+
+                HStack {
+                    Text(String(format: "%.1fs – %.1fs", mask.start, mask.end))
+                        .font(.system(size: Theme.Typography.caption))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button { model.removeMask(mask.id) } label: { Image(systemName: "trash") }
+                        .buttonStyle(.plain).clickableCursor()
+                        .accessibilityLabel("Remove this mask")
+                }
+            }
+            .padding(.vertical, Theme.Space.xs)
+            ModuleSeparator()
+        }
+    }
+}
+
+/// The camera.
+struct CameraInspector: View {
+    @ObservedObject var model: StudioDocumentModel
+
+    var body: some View {
+        SectionHeader("Camera")
+        Picker("Shape", selection: Binding(
+            get: { model.project.camera.shape },
+            set: { value in model.edit { $0.camera.shape = value } })) {
+            ForEach(CameraSettings.Shape.allCases, id: \.self) { Text($0.title).tag($0) }
+        }
+
+        Picker("While zoomed", selection: Binding(
+            get: { model.project.camera.sizeDuringZoom },
+            set: { value in model.edit { $0.camera.sizeDuringZoom = value } })) {
+            ForEach(CameraSettings.ZoomSizing.allCases, id: \.self) { Text($0.title).tag($0) }
+        }
+        // The default is the one people do not expect, so it says why.
+        Text("A zoom exists to show something. The camera getting smaller keeps it out of the way.")
+            .font(.system(size: Theme.Typography.caption))
+            .foregroundStyle(.secondary)
+
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Size").font(.system(size: Theme.Typography.caption)).foregroundStyle(.secondary)
+            Slider(value: Binding(
+                get: { model.project.camera.sizeFraction },
+                set: { value in model.editLive { $0.camera.sizeFraction = value } }),
+                   in: 0.1...0.4) { editing in
+                if editing { model.beginGesture() } else { model.endGesture() }
+            }
+        }
+
+        Toggle("Mirror", isOn: Binding(
+            get: { model.project.camera.mirrored },
+            set: { value in model.edit { $0.camera.mirrored = value } }))
+        .toggleStyle(.switch).controlSize(.small)
+    }
+}
+
+/// Captions, and the transcript that produces them.
+struct CaptionsInspector: View {
+    @ObservedObject var model: StudioDocumentModel
+    @State private var vocabulary = ""
+    @State private var isWorking = false
+    @State private var problem: String?
+
+    var body: some View {
+        SectionHeader("Captions")
+
+        if model.project.captions.isEmpty {
+            TextField("Words to expect", text: $vocabulary)
+                .textFieldStyle(.roundedBorder)
+            // Three lines of code, and the difference between "Sarvkrit" and "sav credit".
+            Text("Product names, library names, jargon — anything a recogniser would guess wrong.")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+
+            Button(isWorking ? "Working…" : "Write captions") { transcribe() }
+                .disabled(isWorking)
+
+            Text("Worked out on this Mac. Nothing is uploaded.")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+        } else {
+            Text("\(model.project.captions.count) lines")
+                .font(.system(size: Theme.Typography.body))
+            Toggle("Highlight word by word", isOn: Binding(
+                get: { model.project.captionStyle.highlight == .word },
+                set: { value in
+                    model.edit { $0.captionStyle.highlight = value ? .word : .none }
+                }))
+            .toggleStyle(.switch).controlSize(.small)
+            Button("Export subtitles…") { exportSubtitles() }
+        }
+
+        if let problem {
+            Label(problem, systemImage: "exclamationmark.triangle")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.orange)
+        }
+    }
+
+    private func transcribe() {
+        isWorking = true
+        problem = nil
+        let words = vocabulary.split(separator: ",").map {
+            $0.trimmingCharacters(in: .whitespaces)
+        }
+        Task {
+            do {
+                try await model.transcribe(vocabulary: words)
+            } catch Transcriber.TranscriptionError.onDeviceUnavailable(let locale) {
+                // Said plainly, and nothing is sent anywhere as a fallback. That is the whole
+                // point of choosing this API over one that would quietly succeed.
+                problem = "No offline model for \(locale). Sarvkrit won't upload your audio to "
+                    + "work around it."
+            } catch Transcriber.TranscriptionError.noAudio {
+                problem = "This recording has no microphone track."
+            } catch {
+                problem = "Couldn't write captions."
+            }
+            isWorking = false
+        }
+    }
+
+    private func exportSubtitles() {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "Captions.srt"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        let text = Transcriber.subtitles(model.project.captions, format: .srt)
+        try? text.write(to: url, atomically: true, encoding: .utf8)
+    }
+}
+
+/// Keystrokes, and the audio-derived edits.
+struct KeystrokesInspector: View {
+    @ObservedObject var model: StudioDocumentModel
+
+    var body: some View {
+        SectionHeader("Keystrokes")
+        Toggle("Show the keys I pressed", isOn: Binding(
+            get: { model.project.keystrokes.isEnabled },
+            set: { value in model.edit { $0.keystrokes.isEnabled = value } }))
+        .toggleStyle(.switch).controlSize(.small)
+
+        Toggle("Include single keys", isOn: Binding(
+            get: { model.project.keystrokes.showsBareKeys },
+            set: { value in model.edit { $0.keystrokes.showsBareKeys = value } }))
+        .toggleStyle(.switch).controlSize(.small)
+        Text("Off by default: ⌘C and ⌃⇧R are what a demo needs to show. Nothing typed into a "
+             + "password field was recorded either way.")
+            .font(.system(size: Theme.Typography.caption))
+            .foregroundStyle(.secondary)
+
+        SectionHeader("Tidy up")
+        let suggestions = model.typingSuggestions
+        if suggestions.isEmpty {
+            Text("No typing worth speeding up in this one.")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+        } else {
+            Button("Speed up \(suggestions.count) typing \(suggestions.count == 1 ? "part" : "parts")") {
+                model.applyAllTypingSuggestions()
+            }
+            Text("Watching someone type is boring at 1×. Suggested, not applied — undo works.")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+        }
+
+        Button("Remove silences") { model.removeSilencesFromMicrophone() }
+            .disabled(!FileManager.default.fileExists(atPath: model.bundle.microphoneURL.path))
+    }
+}
+
+/// Device frames.
+struct DeviceFrameInspector: View {
+    @ObservedObject var model: StudioDocumentModel
+
+    var body: some View {
+        SectionHeader("Device frame")
+        Picker("Frame", selection: Binding(
+            get: { model.project.deviceFrame.frameID ?? "" },
+            set: { value in
+                model.edit { $0.deviceFrame.frameID = value.isEmpty ? nil : value }
+            })) {
+            Text("None").tag("")
+            ForEach(DeviceFrame.all) { Text($0.name).tag($0.id) }
+        }
+
+        if let resolved = model.project.deviceFrame.resolved() {
+            Picker("Colour", selection: Binding(
+                get: { model.project.deviceFrame.colourwayID ?? resolved.colourway.id },
+                set: { value in model.edit { $0.deviceFrame.colourwayID = value } })) {
+                ForEach(resolved.frame.colourways) { Text($0.name).tag($0.id) }
+            }
+        }
     }
 }

--- a/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
@@ -207,6 +207,12 @@ struct MaskInspector: View {
                 .foregroundStyle(.secondary)
         }
 
+        if !model.project.masks.isEmpty {
+            Text("Drag a mask on the canvas to move it, or a corner to resize it.")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+        }
+
         ForEach(model.project.masks) { mask in
             VStack(alignment: .leading, spacing: Theme.Space.xs) {
                 Picker("", selection: Binding(
@@ -215,6 +221,12 @@ struct MaskInspector: View {
                     ForEach(StudioMask.Mode.allCases, id: \.self) { Text($0.title).tag($0) }
                 }
                 .labelsHidden()
+
+                // Typed rather than dragged, for the times a region has to land on an exact
+                // boundary. In the recording's own pixels, which is what the numbers mean.
+                if let box = mask.rects.first {
+                    box2x2(mask: mask, rect: box.rect)
+                }
 
                 // **Said, not implied.** A person choosing "Blur" over a password should be told
                 // that it comes back — the README makes this argument at length and the UI is
@@ -236,7 +248,50 @@ struct MaskInspector: View {
                 }
             }
             .padding(.vertical, Theme.Space.xs)
+            .background(mask.id == model.selectedMask
+                        ? Color.accentColor.opacity(0.08) : .clear)
+            // Selecting here puts the handles on the canvas, so the two views agree about which
+            // mask is being worked on.
+            .onTapGesture { model.selectedMask = mask.id }
             ModuleSeparator()
+        }
+    }
+
+    /// Position and size, in the recording's own pixels.
+    private func box2x2(mask: StudioMask, rect: CGRect) -> some View {
+        func field(_ label: String, _ value: CGFloat,
+                   _ apply: @escaping (CGFloat) -> CGRect) -> some View {
+            HStack(spacing: Theme.Space.xs) {
+                Text(label)
+                    .font(.system(size: Theme.Typography.caption))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 14, alignment: .leading)
+                TextField("", value: Binding<Double>(
+                    get: { Double(value.rounded()) },
+                    // A committed change rather than a live one: typing is not a drag, and each
+                    // field is one undo step.
+                    set: { model.updateMaskRect(mask.id, index: 0, to: apply(CGFloat($0))) }),
+                          format: .number.precision(.fractionLength(0)))
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: Theme.Typography.caption))
+            }
+        }
+
+        return VStack(spacing: Theme.Space.xs) {
+            HStack(spacing: Theme.Space.sm) {
+                field("X", rect.minX) { rect.offsetBy(dx: $0 - rect.minX, dy: 0) }
+                field("Y", rect.minY) { rect.offsetBy(dx: 0, dy: $0 - rect.minY) }
+            }
+            HStack(spacing: Theme.Space.sm) {
+                field("W", rect.width) {
+                    CGRect(x: rect.minX, y: rect.minY,
+                           width: max(SelectionHandles.minimumSide, $0), height: rect.height)
+                }
+                field("H", rect.height) {
+                    CGRect(x: rect.minX, y: rect.minY, width: rect.width,
+                           height: max(SelectionHandles.minimumSide, $0))
+                }
+            }
         }
     }
 }

--- a/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioInspectors.swift
@@ -183,6 +183,109 @@ struct MaskInspector: View {
     }
 }
 
+/// Text put on the video by hand.
+///
+/// **Every measurement is a fraction of the canvas**, so a title keeps its framing when the aspect
+/// or the export size changes — the same reason the camera and the captions are written that way.
+struct TextInspector: View {
+    @ObservedObject var model: StudioDocumentModel
+
+    private var selected: TextOverlay? {
+        model.project.textOverlays.first { $0.id == model.selectedText }
+            ?? model.project.textOverlays.first { $0.covers(model.sourceTime) }
+    }
+
+    var body: some View {
+        Button {
+            model.addTextAtPlayhead()
+        } label: {
+            Label("Add Text Here", systemImage: "textformat")
+        }
+
+        if model.project.textOverlays.isEmpty {
+            Text("Text sits on top of everything, including the camera. Drag it on the canvas to "
+                 + "move it.")
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+
+        if let overlay = selected {
+            SectionHeader("The Selected Line")
+            TextField("Text", text: Binding(
+                get: { overlay.text },
+                set: { value in model.updateText(overlay.id) { $0.text = value } }),
+                      axis: .vertical)
+                .lineLimit(1...4)
+
+            slider("Size", value: Binding(
+                get: { overlay.sizeFraction },
+                set: { value in model.updateTextLive(overlay.id) { $0.sizeFraction = value } }),
+                   range: 0.02...0.18)
+
+            slider("Width", value: Binding(
+                get: { overlay.maxWidthFraction },
+                set: { value in
+                    model.updateTextLive(overlay.id) { $0.maxWidthFraction = value }
+                }),
+                   range: 0.2...1)
+
+            slider("Fade", value: Binding(
+                get: { overlay.fadeSeconds },
+                set: { value in model.updateTextLive(overlay.id) { $0.fadeSeconds = value } }),
+                   range: 0...1)
+
+            Toggle("Bold", isOn: Binding(
+                get: { overlay.isBold },
+                set: { value in model.updateText(overlay.id) { $0.isBold = value } }))
+
+            Picker("Typeface", selection: Binding(
+                get: { overlay.typeface },
+                set: { value in model.updateText(overlay.id) { $0.typeface = value } })) {
+                Text("Rounded").tag(TextElement.Typeface.rounded)
+                Text("System").tag(TextElement.Typeface.standard)
+                Text("Monospaced").tag(TextElement.Typeface.monospaced)
+            }
+
+            // A box or a halo, not both: a halo exists for text that cannot wear a box, and
+            // wearing both looks like a mistake.
+            Toggle("Background box", isOn: Binding(
+                get: { overlay.background != nil },
+                set: { on in
+                    model.updateText(overlay.id) {
+                        $0.background = on ? RGBAColour(r: 0, g: 0, b: 0, a: 0.55) : nil
+                        if on { $0.haloColour = nil }
+                    }
+                }))
+
+            Toggle("Halo", isOn: Binding(
+                get: { overlay.haloColour != nil },
+                set: { on in
+                    model.updateText(overlay.id) {
+                        $0.haloColour = on ? RGBAColour(r: 0, g: 0, b: 0, a: 0.85) : nil
+                        if on { $0.background = nil }
+                    }
+                }))
+
+            Button(role: .destructive) {
+                model.removeText(overlay.id)
+            } label: {
+                Label("Remove This Line", systemImage: "trash")
+            }
+        }
+    }
+
+    private func slider(_ title: String, value: Binding<Double>,
+                        range: ClosedRange<Double>) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: Theme.Typography.caption))
+                .foregroundStyle(.secondary)
+            Slider(value: value, in: range)
+        }
+    }
+}
+
 /// The camera.
 struct CameraInspector: View {
     @ObservedObject var model: StudioDocumentModel

--- a/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
@@ -14,6 +14,7 @@ final class StudioPreviewView: NSView {
     private let cache = StudioRenderer.Cache()
     private var observation: NSObjectProtocol?
     private var lastToken = -1
+    private var lastRevision = -1
     private var pollTimer: Timer?
     /// Which line of text is being dragged, and where it was grabbed within its own box.
     private var textDrag: (id: TextOverlay.ID, grabOffset: CGPoint)?
@@ -43,10 +44,13 @@ final class StudioPreviewView: NSView {
         let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {
                 guard let self else { return }
-                guard self.model.player.frameToken != self.lastToken || self.needsDisplay else {
-                    return
-                }
+                // The project as well as the frame: an edit made while paused changes the
+                // composite without changing the decoded picture, and nothing else was noticing.
+                guard self.model.player.frameToken != self.lastToken
+                    || self.model.revision != self.lastRevision
+                    || self.needsDisplay else { return }
                 self.lastToken = self.model.player.frameToken
+                self.lastRevision = self.model.revision
                 self.needsDisplay = true
             }
         }

--- a/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
@@ -153,7 +153,8 @@ final class StudioPreviewView: NSView {
                             in: context,
                             cache: cache,
                             clipSource: model.currentClipSource,
-                            outputTime: model.playhead)
+                            outputTime: model.playhead,
+                            cameraStart: model.cameraStartOffset)
         context.restoreGState()
     }
 }

--- a/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
@@ -30,6 +30,12 @@ final class StudioPreviewView: NSView {
         super.viewDidMoveToWindow()
         pollTimer?.invalidate()
         guard window != nil else { return }
+        // **Restarted here, not only at construction.** The player is built before this window
+        // exists, and its display link comes from `NSScreen.main` — the screen with the key window,
+        // which at that moment is somebody else's or nothing at all. Asking again now that we are
+        // on screen makes construction order stop mattering, and moves the clock to whichever
+        // display the editor actually opened on.
+        model.player.startClock()
         // Redrawn from the player's frame token rather than from a timer of its own, so the
         // picture and the composite can never disagree about which moment they are showing.
         let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
@@ -70,7 +76,10 @@ final class StudioPreviewView: NSView {
         StudioRenderer.draw(project: model.project,
                             sourceTime: model.sourceTime,
                             events: model.events,
-                            sources: FrameSources(screen: model.player.decoded),
+                            sources: FrameSources(screen: model.player.decoded,
+                                                  camera: model.player.decodedCamera,
+                                                  wallpaper: FrameSources.wallpaper(
+                                                      for: model.project)),
                             canvas: canvas,
                             imageRect: imageRect,
                             in: context,

--- a/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
@@ -22,7 +22,15 @@ final class StudioPreviewView: NSView {
         case text(id: TextOverlay.ID, grabOffset: CGPoint)
         /// Where the box was grabbed, relative to its own origin, in canvas points.
         case maskMove(id: StudioMask.ID, index: Int, grabOffset: CGPoint)
-        case maskResize(id: StudioMask.ID, index: Int, handle: SelectionHandles.Handle)
+        /// `anchor` is the box as it was when the handle was grabbed, in canvas points.
+        ///
+        /// **Not re-read each event.** `SelectionHandles.resize` is a function of the rect the
+        /// handle was grabbed on; feed it its own output and the rect flips when the pointer
+        /// crosses the opposite corner, after which every event measures from the flipped edge —
+        /// the width becomes the distance the mouse moved since the last event rather than the
+        /// distance from the anchor, and the box collapses under a hand still dragging outwards.
+        case maskResize(id: StudioMask.ID, index: Int, handle: SelectionHandles.Handle,
+                        anchor: CGRect)
     }
 
     private var drag: Drag?
@@ -129,7 +137,7 @@ final class StudioPreviewView: NSView {
         if let box = selectedMaskBox(), let bounds = viewRect(box.rect),
            let handle = SelectionHandles.handle(at: point, bounds: bounds) {
             model.beginGesture()
-            drag = .maskResize(id: box.id, index: box.index, handle: handle)
+            drag = .maskResize(id: box.id, index: box.index, handle: handle, anchor: box.rect)
             return
         }
 
@@ -185,13 +193,11 @@ final class StudioPreviewView: NSView {
                                width: box.rect.width, height: box.rect.height)
             writeMask(id: id, index: index, canvasRect: moved)
 
-        case let .maskResize(id, index, handle):
-            guard let box = maskBoxes().first(where: { $0.id == id && $0.index == index })
-            else { return }
+        case let .maskResize(id, index, handle, anchor):
             // The floor is a physical size, so it is converted out of view points rather than
             // left as a canvas number that means something different at every window size.
             let resized = SelectionHandles.resize(
-                box.rect, handle: handle, to: inCanvas,
+                anchor, handle: handle, to: inCanvas,
                 constrainAspect: event.modifierFlags.contains(.shift),
                 minimumSide: SelectionHandles.minimumSide / placement.scale)
             writeMask(id: id, index: index, canvasRect: resized)

--- a/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
@@ -1,0 +1,151 @@
+import AVFoundation
+import VideoToolbox
+import AppKit
+import CoreGraphics
+import QuartzCore
+
+/// The live canvas.
+///
+/// **`AVPlayer` supplies the frames and the clock; `StudioRenderer` composites them.** The player's
+/// own layer is never displayed — an `AVPlayerItemVideoOutput` is attached and a display link pulls
+/// `copyPixelBuffer(forItemTime:)` each tick, which is exactly the shape that header describes.
+///
+/// The reason it is not an `AVAssetReader`: **a reader cannot seek.** A reader-based preview would
+/// have to be torn down and rebuilt on every scrub, decoding from the nearest keyframe each time —
+/// and scrubbing is what a timeline is made of. `AVAssetReader` is still right for the export,
+/// which is strictly sequential.
+@MainActor
+final class StudioPreviewView: NSView {
+
+    private let model: StudioDocumentModel
+    private let player: AVPlayer
+    private let output: AVPlayerItemVideoOutput
+    private var displayLink: CADisplayLink?
+    private let cache = StudioRenderer.Cache()
+    private var lastDecoded: CGImage?
+
+    /// Rendering at full canvas resolution for a preview is wasted work on a 4K recording, and the
+    /// user can choose to spend even less. Never applied silently — the export is unaffected and
+    /// the UI says when it is on.
+    var qualityFraction: CGFloat = 1
+
+    init(model: StudioDocumentModel) {
+        self.model = model
+        let item = AVPlayerItem(url: model.bundle.screenURL)
+        self.output = AVPlayerItemVideoOutput(pixelBufferAttributes: [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        ])
+        item.add(output)
+        self.player = AVPlayer(playerItem: item)
+        player.actionAtItemEnd = .pause
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.cgColor
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not from a nib") }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil else { return stopLink() }
+        startLink()
+    }
+
+    deinit { displayLink?.invalidate() }
+
+    private func startLink() {
+        stopLink()
+        // NSScreen's display link, macOS 14+. CVDisplayLink is deprecated from 15 and this is the
+        // supported replacement at our deployment target.
+        let link = (window?.screen ?? NSScreen.main)?.displayLink(target: self,
+                                                                  selector: #selector(tick))
+        link?.add(to: .main, forMode: .common)
+        displayLink = link
+    }
+
+    private func stopLink() {
+        displayLink?.invalidate()
+        displayLink = nil
+    }
+
+    // MARK: - Playback
+
+    func play() {
+        seekPlayer(to: model.sourceTime)
+        player.rate = 1
+        model.isPlaying = true
+    }
+
+    func pause() {
+        player.rate = 0
+        model.isPlaying = false
+    }
+
+    func setRate(_ rate: Float) {
+        player.rate = rate
+        model.isPlaying = rate != 0
+    }
+
+    func scrub(to output: TimeInterval) {
+        model.playhead = min(max(0, output), max(0, model.duration))
+        seekPlayer(to: model.sourceTime)
+        needsDisplay = true
+    }
+
+    private func seekPlayer(to source: TimeInterval) {
+        player.seek(to: CMTime(seconds: source, preferredTimescale: 600),
+                    toleranceBefore: .zero, toleranceAfter: .zero)
+    }
+
+    @objc private func tick() {
+        if model.isPlaying {
+            model.playhead = min(model.playhead + 1.0 / 60.0, model.duration)
+            if model.playhead >= model.duration { pause() }
+            seekPlayer(to: model.sourceTime)
+        }
+
+        let itemTime = output.itemTime(forHostTime: CACurrentMediaTime())
+        if output.hasNewPixelBuffer(forItemTime: itemTime),
+           let buffer = output.copyPixelBuffer(forItemTime: itemTime,
+                                               itemTimeForDisplay: nil) {
+            var image: CGImage?
+            VTCreateCGImageFromCVPixelBuffer(buffer, options: nil, imageOut: &image)
+            if let image { lastDecoded = image }
+        }
+        needsDisplay = true
+    }
+
+    // MARK: - Drawing
+
+    override var isFlipped: Bool { true }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+        context.setFillColor(NSColor.black.cgColor)
+        context.fill(bounds)
+
+        let (canvas, imageRect) = StudioRenderer.layout(for: model.project)
+        guard canvas.width > 0, canvas.height > 0 else { return }
+
+        // Fit, never fill: a preview that crops is a preview that lies about the framing.
+        let scale = min(bounds.width / canvas.width, bounds.height / canvas.height)
+        let drawn = CGSize(width: canvas.width * scale, height: canvas.height * scale)
+        let origin = CGPoint(x: (bounds.width - drawn.width) / 2,
+                             y: (bounds.height - drawn.height) / 2)
+
+        context.saveGState()
+        context.translateBy(x: origin.x, y: origin.y)
+        context.scaleBy(x: scale, y: scale)
+        // The renderer draws top-left down; this view is flipped, so the two agree already.
+        StudioRenderer.draw(project: model.project,
+                            sourceTime: model.sourceTime,
+                            events: model.events,
+                            sources: FrameSources(screen: lastDecoded),
+                            canvas: canvas,
+                            imageRect: imageRect,
+                            in: context,
+                            cache: cache)
+        context.restoreGState()
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
@@ -15,6 +15,8 @@ final class StudioPreviewView: NSView {
     private var observation: NSObjectProtocol?
     private var lastToken = -1
     private var pollTimer: Timer?
+    /// Which line of text is being dragged, and where it was grabbed within its own box.
+    private var textDrag: (id: TextOverlay.ID, grabOffset: CGPoint)?
 
     init(model: StudioDocumentModel) {
         self.model = model
@@ -55,6 +57,71 @@ final class StudioPreviewView: NSView {
     deinit { pollTimer?.invalidate() }
 
     override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+
+    // MARK: - Placing text by hand
+
+    /// The canvas's geometry inside this view: where it is drawn and how much it is scaled by.
+    ///
+    /// Computed the same way `draw(_:)` does, so a drag lands exactly where the picture is rather
+    /// than on a second guess at the same arithmetic.
+    private var placement: (canvas: CGSize, origin: CGPoint, scale: CGFloat)? {
+        let (canvas, _) = StudioRenderer.layout(for: model.project)
+        guard canvas.width > 0, canvas.height > 0 else { return nil }
+        let scale = min(bounds.width / canvas.width, bounds.height / canvas.height)
+        guard scale > 0 else { return nil }
+        let drawn = CGSize(width: canvas.width * scale, height: canvas.height * scale)
+        return (canvas, CGPoint(x: (bounds.width - drawn.width) / 2,
+                                y: (bounds.height - drawn.height) / 2), scale)
+    }
+
+    private func canvasPoint(_ point: CGPoint) -> CGPoint? {
+        guard let placement else { return nil }
+        return CGPoint(x: (point.x - placement.origin.x) / placement.scale,
+                       y: (point.y - placement.origin.y) / placement.scale)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        guard let placement, let inCanvas = canvasPoint(point) else { return }
+
+        // Topmost first, so overlapping lines behave the way the picture looks.
+        let boxes = StudioRenderer.textBoxes(project: model.project,
+                                             sourceTime: model.sourceTime,
+                                             canvas: placement.canvas)
+        guard let hit = boxes.reversed().first(where: { $0.rect.contains(inCanvas) }) else {
+            model.selectedText = nil
+            needsDisplay = true
+            return
+        }
+
+        model.selectedText = hit.id
+        model.inspector = .text
+        model.beginGesture()
+        textDrag = (hit.id, CGPoint(x: inCanvas.x - hit.rect.midX,
+                                    y: inCanvas.y - hit.rect.midY))
+        needsDisplay = true
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let textDrag, let placement,
+              let inCanvas = canvasPoint(convert(event.locationInWindow, from: nil))
+        else { return }
+
+        // Stored as a fraction of the canvas, so the line keeps its framing at any export size.
+        let centre = CGPoint(x: inCanvas.x - textDrag.grabOffset.x,
+                             y: inCanvas.y - textDrag.grabOffset.y)
+        let unit = CGPoint(x: min(1, max(0, centre.x / placement.canvas.width)),
+                           y: min(1, max(0, centre.y / placement.canvas.height)))
+        model.updateTextLive(textDrag.id) { $0.origin = unit }
+        needsDisplay = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard textDrag != nil else { return }
+        textDrag = nil
+        model.endGesture()
+    }
 
     override func draw(_ dirtyRect: NSRect) {
         guard let context = NSGraphicsContext.current?.cgContext else { return }

--- a/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
@@ -16,8 +16,16 @@ final class StudioPreviewView: NSView {
     private var lastToken = -1
     private var lastRevision = -1
     private var pollTimer: Timer?
-    /// Which line of text is being dragged, and where it was grabbed within its own box.
-    private var textDrag: (id: TextOverlay.ID, grabOffset: CGPoint)?
+    /// What the pointer is currently doing to the picture.
+    private enum Drag {
+        /// Where the box was grabbed, relative to its own centre.
+        case text(id: TextOverlay.ID, grabOffset: CGPoint)
+        /// Where the box was grabbed, relative to its own origin, in canvas points.
+        case maskMove(id: StudioMask.ID, index: Int, grabOffset: CGPoint)
+        case maskResize(id: StudioMask.ID, index: Int, handle: SelectionHandles.Handle)
+    }
+
+    private var drag: Drag?
 
     init(model: StudioDocumentModel) {
         self.model = model
@@ -52,6 +60,10 @@ final class StudioPreviewView: NSView {
                 self.lastToken = self.model.player.frameToken
                 self.lastRevision = self.model.revision
                 self.needsDisplay = true
+                // The handles move with the picture, and cursor rects are not rebuilt by a
+                // redraw — without this the resize cursors stay wherever they were first laid
+                // down, pointing at nothing.
+                self.window?.invalidateCursorRects(for: self)
             }
         }
         RunLoop.main.add(timer, forMode: .common)
@@ -85,46 +97,141 @@ final class StudioPreviewView: NSView {
                        y: (point.y - placement.origin.y) / placement.scale)
     }
 
+    /// Where each visible mask rectangle is, in canvas points — the renderer's own answer.
+    private func maskBoxes() -> [(id: StudioMask.ID, index: Int, rect: CGRect)] {
+        let (_, imageRect) = StudioRenderer.layout(for: model.project)
+        return StudioRenderer.maskBoxes(project: model.project, sourceTime: model.sourceTime,
+                                        events: model.events, imageRect: imageRect,
+                                        clipSource: model.currentClipSource)
+    }
+
+    private func viewRect(_ rect: CGRect) -> CGRect? {
+        guard let placement else { return nil }
+        return CGRect(x: placement.origin.x + rect.minX * placement.scale,
+                      y: placement.origin.y + rect.minY * placement.scale,
+                      width: rect.width * placement.scale,
+                      height: rect.height * placement.scale)
+    }
+
+    /// The box the selected mask's handles belong to, if it is on screen at this moment.
+    private func selectedMaskBox() -> (id: StudioMask.ID, index: Int, rect: CGRect)? {
+        guard let selected = model.selectedMask else { return nil }
+        return maskBoxes().first { $0.id == selected }
+    }
+
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
         guard let placement, let inCanvas = canvasPoint(point) else { return }
 
-        // Topmost first, so overlapping lines behave the way the picture looks.
+        // **Handles first, and before text.** They sit on and just outside the edge of a box, so
+        // anything else winning there would make a corner ungrabbable — and a resize you cannot
+        // start is the report this is answering.
+        if let box = selectedMaskBox(), let bounds = viewRect(box.rect),
+           let handle = SelectionHandles.handle(at: point, bounds: bounds) {
+            model.beginGesture()
+            drag = .maskResize(id: box.id, index: box.index, handle: handle)
+            return
+        }
+
+        // Topmost first, so overlapping lines behave the way the picture looks. Text is drawn
+        // above the masks, so it is asked first here too.
         let boxes = StudioRenderer.textBoxes(project: model.project,
                                              sourceTime: model.sourceTime,
                                              canvas: placement.canvas)
-        guard let hit = boxes.reversed().first(where: { $0.rect.contains(inCanvas) }) else {
-            model.selectedText = nil
+        if let hit = boxes.reversed().first(where: { $0.rect.contains(inCanvas) }) {
+            model.selectedText = hit.id
+            model.selectedMask = nil
+            model.inspector = .text
+            model.beginGesture()
+            drag = .text(id: hit.id, grabOffset: CGPoint(x: inCanvas.x - hit.rect.midX,
+                                                         y: inCanvas.y - hit.rect.midY))
             needsDisplay = true
             return
         }
 
-        model.selectedText = hit.id
-        model.inspector = .text
-        model.beginGesture()
-        textDrag = (hit.id, CGPoint(x: inCanvas.x - hit.rect.midX,
-                                    y: inCanvas.y - hit.rect.midY))
+        if let hit = maskBoxes().reversed().first(where: { $0.rect.contains(inCanvas) }) {
+            model.selectedMask = hit.id
+            model.selectedText = nil
+            model.inspector = .masks
+            model.beginGesture()
+            drag = .maskMove(id: hit.id, index: hit.index,
+                             grabOffset: CGPoint(x: inCanvas.x - hit.rect.minX,
+                                                 y: inCanvas.y - hit.rect.minY))
+            needsDisplay = true
+            return
+        }
+
+        model.selectedText = nil
+        model.selectedMask = nil
         needsDisplay = true
     }
 
     override func mouseDragged(with event: NSEvent) {
-        guard let textDrag, let placement,
-              let inCanvas = canvasPoint(convert(event.locationInWindow, from: nil))
-        else { return }
+        let point = convert(event.locationInWindow, from: nil)
+        guard let drag, let placement, let inCanvas = canvasPoint(point) else { return }
 
-        // Stored as a fraction of the canvas, so the line keeps its framing at any export size.
-        let centre = CGPoint(x: inCanvas.x - textDrag.grabOffset.x,
-                             y: inCanvas.y - textDrag.grabOffset.y)
-        let unit = CGPoint(x: min(1, max(0, centre.x / placement.canvas.width)),
-                           y: min(1, max(0, centre.y / placement.canvas.height)))
-        model.updateTextLive(textDrag.id) { $0.origin = unit }
+        switch drag {
+        case let .text(id, grabOffset):
+            // Stored as a fraction of the canvas, so the line keeps its framing at any export size.
+            let centre = CGPoint(x: inCanvas.x - grabOffset.x, y: inCanvas.y - grabOffset.y)
+            let unit = CGPoint(x: min(1, max(0, centre.x / placement.canvas.width)),
+                               y: min(1, max(0, centre.y / placement.canvas.height)))
+            model.updateTextLive(id) { $0.origin = unit }
+
+        case let .maskMove(id, index, grabOffset):
+            guard let box = maskBoxes().first(where: { $0.id == id && $0.index == index })
+            else { return }
+            let moved = CGRect(x: inCanvas.x - grabOffset.x, y: inCanvas.y - grabOffset.y,
+                               width: box.rect.width, height: box.rect.height)
+            writeMask(id: id, index: index, canvasRect: moved)
+
+        case let .maskResize(id, index, handle):
+            guard let box = maskBoxes().first(where: { $0.id == id && $0.index == index })
+            else { return }
+            // The floor is a physical size, so it is converted out of view points rather than
+            // left as a canvas number that means something different at every window size.
+            let resized = SelectionHandles.resize(
+                box.rect, handle: handle, to: inCanvas,
+                constrainAspect: event.modifierFlags.contains(.shift),
+                minimumSide: SelectionHandles.minimumSide / placement.scale)
+            writeMask(id: id, index: index, canvasRect: resized)
+        }
         needsDisplay = true
     }
 
+    /// A canvas rect back into the project, in the recording's own pixels.
+    private func writeMask(id: StudioMask.ID, index: Int, canvasRect: CGRect) {
+        let (_, imageRect) = StudioRenderer.layout(for: model.project)
+        let geometry = StudioRenderer.screenGeometry(
+            project: model.project, sourceTime: model.sourceTime, events: model.events,
+            imageRect: imageRect, clipSource: model.currentClipSource)
+        guard let source = StudioRenderer.sourceRect(canvasRect, project: model.project,
+                                                     transform: geometry.transform,
+                                                     imageRect: geometry.screenRect)
+        else { return }
+        model.updateMaskRectLive(id, index: index, to: source)
+    }
+
     override func mouseUp(with event: NSEvent) {
-        guard textDrag != nil else { return }
-        textDrag = nil
+        guard drag != nil else { return }
+        drag = nil
         model.endGesture()
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        guard let box = selectedMaskBox(), let bounds = viewRect(box.rect) else { return }
+        for (handle, rect) in SelectionHandles.rects(for: bounds) {
+            addCursorRect(rect, cursor: Self.cursor(for: handle))
+        }
+    }
+
+    private static func cursor(for handle: SelectionHandles.Handle) -> NSCursor {
+        switch handle {
+        case .left, .right: return .resizeLeftRight
+        case .top, .bottom: return .resizeUpDown
+        default: return .crosshair
+        }
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -155,6 +262,30 @@ final class StudioPreviewView: NSView {
                             clipSource: model.currentClipSource,
                             outputTime: model.playhead,
                             cameraStart: model.cameraStartOffset)
+        context.restoreGState()
+
+        drawSelectionHandles(in: context)
+    }
+
+    /// The selected mask's outline and its eight grab points.
+    ///
+    /// **Drawn outside the scaled context, in view points.** A handle sized in canvas points would
+    /// be a huge target on a small window and a 2pt one on a large export canvas; the physical
+    /// size is what the hand cares about, which is the rule `SelectionHandles` is built around.
+    private func drawSelectionHandles(in context: CGContext) {
+        guard let box = selectedMaskBox(), let bounds = viewRect(box.rect) else { return }
+
+        context.saveGState()
+        context.setStrokeColor(NSColor.controlAccentColor.cgColor)
+        context.setLineWidth(1)
+        context.stroke(bounds.insetBy(dx: -0.5, dy: -0.5))
+
+        for rect in SelectionHandles.rects(for: bounds).values {
+            context.setFillColor(NSColor.white.cgColor)
+            context.fillEllipse(in: rect)
+            context.setStrokeColor(NSColor.controlAccentColor.cgColor)
+            context.strokeEllipse(in: rect.insetBy(dx: 0.5, dy: 0.5))
+        }
         context.restoreGState()
     }
 }

--- a/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
@@ -80,7 +80,8 @@ final class StudioPreviewView: NSView {
                             canvas: canvas,
                             imageRect: imageRect,
                             in: context,
-                            cache: cache)
+                            cache: cache,
+                            clipSource: model.currentClipSource)
         context.restoreGState()
     }
 }

--- a/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
@@ -152,7 +152,8 @@ final class StudioPreviewView: NSView {
                             imageRect: imageRect,
                             in: context,
                             cache: cache,
-                            clipSource: model.currentClipSource)
+                            clipSource: model.currentClipSource,
+                            outputTime: model.playhead)
         context.restoreGState()
     }
 }

--- a/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
@@ -1,43 +1,23 @@
-import AVFoundation
-import VideoToolbox
 import AppKit
 import CoreGraphics
-import QuartzCore
 
 /// The live canvas.
 ///
-/// **`AVPlayer` supplies the frames and the clock; `StudioRenderer` composites them.** The player's
-/// own layer is never displayed — an `AVPlayerItemVideoOutput` is attached and a display link pulls
-/// `copyPixelBuffer(forItemTime:)` each tick, which is exactly the shape that header describes.
-///
-/// The reason it is not an `AVAssetReader`: **a reader cannot seek.** A reader-based preview would
-/// have to be torn down and rebuilt on every scrub, decoding from the nearest keyframe each time —
-/// and scrubbing is what a timeline is made of. `AVAssetReader` is still right for the export,
-/// which is strictly sequential.
+/// **A renderer and nothing else.** Playback, seeking and frame decoding all live in
+/// `StudioPlayer`, which the model owns — the previous version created the player inside this view
+/// and left the window controller walking the hosting hierarchy to find it, which returned nil and
+/// silently killed every transport control.
 @MainActor
 final class StudioPreviewView: NSView {
 
     private let model: StudioDocumentModel
-    private let player: AVPlayer
-    private let output: AVPlayerItemVideoOutput
-    private var displayLink: CADisplayLink?
     private let cache = StudioRenderer.Cache()
-    private var lastDecoded: CGImage?
-
-    /// Rendering at full canvas resolution for a preview is wasted work on a 4K recording, and the
-    /// user can choose to spend even less. Never applied silently — the export is unaffected and
-    /// the UI says when it is on.
-    var qualityFraction: CGFloat = 1
+    private var observation: NSObjectProtocol?
+    private var lastToken = -1
+    private var pollTimer: Timer?
 
     init(model: StudioDocumentModel) {
         self.model = model
-        let item = AVPlayerItem(url: model.bundle.screenURL)
-        self.output = AVPlayerItemVideoOutput(pixelBufferAttributes: [
-            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
-        ])
-        item.add(output)
-        self.player = AVPlayer(playerItem: item)
-        player.actionAtItemEnd = .pause
         super.init(frame: .zero)
         wantsLayer = true
         layer?.backgroundColor = NSColor.black.cgColor
@@ -48,75 +28,25 @@ final class StudioPreviewView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard window != nil else { return stopLink() }
-        startLink()
-    }
-
-    deinit { displayLink?.invalidate() }
-
-    private func startLink() {
-        stopLink()
-        // NSScreen's display link, macOS 14+. CVDisplayLink is deprecated from 15 and this is the
-        // supported replacement at our deployment target.
-        let link = (window?.screen ?? NSScreen.main)?.displayLink(target: self,
-                                                                  selector: #selector(tick))
-        link?.add(to: .main, forMode: .common)
-        displayLink = link
-    }
-
-    private func stopLink() {
-        displayLink?.invalidate()
-        displayLink = nil
-    }
-
-    // MARK: - Playback
-
-    func play() {
-        seekPlayer(to: model.sourceTime)
-        player.rate = 1
-        model.isPlaying = true
-    }
-
-    func pause() {
-        player.rate = 0
-        model.isPlaying = false
-    }
-
-    func setRate(_ rate: Float) {
-        player.rate = rate
-        model.isPlaying = rate != 0
-    }
-
-    func scrub(to output: TimeInterval) {
-        model.playhead = min(max(0, output), max(0, model.duration))
-        seekPlayer(to: model.sourceTime)
-        needsDisplay = true
-    }
-
-    private func seekPlayer(to source: TimeInterval) {
-        player.seek(to: CMTime(seconds: source, preferredTimescale: 600),
-                    toleranceBefore: .zero, toleranceAfter: .zero)
-    }
-
-    @objc private func tick() {
-        if model.isPlaying {
-            model.playhead = min(model.playhead + 1.0 / 60.0, model.duration)
-            if model.playhead >= model.duration { pause() }
-            seekPlayer(to: model.sourceTime)
+        pollTimer?.invalidate()
+        guard window != nil else { return }
+        // Redrawn from the player's frame token rather than from a timer of its own, so the
+        // picture and the composite can never disagree about which moment they are showing.
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                guard self.model.player.frameToken != self.lastToken || self.needsDisplay else {
+                    return
+                }
+                self.lastToken = self.model.player.frameToken
+                self.needsDisplay = true
+            }
         }
-
-        let itemTime = output.itemTime(forHostTime: CACurrentMediaTime())
-        if output.hasNewPixelBuffer(forItemTime: itemTime),
-           let buffer = output.copyPixelBuffer(forItemTime: itemTime,
-                                               itemTimeForDisplay: nil) {
-            var image: CGImage?
-            VTCreateCGImageFromCVPixelBuffer(buffer, options: nil, imageOut: &image)
-            if let image { lastDecoded = image }
-        }
-        needsDisplay = true
+        RunLoop.main.add(timer, forMode: .common)
+        pollTimer = timer
     }
 
-    // MARK: - Drawing
+    deinit { pollTimer?.invalidate() }
 
     override var isFlipped: Bool { true }
 
@@ -137,11 +67,10 @@ final class StudioPreviewView: NSView {
         context.saveGState()
         context.translateBy(x: origin.x, y: origin.y)
         context.scaleBy(x: scale, y: scale)
-        // The renderer draws top-left down; this view is flipped, so the two agree already.
         StudioRenderer.draw(project: model.project,
                             sourceTime: model.sourceTime,
                             events: model.events,
-                            sources: FrameSources(screen: lastDecoded),
+                            sources: FrameSources(screen: model.player.decoded),
                             canvas: canvas,
                             imageRect: imageRect,
                             in: context,

--- a/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioPreviewView.swift
@@ -76,10 +76,7 @@ final class StudioPreviewView: NSView {
         StudioRenderer.draw(project: model.project,
                             sourceTime: model.sourceTime,
                             events: model.events,
-                            sources: FrameSources(screen: model.player.decoded,
-                                                  camera: model.player.decodedCamera,
-                                                  wallpaper: FrameSources.wallpaper(
-                                                      for: model.project)),
+                            sources: model.frameSources,
                             canvas: canvas,
                             imageRect: imageRect,
                             in: context,

--- a/Sources/Sarvkrit/UI/Studio/StudioShortcutsSheet.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioShortcutsSheet.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// What ⌘/ shows.
+///
+/// **⌘/ was routed to `break`.** So the editor's keyboard shortcuts — including the only way to add
+/// a zoom by hand short of an unlabelled glyph in the transport bar — had no way of being found, and
+/// were reported as not existing. Fair: a shortcut nobody can find does not exist.
+///
+/// The list itself lives in `StudioShortcuts` as data, and a test checks every entry against
+/// `StudioKeyRouting`, so this can never promise a key that does nothing.
+struct StudioShortcutsSheet: View {
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Keyboard Shortcuts")
+                    .font(.system(size: Theme.Typography.title, weight: .semibold))
+                Spacer()
+                Button("Done", action: onClose)
+                    .keyboardShortcut(.defaultAction)
+            }
+            .padding(16)
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    ForEach(StudioShortcuts.groups) { group in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(group.name.uppercased())
+                                .font(.system(size: Theme.Typography.caption, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                            ForEach(group.entries) { entry in
+                                row(entry)
+                            }
+                        }
+                    }
+
+                    // Said here because the timeline is where people look for it and did not find
+                    // it: clicks, pointer highlights, blurs and the camera are all placed from the
+                    // timeline's own menu.
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("RIGHT-CLICK THE TIMELINE")
+                            .font(.system(size: Theme.Typography.caption, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                        Text("Everything that happens at a moment — a zoom, a click, a pointer "
+                             + "highlight, a blur, the camera going full-frame — is placed from "
+                             + "there, at the point you clicked.")
+                            .font(.system(size: Theme.Typography.caption))
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .padding(16)
+            }
+        }
+        .frame(width: 460, height: 520)
+    }
+
+    private func row(_ entry: StudioShortcuts.Entry) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text(entry.keyLabel)
+                .font(.system(size: Theme.Typography.body, weight: .medium, design: .rounded))
+                .frame(width: 64, alignment: .leading)
+                .foregroundStyle(entry.isUnavailable ? .tertiary : .primary)
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 6) {
+                    Text(entry.title)
+                        .font(.system(size: Theme.Typography.body))
+                        .foregroundStyle(entry.isUnavailable ? .secondary : .primary)
+                    if entry.isUnavailable {
+                        Text("not built yet")
+                            .font(.system(size: Theme.Typography.caption))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                if let note = entry.note {
+                    Text(note)
+                        .font(.system(size: Theme.Typography.caption))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
@@ -41,6 +41,7 @@ final class StudioTimelineView: NSView {
 
     private var pollTimer: Timer?
     private var lastDrawnPlayhead: TimeInterval = -1
+    private var lastRevision = -1
 
     init(model: StudioDocumentModel) {
         self.model = model
@@ -69,8 +70,10 @@ final class StudioTimelineView: NSView {
         let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
             MainActor.assumeIsolated {
                 guard let self else { return }
-                guard self.model.playhead != self.lastDrawnPlayhead else { return }
+                guard self.model.playhead != self.lastDrawnPlayhead
+                    || self.model.revision != self.lastRevision else { return }
                 self.lastDrawnPlayhead = self.model.playhead
+                self.lastRevision = self.model.revision
                 self.needsDisplay = true
             }
         }

--- a/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
@@ -1,0 +1,309 @@
+import AppKit
+import CoreGraphics
+
+/// The timeline: a ruler, the clip track, the zoom track and a playhead.
+///
+/// **AppKit rather than SwiftUI**, for the same reason `SelectionView` is: it redraws on every
+/// mouse-moved over a waveform that may be tens of thousands of samples, and SwiftUI's diffing is
+/// the wrong tool for a surface that is one custom drawing.
+@MainActor
+final class StudioTimelineView: NSView {
+
+    private let model: StudioDocumentModel
+    var onScrub: ((TimeInterval) -> Void)?
+
+    private enum Metrics {
+        static let ruler: CGFloat = 22
+        static let trackHeight: CGFloat = 44
+        static let trackGap: CGFloat = 6
+        static let inset: CGFloat = 12
+        /// A grab this near an edge is a trim, not a move.
+        static let edgeGrab: CGFloat = 6
+    }
+
+    private enum Drag {
+        case none
+        case playhead
+        case zoomBody(ZoomSegment.ID, grabbedAt: TimeInterval)
+        case zoomEdge(ZoomSegment.ID, leading: Bool)
+    }
+
+    private var drag: Drag = .none
+
+    init(model: StudioDocumentModel) {
+        self.model = model
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not from a nib") }
+
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+
+    // MARK: - Geometry
+
+    private var contentWidth: CGFloat { max(1, bounds.width - Metrics.inset * 2) }
+
+    private func x(forOutput t: TimeInterval) -> CGFloat {
+        guard model.duration > 0 else { return Metrics.inset }
+        return Metrics.inset + CGFloat(t / model.duration) * contentWidth
+    }
+
+    private func outputTime(forX x: CGFloat) -> TimeInterval {
+        guard model.duration > 0 else { return 0 }
+        return min(max(0, Double((x - Metrics.inset) / contentWidth) * model.duration),
+                   model.duration)
+    }
+
+    /// A source moment's place on the timeline, or nil when the edit cut it out.
+    private func x(forSource t: TimeInterval) -> CGFloat? {
+        model.project.timeline.outputTime(forSource: t).map { x(forOutput: $0) }
+    }
+
+    private var clipTrack: CGRect {
+        CGRect(x: 0, y: Metrics.ruler, width: bounds.width, height: Metrics.trackHeight)
+    }
+
+    private var zoomTrack: CGRect {
+        CGRect(x: 0, y: Metrics.ruler + Metrics.trackHeight + Metrics.trackGap,
+               width: bounds.width, height: Metrics.trackHeight)
+    }
+
+    static var preferredHeight: CGFloat {
+        Metrics.ruler + Metrics.trackHeight * 2 + Metrics.trackGap + 8
+    }
+
+    // MARK: - Drawing
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+        context.setFillColor(NSColor.underPageBackgroundColor.cgColor)
+        context.fill(bounds)
+
+        drawRuler(in: context)
+        drawClips(in: context)
+        drawZooms(in: context)
+        drawFlags(in: context)
+        drawPlayhead(in: context)
+    }
+
+    /// Tick density follows the zoom, so the labels stay readable rather than merging into a bar.
+    private func drawRuler(in context: CGContext) {
+        guard model.duration > 0 else { return }
+        let candidates: [TimeInterval] = [1, 2, 5, 10, 15, 30, 60, 120, 300]
+        let step = candidates.first { CGFloat($0 / model.duration) * contentWidth > 52 }
+            ?? candidates[candidates.count - 1]
+
+        context.setStrokeColor(NSColor.separatorColor.cgColor)
+        context.setLineWidth(1)
+
+        var time: TimeInterval = 0
+        while time <= model.duration {
+            let position = x(forOutput: time).rounded() + 0.5
+            context.move(to: CGPoint(x: position, y: Metrics.ruler - 6))
+            context.addLine(to: CGPoint(x: position, y: Metrics.ruler))
+            context.strokePath()
+
+            let label = NSAttributedString(
+                string: Self.label(time),
+                attributes: [.font: NSFont.systemFont(ofSize: 9),
+                             .foregroundColor: NSColor.secondaryLabelColor])
+            label.draw(at: CGPoint(x: position + 3, y: 3))
+            time += step
+        }
+    }
+
+    private static func label(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds.rounded())
+        return total >= 60 ? String(format: "%d:%02d", total / 60, total % 60) : "\(total)s"
+    }
+
+    private func drawClips(in context: CGContext) {
+        var elapsed: TimeInterval = 0
+        for clip in model.project.timeline.clips {
+            let rect = CGRect(x: x(forOutput: elapsed) ,
+                              y: clipTrack.minY,
+                              width: max(2, x(forOutput: elapsed + clip.outputDuration)
+                                            - x(forOutput: elapsed)),
+                              height: clipTrack.height)
+            let selected = model.selectedClip == clip.id
+            let path = CGPath.rounded(rect.insetBy(dx: 1, dy: 2), cornerRadius: 6)
+
+            context.addPath(path)
+            context.setFillColor(NSColor.systemOrange.withAlphaComponent(selected ? 0.55 : 0.38)
+                .cgColor)
+            context.fillPath()
+
+            if selected {
+                context.addPath(path)
+                context.setStrokeColor(NSColor.controlAccentColor.cgColor)
+                context.setLineWidth(1.5)
+                context.strokePath()
+            }
+
+            // Speed is stated on the clip rather than hidden in an inspector: it changes how every
+            // other track maps onto this stretch, so it should never be a surprise.
+            let text = clip.speed == 1
+                ? String(format: "%.1fs", clip.outputDuration)
+                : String(format: "%.1fs · %.2gx", clip.outputDuration, clip.speed)
+            NSAttributedString(string: text,
+                               attributes: [.font: NSFont.systemFont(ofSize: 10, weight: .medium),
+                                            .foregroundColor: NSColor.labelColor])
+                .draw(at: CGPoint(x: rect.minX + 8, y: rect.minY + 6))
+            elapsed += clip.outputDuration
+        }
+    }
+
+    private func drawZooms(in context: CGContext) {
+        context.setFillColor(NSColor.quaternaryLabelColor.withAlphaComponent(0.12).cgColor)
+        context.fill(zoomTrack.insetBy(dx: Metrics.inset, dy: 4))
+
+        for segment in model.project.zooms {
+            guard let from = x(forSource: segment.start) else { continue }
+            let to = x(forSource: segment.end) ?? bounds.maxX - Metrics.inset
+            let rect = CGRect(x: from, y: zoomTrack.minY + 2,
+                              width: max(3, to - from), height: zoomTrack.height - 4)
+            let selected = model.selectedZoom == segment.id
+            let path = CGPath.rounded(rect, cornerRadius: 6)
+
+            context.addPath(path)
+            let base = NSColor.systemIndigo
+            context.setFillColor(base.withAlphaComponent(
+                segment.isDisabled ? 0.15 : (selected ? 0.7 : 0.5)).cgColor)
+            context.fillPath()
+
+            if selected {
+                context.addPath(path)
+                context.setStrokeColor(NSColor.controlAccentColor.cgColor)
+                context.setLineWidth(1.5)
+                context.strokePath()
+            }
+
+            guard rect.width > 44 else { continue }
+            let follows: String
+            if case .followCursor = segment.anchor { follows = " · follows" } else { follows = "" }
+            NSAttributedString(
+                string: String(format: "%.1fx%@", segment.level, follows),
+                attributes: [.font: NSFont.systemFont(ofSize: 10, weight: .medium),
+                             .foregroundColor: NSColor.white])
+                .draw(at: CGPoint(x: rect.minX + 8, y: rect.minY + 6))
+        }
+    }
+
+    /// Moments marked with ⌃⌥⌘M while recording. One keystroke then beats a hunt afterwards.
+    private func drawFlags(in context: CGContext) {
+        context.setFillColor(NSColor.systemYellow.cgColor)
+        for flag in model.events.flags {
+            guard let position = x(forSource: flag) else { continue }
+            context.fill(CGRect(x: position - 1, y: 0, width: 2, height: Metrics.ruler))
+        }
+    }
+
+    private func drawPlayhead(in context: CGContext) {
+        let position = x(forOutput: model.playhead).rounded() + 0.5
+        context.setStrokeColor(NSColor.controlAccentColor.cgColor)
+        context.setLineWidth(1.5)
+        context.move(to: CGPoint(x: position, y: 0))
+        context.addLine(to: CGPoint(x: position, y: bounds.height))
+        context.strokePath()
+
+        context.setFillColor(NSColor.controlAccentColor.cgColor)
+        context.fillEllipse(in: CGRect(x: position - 4, y: 0, width: 8, height: 8))
+    }
+
+    // MARK: - Mouse
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        if zoomTrack.contains(point), let hit = zoom(at: point) {
+            model.selectedZoom = hit.segment.id
+            model.selectedClip = nil
+            model.beginGesture()
+            drag = hit.edge.map { .zoomEdge(hit.segment.id, leading: $0) }
+                ?? .zoomBody(hit.segment.id, grabbedAt: outputTime(forX: point.x))
+            needsDisplay = true
+            return
+        }
+
+        if clipTrack.contains(point) {
+            model.selectedClip = clip(at: point)?.id
+            model.selectedZoom = nil
+            needsDisplay = true
+        }
+
+        drag = .playhead
+        onScrub?(outputTime(forX: point.x))
+        needsDisplay = true
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        let time = outputTime(forX: point.x)
+
+        switch drag {
+        case .none:
+            return
+        case .playhead:
+            onScrub?(time)
+        case .zoomBody(let id, let grabbedAt):
+            let delta = time - grabbedAt
+            guard abs(delta) > 0.0001 else { return }
+            drag = .zoomBody(id, grabbedAt: time)
+            moveZoom(id) { segment in
+                segment.start += delta
+                segment.end += delta
+            }
+        case .zoomEdge(let id, let leading):
+            moveZoom(id) { segment in
+                if leading {
+                    segment.start = min(time, segment.end - ZoomSegment.minimumDuration)
+                } else {
+                    segment.end = max(time, segment.start + ZoomSegment.minimumDuration)
+                }
+            }
+        }
+        needsDisplay = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        if case .none = drag {} else if case .playhead = drag {} else { model.endGesture() }
+        drag = .none
+    }
+
+    /// Editing a zoom marks it as the user's, so "Re-detect" will not take it away again.
+    private func moveZoom(_ id: ZoomSegment.ID, _ change: (inout ZoomSegment) -> Void) {
+        model.editLive { project in
+            guard let index = project.zooms.firstIndex(where: { $0.id == id }) else { return }
+            change(&project.zooms[index])
+            project.zooms[index].isAutomatic = false
+            project.zooms.sort { $0.start < $1.start }
+        }
+    }
+
+    private func zoom(at point: CGPoint) -> (segment: ZoomSegment, edge: Bool?)? {
+        for segment in model.project.zooms {
+            guard let from = x(forSource: segment.start),
+                  let to = x(forSource: segment.end) else { continue }
+            guard point.x >= from - Metrics.edgeGrab, point.x <= to + Metrics.edgeGrab else {
+                continue
+            }
+            if abs(point.x - from) <= Metrics.edgeGrab { return (segment, true) }
+            if abs(point.x - to) <= Metrics.edgeGrab { return (segment, false) }
+            return (segment, nil)
+        }
+        return nil
+    }
+
+    private func clip(at point: CGPoint) -> Clip? {
+        var elapsed: TimeInterval = 0
+        for clip in model.project.timeline.clips {
+            let from = x(forOutput: elapsed)
+            let to = x(forOutput: elapsed + clip.outputDuration)
+            if point.x >= from && point.x <= to { return clip }
+            elapsed += clip.outputDuration
+        }
+        return nil
+    }
+}

--- a/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
@@ -30,6 +30,9 @@ final class StudioTimelineView: NSView {
 
     private var drag: Drag = .none
 
+    private var pollTimer: Timer?
+    private var lastDrawnPlayhead: TimeInterval = -1
+
     init(model: StudioDocumentModel) {
         self.model = model
         super.init(frame: .zero)
@@ -37,6 +40,36 @@ final class StudioTimelineView: NSView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("not from a nib") }
+
+    /// Repaints when the playhead moves.
+    ///
+    /// **This view used to have no way to know.** It is an `NSView` reading `model.playhead` inside
+    /// `draw(_:)`, and it relied entirely on SwiftUI re-running the enclosing body and calling
+    /// `updateNSView`. That does not happen reliably: during playback the transport's clock text
+    /// updated to `0:40` while the playhead line stayed where it had been drawn eight seconds in.
+    /// From the outside that is "when I click play the seekbar never moves" — the picture and the
+    /// counter run, and the one thing showing you where you are does not.
+    ///
+    /// `StudioPreviewView` already solved this for the canvas with a poll of its own; this is the
+    /// same answer for the timeline, and it removes the dependency on SwiftUI's update heuristics
+    /// rather than hoping about them.
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        pollTimer?.invalidate()
+        guard window != nil else { return }
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                guard self.model.playhead != self.lastDrawnPlayhead else { return }
+                self.lastDrawnPlayhead = self.model.playhead
+                self.needsDisplay = true
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        pollTimer = timer
+    }
+
+    deinit { pollTimer?.invalidate() }
 
     override var isFlipped: Bool { true }
     override var acceptsFirstResponder: Bool { true }

--- a/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
@@ -1,7 +1,7 @@
 import AppKit
 import CoreGraphics
 
-/// The timeline: a ruler, the clip track, the zoom track and a playhead.
+/// The timeline: a ruler, one row per track, and a playhead.
 ///
 /// **AppKit rather than SwiftUI**, for the same reason `SelectionView` is: it redraws on every
 /// mouse-moved over a waveform that may be tens of thousands of samples, and SwiftUI's diffing is
@@ -12,20 +12,19 @@ final class StudioTimelineView: NSView {
     private let model: StudioDocumentModel
     var onScrub: ((TimeInterval) -> Void)?
 
-    private enum Metrics {
-        static let ruler: CGFloat = 22
-        static let trackHeight: CGFloat = 44
-        static let trackGap: CGFloat = 6
-        static let inset: CGFloat = 12
-        /// A grab this near an edge is a trim, not a move.
-        static let edgeGrab: CGFloat = 6
-    }
+    /// **The rows are a value now, not hand-placed rects.** Two tracks used to be hardcoded, each
+    /// with its own bespoke hit test, which is why five of the project's own collections had no
+    /// representation at all. See `TimelineLayout`.
+    private let metrics = TimelineLayout.Metrics()
 
     private enum Drag {
         case none
         case playhead
-        case zoomBody(ZoomSegment.ID, grabbedAt: TimeInterval)
-        case zoomEdge(ZoomSegment.ID, leading: Bool)
+        /// Moving any source-time item, on any row. `grabOffset` is how far into the item it was
+        /// grabbed, in source seconds, so it does not jump to the pointer.
+        case itemBody(TimelineLayout.RowKind, UUID, grabOffset: TimeInterval)
+        /// Trimming either edge of one.
+        case itemEdge(TimelineLayout.RowKind, UUID, leading: Bool)
         /// Reordering. The move is committed on release, so the whole drag is one undo step and
         /// the clips do not shuffle about under the pointer while it is in flight.
         case clipBody(Clip.ID, from: Int)
@@ -88,35 +87,56 @@ final class StudioTimelineView: NSView {
 
     // MARK: - Geometry
 
-    private var contentWidth: CGFloat { max(1, bounds.width - Metrics.inset * 2) }
+    private var rows: [TimelineLayout.Row] {
+        TimelineLayout.rows(project: model.project, events: model.events,
+                            selection: .init(clip: model.selectedClip,
+                                             zoom: model.selectedZoom,
+                                             text: model.selectedText,
+                                             camera: model.selectedCamera,
+                                             mask: model.selectedMask,
+                                             pointer: model.selectedPointer))
+    }
+
+    /// The rows are laid out once per event, not once per lookup: `rows` walks the whole project.
+    private var cachedRows: [TimelineLayout.Row] = []
+
+    static func preferredHeight(rowCount: Int) -> CGFloat {
+        TimelineLayout.preferredHeight(rowCount: rowCount)
+    }
+
+    /// Kept for the host, which cannot know the row count before the model exists.
+    static var preferredHeight: CGFloat { TimelineLayout.preferredHeight(rowCount: 4) }
+
+    private var contentWidth: CGFloat {
+        max(1, bounds.width - metrics.gutter - metrics.inset)
+    }
 
     private func x(forOutput t: TimeInterval) -> CGFloat {
-        guard model.duration > 0 else { return Metrics.inset }
-        return Metrics.inset + CGFloat(t / model.duration) * contentWidth
+        guard model.duration > 0 else { return metrics.gutter }
+        return metrics.gutter + CGFloat(t / model.duration) * contentWidth
     }
 
     private func outputTime(forX x: CGFloat) -> TimeInterval {
         guard model.duration > 0 else { return 0 }
-        return min(max(0, Double((x - Metrics.inset) / contentWidth) * model.duration),
+        return min(max(0, Double((x - metrics.gutter) / contentWidth) * model.duration),
                    model.duration)
     }
 
-    /// A source moment's place on the timeline, or nil when the edit cut it out.
-    private func x(forSource t: TimeInterval) -> CGFloat? {
-        model.project.timeline.outputTime(forSource: t).map { x(forOutput: $0) }
+    /// The recording moment under a point on the timeline, which is what every source-time track
+    /// is edited in.
+    private func sourceTime(forX x: CGFloat) -> TimeInterval? {
+        model.project.timeline.sourceTime(forOutput: outputTime(forX: x))?.sourceTime
     }
 
-    private var clipTrack: CGRect {
-        CGRect(x: 0, y: Metrics.ruler, width: bounds.width, height: Metrics.trackHeight)
+    private func rect(ofRow index: Int) -> CGRect {
+        TimelineLayout.rect(ofRow: index, in: bounds, metrics: metrics)
     }
 
-    private var zoomTrack: CGRect {
-        CGRect(x: 0, y: Metrics.ruler + Metrics.trackHeight + Metrics.trackGap,
-               width: bounds.width, height: Metrics.trackHeight)
-    }
-
-    static var preferredHeight: CGFloat {
-        Metrics.ruler + Metrics.trackHeight * 2 + Metrics.trackGap + 8
+    private func rect(of item: TimelineLayout.Item, row index: Int) -> CGRect {
+        let from = x(forOutput: item.start)
+        let to = x(forOutput: item.end)
+        let row = rect(ofRow: index)
+        return CGRect(x: from, y: row.minY + 2, width: max(3, to - from), height: row.height - 4)
     }
 
     // MARK: - Drawing
@@ -126,14 +146,17 @@ final class StudioTimelineView: NSView {
         context.setFillColor(NSColor.underPageBackgroundColor.cgColor)
         context.fill(bounds)
 
+        cachedRows = rows
         drawRuler(in: context)
-        drawClips(in: context)
-        drawZooms(in: context)
+        for (index, row) in cachedRows.enumerated() {
+            drawRow(row, at: index, in: context)
+        }
         drawFlags(in: context)
+        drawDropLine(in: context)
         drawPlayhead(in: context)
     }
 
-    /// Tick density follows the zoom, so the labels stay readable rather than merging into a bar.
+    /// Tick density follows the width, so the labels stay readable rather than merging into a bar.
     private func drawRuler(in context: CGContext) {
         guard model.duration > 0 else { return }
         let candidates: [TimeInterval] = [1, 2, 5, 10, 15, 30, 60, 120, 300]
@@ -146,168 +169,142 @@ final class StudioTimelineView: NSView {
         var time: TimeInterval = 0
         while time <= model.duration {
             let position = x(forOutput: time).rounded() + 0.5
-            context.move(to: CGPoint(x: position, y: Metrics.ruler - 6))
-            context.addLine(to: CGPoint(x: position, y: Metrics.ruler))
+            context.move(to: CGPoint(x: position, y: metrics.ruler - 6))
+            context.addLine(to: CGPoint(x: position, y: metrics.ruler))
             context.strokePath()
 
-            let label = NSAttributedString(
-                string: Self.label(time),
-                attributes: [.font: NSFont.systemFont(ofSize: 9),
-                             .foregroundColor: NSColor.secondaryLabelColor])
-            label.draw(at: CGPoint(x: position + 3, y: 3))
+            NSAttributedString(string: Self.label(time),
+                               attributes: [.font: NSFont.systemFont(ofSize: 9),
+                                            .foregroundColor: NSColor.secondaryLabelColor])
+                .draw(at: CGPoint(x: position + 3, y: 3))
             time += step
         }
     }
 
     private static func label(_ seconds: TimeInterval) -> String {
         let total = Int(seconds.rounded())
-        return total >= 60 ? String(format: "%d:%02d", total / 60, total % 60) : "\(total)s"
+        return total >= 60 ? "\(total / 60):\(String(format: "%02d", total % 60))" : "\(total)s"
     }
 
-    /// **A cut has to look like a cut.**
-    ///
-    /// Unselected clips used to have a fill and no border, so two neighbours of the same colour
-    /// read as one continuous bar and the only hint of a split was a two-pixel gap from the rounded
-    /// inset. "What happens when I split?" was a fair question: visually, almost nothing did.
-    ///
-    /// Now every clip carries its own edge, the seam between two of them is drawn explicitly, and a
-    /// clip that is hiding material says how much — the badge `Clip`'s own doc comment has promised
-    /// all along and which nothing drew.
-    private func drawClips(in context: CGContext) {
-        var elapsed: TimeInterval = 0
-        let clips = model.project.timeline.clips
+    /// One row: its name in the gutter, a faint bed, and its items.
+    private func drawRow(_ row: TimelineLayout.Row, at index: Int, in context: CGContext) {
+        let bed = rect(ofRow: index)
 
-        for (index, clip) in clips.enumerated() {
-            let from = x(forOutput: elapsed)
-            let to = x(forOutput: elapsed + clip.outputDuration)
-            let rect = CGRect(x: from, y: clipTrack.minY,
-                              width: max(2, to - from), height: clipTrack.height)
-            let selected = model.selectedClip == clip.id
+        // The name, so it is obvious what each row is — the thing a timeline of unlabelled bars
+        // cannot tell you.
+        NSAttributedString(string: row.kind.name,
+                           attributes: [.font: NSFont.systemFont(ofSize: 9, weight: .medium),
+                                        .foregroundColor: NSColor.secondaryLabelColor])
+            .draw(at: CGPoint(x: 6, y: bed.minY + bed.height / 2 - 6))
+
+        context.setFillColor(NSColor.quaternaryLabelColor.withAlphaComponent(0.1).cgColor)
+        context.fill(CGRect(x: metrics.gutter, y: bed.minY + 2,
+                            width: max(0, bounds.width - metrics.gutter - metrics.inset),
+                            height: bed.height - 4))
+
+        for (position, item) in row.items.enumerated() {
+            let box = rect(of: item, row: index)
             let dragging: Bool
-            if case .clipBody(let id, _) = drag, id == clip.id { dragging = true } else {
+            if case .itemBody(_, let id, _) = drag, id == item.id { dragging = true } else if
+                case .clipBody(let id, _) = drag, id == item.id { dragging = true } else {
                 dragging = false
             }
-            let path = CGPath.rounded(rect.insetBy(dx: 1, dy: 2), cornerRadius: 6)
+            let path = CGPath.rounded(box, cornerRadius: 5)
 
             context.addPath(path)
-            context.setFillColor(NSColor.systemOrange
-                .withAlphaComponent(dragging ? 0.25 : (selected ? 0.55 : 0.38)).cgColor)
+            context.setFillColor(Self.colour(for: row.kind)
+                .withAlphaComponent(item.isMuted ? 0.15
+                                    : (dragging ? 0.25 : (item.isSelected ? 0.7 : 0.45))).cgColor)
             context.fillPath()
 
-            // Every clip, not only the selected one.
+            // Every item carries an edge, not only the selected one. Two neighbours of the same
+            // colour used to read as one continuous bar, which is why a split looked like nothing
+            // had happened.
             context.addPath(path)
-            context.setStrokeColor(selected
+            context.setStrokeColor(item.isSelected
                 ? NSColor.controlAccentColor.cgColor
-                : NSColor.systemOrange.withAlphaComponent(0.9).cgColor)
-            context.setLineWidth(selected ? 1.5 : 1)
+                : Self.colour(for: row.kind).withAlphaComponent(0.9).cgColor)
+            context.setLineWidth(item.isSelected ? 1.5 : 1)
             context.strokePath()
 
-            // Speed is stated on the clip rather than hidden in an inspector: it changes how every
-            // other track maps onto this stretch, so it should never be a surprise.
-            var text = clip.speed == 1
-                ? String(format: "%.1fs", clip.outputDuration)
-                : String(format: "%.1fs · %.2gx", clip.outputDuration, clip.speed)
-            if clip.hold > 0 { text += String(format: " · hold %.1fs", clip.hold) }
-            NSAttributedString(string: text,
-                               attributes: [.font: NSFont.systemFont(ofSize: 10, weight: .medium),
-                                            .foregroundColor: NSColor.labelColor])
-                .draw(at: CGPoint(x: rect.minX + 8, y: rect.minY + 6))
+            if box.width > 40 {
+                NSAttributedString(
+                    string: item.label,
+                    attributes: [.font: NSFont.systemFont(ofSize: 9, weight: .medium),
+                                 .foregroundColor: NSColor.labelColor])
+                    .draw(in: box.insetBy(dx: 5, dy: 4))
+            }
 
-            drawTrimBadge(for: clip, at: index, in: rect, context: context)
-
-            elapsed += clip.outputDuration
-
-            // The seam, drawn on the boundary rather than left to a gap in the fills.
-            if index + 1 < clips.count {
-                let seamX = x(forOutput: elapsed).rounded() + 0.5
-                context.setStrokeColor(NSColor.underPageBackgroundColor.cgColor)
-                context.setLineWidth(2)
-                context.move(to: CGPoint(x: seamX, y: clipTrack.minY + 2))
-                context.addLine(to: CGPoint(x: seamX, y: clipTrack.maxY - 2))
-                context.strokePath()
+            if row.kind == .video {
+                drawTrimBadge(forClipAt: position, in: box, context: context)
+                // The seam, drawn on the boundary rather than left to a gap between fills.
+                if position + 1 < row.items.count {
+                    let seamX = x(forOutput: item.end).rounded() + 0.5
+                    context.setStrokeColor(NSColor.underPageBackgroundColor.cgColor)
+                    context.setLineWidth(2)
+                    context.move(to: CGPoint(x: seamX, y: box.minY))
+                    context.addLine(to: CGPoint(x: seamX, y: box.maxY))
+                    context.strokePath()
+                }
             }
         }
+    }
 
-        drawDropLine(in: context)
+    private static func colour(for kind: TimelineLayout.RowKind) -> NSColor {
+        switch kind {
+        case .video: return .systemOrange
+        case .text: return .systemTeal
+        case .camera: return .systemPink
+        case .zoom: return .systemIndigo
+        case .mask: return .systemGray
+        case .pointer: return .systemYellow
+        case .caption: return .systemGreen
+        }
     }
 
     /// How much of the recording a clip is hiding, if any.
     ///
     /// Trimming is a window, never a cut, so the material is always still there — and the badge is
-    /// what makes that visible instead of merely true. Right-click offers to put it back.
-    private func drawTrimBadge(for clip: Clip, at index: Int, in rect: CGRect,
-                               context: CGContext) {
+    /// what makes that visible rather than merely true. Right-click offers to put it back.
+    private func drawTrimBadge(forClipAt index: Int, in rect: CGRect, context: CGContext) {
         let clips = model.project.timeline.clips
+        guard clips.indices.contains(index), rect.width > 108 else { return }
+        let clip = clips[index]
         let lower = index > 0 ? clips[index - 1].sourceEnd : 0
         let upper = index + 1 < clips.count ? clips[index + 1].sourceStart : model.recordingDuration
         let hidden = max(0, clip.sourceStart - lower) + max(0, upper - clip.sourceEnd)
-        guard hidden > 0.15, rect.width > 92 else { return }
+        guard hidden > 0.15 else { return }
 
-        let label = NSAttributedString(
-            string: String(format: "✂︎ %.1fs hidden", hidden),
-            attributes: [.font: NSFont.systemFont(ofSize: 9, weight: .medium),
+        NSAttributedString(
+            string: String(format: "✂︎ %.1fs", hidden),
+            attributes: [.font: NSFont.systemFont(ofSize: 9),
                          .foregroundColor: NSColor.secondaryLabelColor])
-        label.draw(at: CGPoint(x: rect.minX + 8, y: rect.minY + 22))
-    }
-
-    /// Where a dragged clip would land.
-    private func drawDropLine(in context: CGContext) {
-        guard case .clipBody = drag, let dropIndex else { return }
-        var elapsed: TimeInterval = 0
-        for clip in model.project.timeline.clips.prefix(dropIndex) {
-            elapsed += clip.outputDuration
-        }
-        let position = x(forOutput: elapsed).rounded() + 0.5
-        context.setStrokeColor(NSColor.controlAccentColor.cgColor)
-        context.setLineWidth(3)
-        context.move(to: CGPoint(x: position, y: clipTrack.minY))
-        context.addLine(to: CGPoint(x: position, y: clipTrack.maxY))
-        context.strokePath()
-    }
-
-    private func drawZooms(in context: CGContext) {
-        context.setFillColor(NSColor.quaternaryLabelColor.withAlphaComponent(0.12).cgColor)
-        context.fill(zoomTrack.insetBy(dx: Metrics.inset, dy: 4))
-
-        for segment in model.project.zooms {
-            guard let from = x(forSource: segment.start) else { continue }
-            let to = x(forSource: segment.end) ?? bounds.maxX - Metrics.inset
-            let rect = CGRect(x: from, y: zoomTrack.minY + 2,
-                              width: max(3, to - from), height: zoomTrack.height - 4)
-            let selected = model.selectedZoom == segment.id
-            let path = CGPath.rounded(rect, cornerRadius: 6)
-
-            context.addPath(path)
-            let base = NSColor.systemIndigo
-            context.setFillColor(base.withAlphaComponent(
-                segment.isDisabled ? 0.15 : (selected ? 0.7 : 0.5)).cgColor)
-            context.fillPath()
-
-            if selected {
-                context.addPath(path)
-                context.setStrokeColor(NSColor.controlAccentColor.cgColor)
-                context.setLineWidth(1.5)
-                context.strokePath()
-            }
-
-            guard rect.width > 44 else { continue }
-            let follows: String
-            if case .followCursor = segment.anchor { follows = " · follows" } else { follows = "" }
-            NSAttributedString(
-                string: String(format: "%.1fx%@", segment.level, follows),
-                attributes: [.font: NSFont.systemFont(ofSize: 10, weight: .medium),
-                             .foregroundColor: NSColor.white])
-                .draw(at: CGPoint(x: rect.minX + 8, y: rect.minY + 6))
-        }
+            .draw(at: CGPoint(x: rect.maxX - 46, y: rect.minY + 4))
     }
 
     /// Moments marked with ⌃⌥⌘M while recording. One keystroke then beats a hunt afterwards.
     private func drawFlags(in context: CGContext) {
         context.setFillColor(NSColor.systemYellow.cgColor)
         for flag in model.events.flags {
-            guard let position = x(forSource: flag) else { continue }
-            context.fill(CGRect(x: position - 1, y: 0, width: 2, height: Metrics.ruler))
+            guard let output = model.project.timeline.outputTime(forSource: flag) else { continue }
+            context.fill(CGRect(x: x(forOutput: output) - 1, y: 0, width: 2, height: metrics.ruler))
         }
+    }
+
+    /// Where a dragged clip would land.
+    private func drawDropLine(in context: CGContext) {
+        guard case .clipBody = drag, let dropIndex,
+              let videoRow = cachedRows.firstIndex(where: { $0.kind == .video }) else { return }
+        let clips = model.project.timeline.clips
+        var elapsed: TimeInterval = 0
+        for clip in clips.prefix(dropIndex) { elapsed += clip.outputDuration }
+        let position = x(forOutput: elapsed).rounded() + 0.5
+        let row = rect(ofRow: videoRow)
+        context.setStrokeColor(NSColor.controlAccentColor.cgColor)
+        context.setLineWidth(3)
+        context.move(to: CGPoint(x: position, y: row.minY))
+        context.addLine(to: CGPoint(x: position, y: row.maxY))
+        context.strokePath()
     }
 
     private func drawPlayhead(in context: CGContext) {
@@ -322,6 +319,57 @@ final class StudioTimelineView: NSView {
         context.fillEllipse(in: CGRect(x: position - 4, y: 0, width: 8, height: 8))
     }
 
+    // MARK: - Hit testing
+
+    /// What is under a point: which row, which item, and whether an edge was grabbed.
+    private func hit(at point: CGPoint)
+        -> (row: TimelineLayout.Row, index: Int, item: TimelineLayout.Item, edge: Bool?)? {
+        let laid = cachedRows.isEmpty ? rows : cachedRows
+        for (index, row) in laid.enumerated() where rect(ofRow: index).contains(point) {
+            for item in row.items {
+                let box = rect(of: item, row: index)
+                guard point.x >= box.minX - metrics.edgeGrab,
+                      point.x <= box.maxX + metrics.edgeGrab else { continue }
+                if abs(point.x - box.minX) <= metrics.edgeGrab { return (row, index, item, true) }
+                if abs(point.x - box.maxX) <= metrics.edgeGrab { return (row, index, item, false) }
+                return (row, index, item, nil)
+            }
+            return nil
+        }
+        return nil
+    }
+
+    /// The seam between two clips, if the pointer is near one.
+    private func seam(at point: CGPoint) -> Clip.ID? {
+        guard let videoRow = (cachedRows.isEmpty ? rows : cachedRows)
+            .firstIndex(where: { $0.kind == .video }),
+              rect(ofRow: videoRow).contains(point) else { return nil }
+
+        var elapsed: TimeInterval = 0
+        let clips = model.project.timeline.clips
+        for (index, clip) in clips.enumerated() {
+            elapsed += clip.outputDuration
+            guard index + 1 < clips.count else { break }
+            if abs(point.x - x(forOutput: elapsed)) <= metrics.edgeGrab { return clip.id }
+        }
+        return nil
+    }
+
+    private func select(_ item: TimelineLayout.Item) {
+        model.clearTimelineSelection()
+        switch item.kind {
+        case .video: model.selectedClip = item.id
+        case .zoom: model.selectedZoom = item.id
+        case .text:
+            model.selectedText = item.id
+            model.inspector = .text
+        case .camera: model.selectedCamera = item.id
+        case .mask: model.selectedMask = item.id
+        case .pointer: model.selectedPointer = item.id
+        case .caption: break
+        }
+    }
+
     // MARK: - Mouse
 
     override func mouseDown(with event: NSEvent) {
@@ -329,96 +377,98 @@ final class StudioTimelineView: NSView {
         // The clock stops writing the playhead for the length of any timeline drag. Otherwise
         // playback and the drag write it alternately and the handle fights the pointer.
         model.player.beginScrubbing()
+        cachedRows = rows
 
-        if clipTrack.contains(point) {
-            // A seam takes precedence over the clip body, the way a zoom's edge does over its
-            // middle: the narrow target is the one you have to aim at.
-            if let seam = seam(at: point) {
-                model.selectedClip = nil
-                model.beginGesture()
-                drag = .clipSeam(seam, lastTime: outputTime(forX: point.x))
-                needsDisplay = true
-                return
-            }
-            if let hit = clip(at: point),
-               let index = model.project.timeline.clips.firstIndex(where: { $0.id == hit.id }) {
-                model.selectedClip = hit.id
-                model.selectedZoom = nil
-                drag = .clipBody(hit.id, from: index)
-                dropIndex = index
-                needsDisplay = true
-                // **Returns rather than falling through.** It used to set the selection and then
-                // start a playhead scrub regardless, so a clip could never be dragged: every
-                // attempt scrubbed instead.
-                return
-            }
-        }
-
-        if zoomTrack.contains(point), let hit = zoom(at: point) {
-            model.selectedZoom = hit.segment.id
-            model.selectedClip = nil
+        // A seam takes precedence over a clip body, the way an edge does over a middle: the narrow
+        // target is the one you have to aim at.
+        if let seamID = seam(at: point) {
+            model.clearTimelineSelection()
             model.beginGesture()
-            drag = hit.edge.map { .zoomEdge(hit.segment.id, leading: $0) }
-                ?? .zoomBody(hit.segment.id, grabbedAt: outputTime(forX: point.x))
+            drag = .clipSeam(seamID, lastTime: outputTime(forX: point.x))
             needsDisplay = true
             return
         }
 
-        if clipTrack.contains(point) {
-            model.selectedClip = clip(at: point)?.id
-            model.selectedZoom = nil
+        if let hit = hit(at: point) {
+            select(hit.item)
+            if hit.row.kind == .video {
+                guard let index = model.project.timeline.clips
+                    .firstIndex(where: { $0.id == hit.item.id }) else { return }
+                drag = .clipBody(hit.item.id, from: index)
+                dropIndex = index
+            } else if let leading = hit.edge {
+                model.beginGesture()
+                drag = .itemEdge(hit.row.kind, hit.item.id, leading: leading)
+            } else if hit.row.kind != .caption {
+                model.beginGesture()
+                let grabbed = sourceTime(forX: point.x) ?? 0
+                let start = sourceStart(of: hit.item, kind: hit.row.kind) ?? grabbed
+                drag = .itemBody(hit.row.kind, hit.item.id, grabOffset: grabbed - start)
+            }
             needsDisplay = true
+            // **Returns rather than falling through.** It used to set the selection and then start
+            // a playhead scrub regardless, so nothing on the timeline could be dragged: every
+            // attempt scrubbed instead.
+            return
         }
 
+        model.clearTimelineSelection()
         drag = .playhead
         onScrub?(outputTime(forX: point.x))
         needsDisplay = true
     }
 
+    /// An item's start in *source* time, which is what it is stored in.
+    private func sourceStart(of item: TimelineLayout.Item,
+                             kind: TimelineLayout.RowKind) -> TimeInterval? {
+        switch kind {
+        case .text: return model.project.textOverlays.first { $0.id == item.id }?.start
+        case .zoom: return model.project.zooms.first { $0.id == item.id }?.start
+        case .camera: return model.project.cameraSegments.first { $0.id == item.id }?.start
+        case .mask: return model.project.masks.first { $0.id == item.id }?.start
+        case .pointer: return model.project.pointerHighlights.first { $0.id == item.id }?.start
+        case .video, .caption: return nil
+        }
+    }
+
     override func mouseDragged(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-        let time = outputTime(forX: point.x)
 
         switch drag {
         case .none:
             return
+        case .playhead:
+            onScrub?(outputTime(forX: point.x))
         case .clipBody:
             dropIndex = insertionIndex(forX: point.x)
         case .clipSeam(let id, let lastTime):
+            let time = outputTime(forX: point.x)
             let delta = time - lastTime
             guard abs(delta) > 0.0001 else { return }
             drag = .clipSeam(id, lastTime: time)
             model.rollCut(after: id, by: delta)
-        case .playhead:
-            onScrub?(time)
-        case .zoomBody(let id, let grabbedAt):
-            let delta = time - grabbedAt
-            guard abs(delta) > 0.0001 else { return }
-            drag = .zoomBody(id, grabbedAt: time)
-            moveZoom(id) { segment in
-                segment.start += delta
-                segment.end += delta
-            }
-        case .zoomEdge(let id, let leading):
-            moveZoom(id) { segment in
-                if leading {
-                    segment.start = min(time, segment.end - ZoomSegment.minimumDuration)
-                } else {
-                    segment.end = max(time, segment.start + ZoomSegment.minimumDuration)
-                }
-            }
+        case .itemBody(let kind, let id, let grabOffset):
+            guard let source = sourceTime(forX: point.x) else { return }
+            model.moveTimelineItem(kind, id: id, toSourceStart: source - grabOffset)
+        case .itemEdge(let kind, let id, let leading):
+            guard let source = sourceTime(forX: point.x) else { return }
+            model.trimTimelineItem(kind, id: id, leading: leading, toSource: source)
         }
         needsDisplay = true
     }
 
     override func mouseUp(with event: NSEvent) {
         if case .clipBody(_, let from) = drag, let dropIndex, dropIndex != from {
-            // Insert-before semantics: dropping to the right of where it came from means the
-            // index shifts down by one once the clip is lifted out.
+            // Insert-before semantics: dropping to the right of where it came from means the index
+            // shifts down by one once the clip is lifted out.
             model.moveClip(from: from, to: dropIndex > from ? dropIndex - 1 : dropIndex)
         }
-        if case .none = drag {} else if case .playhead = drag {} else if case .clipBody = drag {
-        } else { model.endGesture() }
+        switch drag {
+        case .none, .playhead, .clipBody:
+            break
+        case .clipSeam, .itemBody, .itemEdge:
+            model.endGesture()
+        }
         drag = .none
         dropIndex = nil
         needsDisplay = true
@@ -434,29 +484,6 @@ final class StudioTimelineView: NSView {
             elapsed += clip.outputDuration
         }
         return model.project.timeline.clips.count
-    }
-
-    /// The clip *before* a seam the pointer is close to, if any. Nil for the outer edges, which
-    /// are trims rather than seams.
-    private func seam(at point: CGPoint) -> Clip.ID? {
-        var elapsed: TimeInterval = 0
-        let clips = model.project.timeline.clips
-        for (index, clip) in clips.enumerated() {
-            elapsed += clip.outputDuration
-            guard index + 1 < clips.count else { break }
-            if abs(point.x - x(forOutput: elapsed)) <= Metrics.edgeGrab { return clip.id }
-        }
-        return nil
-    }
-
-    /// Editing a zoom marks it as the user's, so "Re-detect" will not take it away again.
-    private func moveZoom(_ id: ZoomSegment.ID, _ change: (inout ZoomSegment) -> Void) {
-        model.editLive { project in
-            guard let index = project.zooms.firstIndex(where: { $0.id == id }) else { return }
-            change(&project.zooms[index])
-            project.zooms[index].isAutomatic = false
-            project.zooms.sort { $0.start < $1.start }
-        }
     }
 
     // MARK: - The menu
@@ -480,22 +507,26 @@ final class StudioTimelineView: NSView {
 
         let menu = NSMenu()
 
-        if zoomTrack.contains(point), let hit = zoom(at: point) {
-            model.selectedZoom = hit.segment.id
-            model.selectedClip = nil
-            add(to: menu, "Delete Zoom", #selector(menuDeleteZoom))
-            menu.addItem(.separator())
-        }
-
-        if clipTrack.contains(point), let hit = clip(at: point) {
-            model.selectedClip = hit.id
-            model.selectedZoom = nil
-            add(to: menu, "Duplicate Clip", #selector(menuDuplicateClip))
-            add(to: menu, "Delete Clip", #selector(menuDeleteClip), key: "⌫")
-            if hasHiddenMaterial(hit) {
-                add(to: menu, "Put Back Trimmed Material", #selector(menuUntrimClip))
+        // Whatever is under the pointer, on whichever row — one hit test now serves all of them.
+        cachedRows = rows
+        if let hit = hit(at: point) {
+            select(hit.item)
+            switch hit.row.kind {
+            case .video:
+                add(to: menu, "Duplicate Clip", #selector(menuDuplicateClip))
+                add(to: menu, "Delete Clip", #selector(menuDeleteClip), key: "⌫")
+                if let clip = model.project.timeline.clips.first(where: { $0.id == hit.item.id }),
+                   hasHiddenMaterial(clip) {
+                    add(to: menu, "Put Back Trimmed Material", #selector(menuUntrimClip))
+                }
+                menu.addItem(.separator())
+            case .caption:
+                break
+            default:
+                add(to: menu, "Delete \(hit.row.kind.name)", #selector(menuDeleteSelection),
+                    key: "⌫")
+                menu.addItem(.separator())
             }
-            menu.addItem(.separator())
         }
 
         add(to: menu, "Add Zoom Here", #selector(menuAddZoom), key: "Z")
@@ -549,28 +580,10 @@ final class StudioTimelineView: NSView {
     @objc private func menuCameraHidden() { model.addCameraSegment(.hidden) }
     @objc private func menuSplit() { model.split() }
 
-    private func zoom(at point: CGPoint) -> (segment: ZoomSegment, edge: Bool?)? {
-        for segment in model.project.zooms {
-            guard let from = x(forSource: segment.start),
-                  let to = x(forSource: segment.end) else { continue }
-            guard point.x >= from - Metrics.edgeGrab, point.x <= to + Metrics.edgeGrab else {
-                continue
-            }
-            if abs(point.x - from) <= Metrics.edgeGrab { return (segment, true) }
-            if abs(point.x - to) <= Metrics.edgeGrab { return (segment, false) }
-            return (segment, nil)
-        }
-        return nil
+    /// Deletes whatever is selected, whichever row it is on.
+    @objc private func menuDeleteSelection() {
+        guard let selection = model.timelineSelection else { return }
+        model.deleteTimelineItem(selection.kind, id: selection.id)
     }
 
-    private func clip(at point: CGPoint) -> Clip? {
-        var elapsed: TimeInterval = 0
-        for clip in model.project.timeline.clips {
-            let from = x(forOutput: elapsed)
-            let to = x(forOutput: elapsed + clip.outputDuration)
-            if point.x >= from && point.x <= to { return clip }
-            elapsed += clip.outputDuration
-        }
-        return nil
-    }
 }

--- a/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
@@ -319,6 +319,69 @@ final class StudioTimelineView: NSView {
         }
     }
 
+    // MARK: - The menu
+
+    /// Everything that can be placed at a moment, at the moment you are pointing at.
+    ///
+    /// **This is the answer to "there is no way to add zoom, click, point manually".** Adding a zoom
+    /// by hand had worked all along — an unlabelled magnifying glass in the transport bar and the
+    /// `Z` key — and was reported as absent, which is a fair report: two unlabelled glyphs and a
+    /// keyboard shortcut with no menu is not a discoverable editor. Masks and camera segments were
+    /// worse off, reachable only from inside their own inspector tabs.
+    ///
+    /// A right-click is where people look for "do something here", and until now this view had no
+    /// `menu(for:)` and no `rightMouseDown` at all.
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let point = convert(event.locationInWindow, from: nil)
+        // The playhead moves to where you clicked first, so every "here" below means the place you
+        // pointed at rather than wherever the playhead happened to be left.
+        onScrub?(outputTime(forX: point.x))
+        needsDisplay = true
+
+        let menu = NSMenu()
+
+        if zoomTrack.contains(point), let hit = zoom(at: point) {
+            model.selectedZoom = hit.segment.id
+            model.selectedClip = nil
+            add(to: menu, "Delete Zoom", #selector(menuDeleteZoom))
+            menu.addItem(.separator())
+        }
+
+        add(to: menu, "Add Zoom Here", #selector(menuAddZoom), key: "Z")
+        add(to: menu, "Add Click Here", #selector(menuAddClick))
+        add(to: menu, "Add Pointer Highlight Here", #selector(menuAddPointerHighlight))
+        add(to: menu, "Add Blur or Highlight Here", #selector(menuAddMask))
+        menu.addItem(.separator())
+        add(to: menu, "Camera Full Frame Here", #selector(menuCameraFullFrame))
+        add(to: menu, "Hide Camera Here", #selector(menuCameraHidden))
+        menu.addItem(.separator())
+        add(to: menu, "Split Clip Here", #selector(menuSplit), key: "⌘B")
+        add(to: menu, "Remove Click Here", #selector(menuRemoveClick))
+        return menu
+    }
+
+    /// The key equivalent is shown as a label rather than made live: these shortcuts are already
+    /// routed by `StudioKeyRouting` on the window, and claiming them here too would mean two owners
+    /// for one keystroke.
+    private func add(to menu: NSMenu, _ title: String, _ action: Selector, key: String? = nil) {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        if let key {
+            item.attributedTitle = NSAttributedString(string: "\(title)   \(key)")
+        }
+        menu.addItem(item)
+    }
+
+    @objc private func menuAddZoom() { model.addZoomAtPlayhead() }
+    @objc private func menuDeleteZoom() { model.deleteSelectedZoom() }
+    @objc private func menuAddClick() { model.addClickAtPlayhead() }
+    @objc private func menuRemoveClick() { model.suppressClickNearPlayhead() }
+    @objc private func menuAddPointerHighlight() { model.addPointerHighlightAtPlayhead() }
+    @objc private func menuAddMask() { model.addMaskAtPlayhead() }
+    @objc private func menuCameraFullFrame() { model.addCameraSegment(.fullFrame) }
+    @objc private func menuCameraHidden() { model.addCameraSegment(.hidden) }
+    @objc private func menuSplit() { model.split() }
+
     private func zoom(at point: CGPoint) -> (segment: ZoomSegment, edge: Bool?)? {
         for segment in model.project.zooms {
             guard let from = x(forSource: segment.start),

--- a/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
@@ -26,7 +26,16 @@ final class StudioTimelineView: NSView {
         case playhead
         case zoomBody(ZoomSegment.ID, grabbedAt: TimeInterval)
         case zoomEdge(ZoomSegment.ID, leading: Bool)
+        /// Reordering. The move is committed on release, so the whole drag is one undo step and
+        /// the clips do not shuffle about under the pointer while it is in flight.
+        case clipBody(Clip.ID, from: Int)
+        /// Rolling the cut between this clip and the next: one side gains what the other gives up,
+        /// and the cut stays where it is in the finished video.
+        case clipSeam(Clip.ID, lastTime: TimeInterval)
     }
+
+    /// Where a dragged clip would land, drawn as an insertion line.
+    private var dropIndex: Int?
 
     private var drag: Drag = .none
 
@@ -152,40 +161,105 @@ final class StudioTimelineView: NSView {
         return total >= 60 ? String(format: "%d:%02d", total / 60, total % 60) : "\(total)s"
     }
 
+    /// **A cut has to look like a cut.**
+    ///
+    /// Unselected clips used to have a fill and no border, so two neighbours of the same colour
+    /// read as one continuous bar and the only hint of a split was a two-pixel gap from the rounded
+    /// inset. "What happens when I split?" was a fair question: visually, almost nothing did.
+    ///
+    /// Now every clip carries its own edge, the seam between two of them is drawn explicitly, and a
+    /// clip that is hiding material says how much — the badge `Clip`'s own doc comment has promised
+    /// all along and which nothing drew.
     private func drawClips(in context: CGContext) {
         var elapsed: TimeInterval = 0
-        for clip in model.project.timeline.clips {
-            let rect = CGRect(x: x(forOutput: elapsed) ,
-                              y: clipTrack.minY,
-                              width: max(2, x(forOutput: elapsed + clip.outputDuration)
-                                            - x(forOutput: elapsed)),
-                              height: clipTrack.height)
+        let clips = model.project.timeline.clips
+
+        for (index, clip) in clips.enumerated() {
+            let from = x(forOutput: elapsed)
+            let to = x(forOutput: elapsed + clip.outputDuration)
+            let rect = CGRect(x: from, y: clipTrack.minY,
+                              width: max(2, to - from), height: clipTrack.height)
             let selected = model.selectedClip == clip.id
+            let dragging: Bool
+            if case .clipBody(let id, _) = drag, id == clip.id { dragging = true } else {
+                dragging = false
+            }
             let path = CGPath.rounded(rect.insetBy(dx: 1, dy: 2), cornerRadius: 6)
 
             context.addPath(path)
-            context.setFillColor(NSColor.systemOrange.withAlphaComponent(selected ? 0.55 : 0.38)
-                .cgColor)
+            context.setFillColor(NSColor.systemOrange
+                .withAlphaComponent(dragging ? 0.25 : (selected ? 0.55 : 0.38)).cgColor)
             context.fillPath()
 
-            if selected {
-                context.addPath(path)
-                context.setStrokeColor(NSColor.controlAccentColor.cgColor)
-                context.setLineWidth(1.5)
-                context.strokePath()
-            }
+            // Every clip, not only the selected one.
+            context.addPath(path)
+            context.setStrokeColor(selected
+                ? NSColor.controlAccentColor.cgColor
+                : NSColor.systemOrange.withAlphaComponent(0.9).cgColor)
+            context.setLineWidth(selected ? 1.5 : 1)
+            context.strokePath()
 
             // Speed is stated on the clip rather than hidden in an inspector: it changes how every
             // other track maps onto this stretch, so it should never be a surprise.
-            let text = clip.speed == 1
+            var text = clip.speed == 1
                 ? String(format: "%.1fs", clip.outputDuration)
                 : String(format: "%.1fs · %.2gx", clip.outputDuration, clip.speed)
+            if clip.hold > 0 { text += String(format: " · hold %.1fs", clip.hold) }
             NSAttributedString(string: text,
                                attributes: [.font: NSFont.systemFont(ofSize: 10, weight: .medium),
                                             .foregroundColor: NSColor.labelColor])
                 .draw(at: CGPoint(x: rect.minX + 8, y: rect.minY + 6))
+
+            drawTrimBadge(for: clip, at: index, in: rect, context: context)
+
+            elapsed += clip.outputDuration
+
+            // The seam, drawn on the boundary rather than left to a gap in the fills.
+            if index + 1 < clips.count {
+                let seamX = x(forOutput: elapsed).rounded() + 0.5
+                context.setStrokeColor(NSColor.underPageBackgroundColor.cgColor)
+                context.setLineWidth(2)
+                context.move(to: CGPoint(x: seamX, y: clipTrack.minY + 2))
+                context.addLine(to: CGPoint(x: seamX, y: clipTrack.maxY - 2))
+                context.strokePath()
+            }
+        }
+
+        drawDropLine(in: context)
+    }
+
+    /// How much of the recording a clip is hiding, if any.
+    ///
+    /// Trimming is a window, never a cut, so the material is always still there — and the badge is
+    /// what makes that visible instead of merely true. Right-click offers to put it back.
+    private func drawTrimBadge(for clip: Clip, at index: Int, in rect: CGRect,
+                               context: CGContext) {
+        let clips = model.project.timeline.clips
+        let lower = index > 0 ? clips[index - 1].sourceEnd : 0
+        let upper = index + 1 < clips.count ? clips[index + 1].sourceStart : model.recordingDuration
+        let hidden = max(0, clip.sourceStart - lower) + max(0, upper - clip.sourceEnd)
+        guard hidden > 0.15, rect.width > 92 else { return }
+
+        let label = NSAttributedString(
+            string: String(format: "✂︎ %.1fs hidden", hidden),
+            attributes: [.font: NSFont.systemFont(ofSize: 9, weight: .medium),
+                         .foregroundColor: NSColor.secondaryLabelColor])
+        label.draw(at: CGPoint(x: rect.minX + 8, y: rect.minY + 22))
+    }
+
+    /// Where a dragged clip would land.
+    private func drawDropLine(in context: CGContext) {
+        guard case .clipBody = drag, let dropIndex else { return }
+        var elapsed: TimeInterval = 0
+        for clip in model.project.timeline.clips.prefix(dropIndex) {
             elapsed += clip.outputDuration
         }
+        let position = x(forOutput: elapsed).rounded() + 0.5
+        context.setStrokeColor(NSColor.controlAccentColor.cgColor)
+        context.setLineWidth(3)
+        context.move(to: CGPoint(x: position, y: clipTrack.minY))
+        context.addLine(to: CGPoint(x: position, y: clipTrack.maxY))
+        context.strokePath()
     }
 
     private func drawZooms(in context: CGContext) {
@@ -253,6 +327,30 @@ final class StudioTimelineView: NSView {
         // playback and the drag write it alternately and the handle fights the pointer.
         model.player.beginScrubbing()
 
+        if clipTrack.contains(point) {
+            // A seam takes precedence over the clip body, the way a zoom's edge does over its
+            // middle: the narrow target is the one you have to aim at.
+            if let seam = seam(at: point) {
+                model.selectedClip = nil
+                model.beginGesture()
+                drag = .clipSeam(seam, lastTime: outputTime(forX: point.x))
+                needsDisplay = true
+                return
+            }
+            if let hit = clip(at: point),
+               let index = model.project.timeline.clips.firstIndex(where: { $0.id == hit.id }) {
+                model.selectedClip = hit.id
+                model.selectedZoom = nil
+                drag = .clipBody(hit.id, from: index)
+                dropIndex = index
+                needsDisplay = true
+                // **Returns rather than falling through.** It used to set the selection and then
+                // start a playhead scrub regardless, so a clip could never be dragged: every
+                // attempt scrubbed instead.
+                return
+            }
+        }
+
         if zoomTrack.contains(point), let hit = zoom(at: point) {
             model.selectedZoom = hit.segment.id
             model.selectedClip = nil
@@ -281,6 +379,13 @@ final class StudioTimelineView: NSView {
         switch drag {
         case .none:
             return
+        case .clipBody:
+            dropIndex = insertionIndex(forX: point.x)
+        case .clipSeam(let id, let lastTime):
+            let delta = time - lastTime
+            guard abs(delta) > 0.0001 else { return }
+            drag = .clipSeam(id, lastTime: time)
+            model.rollCut(after: id, by: delta)
         case .playhead:
             onScrub?(time)
         case .zoomBody(let id, let grabbedAt):
@@ -304,9 +409,41 @@ final class StudioTimelineView: NSView {
     }
 
     override func mouseUp(with event: NSEvent) {
-        if case .none = drag {} else if case .playhead = drag {} else { model.endGesture() }
+        if case .clipBody(_, let from) = drag, let dropIndex, dropIndex != from {
+            // Insert-before semantics: dropping to the right of where it came from means the
+            // index shifts down by one once the clip is lifted out.
+            model.moveClip(from: from, to: dropIndex > from ? dropIndex - 1 : dropIndex)
+        }
+        if case .none = drag {} else if case .playhead = drag {} else if case .clipBody = drag {
+        } else { model.endGesture() }
         drag = .none
+        dropIndex = nil
+        needsDisplay = true
         model.player.endScrubbing()
+    }
+
+    /// Which slot in the running order the pointer is over, 0…count.
+    private func insertionIndex(forX position: CGFloat) -> Int {
+        var elapsed: TimeInterval = 0
+        for (index, clip) in model.project.timeline.clips.enumerated() {
+            let middle = x(forOutput: elapsed + clip.outputDuration / 2)
+            if position < middle { return index }
+            elapsed += clip.outputDuration
+        }
+        return model.project.timeline.clips.count
+    }
+
+    /// The clip *before* a seam the pointer is close to, if any. Nil for the outer edges, which
+    /// are trims rather than seams.
+    private func seam(at point: CGPoint) -> Clip.ID? {
+        var elapsed: TimeInterval = 0
+        let clips = model.project.timeline.clips
+        for (index, clip) in clips.enumerated() {
+            elapsed += clip.outputDuration
+            guard index + 1 < clips.count else { break }
+            if abs(point.x - x(forOutput: elapsed)) <= Metrics.edgeGrab { return clip.id }
+        }
+        return nil
     }
 
     /// Editing a zoom marks it as the user's, so "Re-detect" will not take it away again.
@@ -347,6 +484,17 @@ final class StudioTimelineView: NSView {
             menu.addItem(.separator())
         }
 
+        if clipTrack.contains(point), let hit = clip(at: point) {
+            model.selectedClip = hit.id
+            model.selectedZoom = nil
+            add(to: menu, "Duplicate Clip", #selector(menuDuplicateClip))
+            add(to: menu, "Delete Clip", #selector(menuDeleteClip), key: "⌫")
+            if hasHiddenMaterial(hit) {
+                add(to: menu, "Put Back Trimmed Material", #selector(menuUntrimClip))
+            }
+            menu.addItem(.separator())
+        }
+
         add(to: menu, "Add Zoom Here", #selector(menuAddZoom), key: "Z")
         add(to: menu, "Add Click Here", #selector(menuAddClick))
         add(to: menu, "Add Pointer Highlight Here", #selector(menuAddPointerHighlight))
@@ -372,6 +520,20 @@ final class StudioTimelineView: NSView {
         menu.addItem(item)
     }
 
+    private func hasHiddenMaterial(_ clip: Clip) -> Bool {
+        let clips = model.project.timeline.clips
+        guard let index = clips.firstIndex(where: { $0.id == clip.id }) else { return false }
+        let lower = index > 0 ? clips[index - 1].sourceEnd : 0
+        let upper = index + 1 < clips.count ? clips[index + 1].sourceStart : model.recordingDuration
+        return max(0, clip.sourceStart - lower) + max(0, upper - clip.sourceEnd) > 0.15
+    }
+
+    @objc private func menuDuplicateClip() { model.duplicateSelectedClip() }
+    @objc private func menuDeleteClip() { model.deleteSelectedClip() }
+    @objc private func menuUntrimClip() {
+        guard let id = model.selectedClip else { return }
+        model.untrimClip(id)
+    }
     @objc private func menuAddZoom() { model.addZoomAtPlayhead() }
     @objc private func menuDeleteZoom() { model.deleteSelectedZoom() }
     @objc private func menuAddClick() { model.addClickAtPlayhead() }

--- a/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
@@ -253,6 +253,7 @@ final class StudioTimelineView: NSView {
     private static func colour(for kind: TimelineLayout.RowKind) -> NSColor {
         switch kind {
         case .video: return .systemOrange
+        case .media: return .systemBrown
         case .text: return .systemTeal
         case .camera: return .systemPink
         case .zoom: return .systemIndigo
@@ -360,6 +361,9 @@ final class StudioTimelineView: NSView {
         switch item.kind {
         case .video: model.selectedClip = item.id
         case .zoom: model.selectedZoom = item.id
+        case .media:
+            model.selectedMedia = item.id
+            model.inspector = .media
         case .text:
             model.selectedText = item.id
             model.inspector = .text
@@ -427,6 +431,7 @@ final class StudioTimelineView: NSView {
         case .camera: return model.project.cameraSegments.first { $0.id == item.id }?.start
         case .mask: return model.project.masks.first { $0.id == item.id }?.start
         case .pointer: return model.project.pointerHighlights.first { $0.id == item.id }?.start
+        case .media: return model.project.mediaOverlays.first { $0.id == item.id }?.start
         case .video, .caption: return nil
         }
     }

--- a/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
@@ -496,6 +496,7 @@ final class StudioTimelineView: NSView {
         }
 
         add(to: menu, "Add Zoom Here", #selector(menuAddZoom), key: "Z")
+        add(to: menu, "Add Text Here", #selector(menuAddText))
         add(to: menu, "Add Click Here", #selector(menuAddClick))
         add(to: menu, "Add Pointer Highlight Here", #selector(menuAddPointerHighlight))
         add(to: menu, "Add Blur or Highlight Here", #selector(menuAddMask))
@@ -536,6 +537,7 @@ final class StudioTimelineView: NSView {
     }
     @objc private func menuAddZoom() { model.addZoomAtPlayhead() }
     @objc private func menuDeleteZoom() { model.deleteSelectedZoom() }
+    @objc private func menuAddText() { model.addTextAtPlayhead() }
     @objc private func menuAddClick() { model.addClickAtPlayhead() }
     @objc private func menuRemoveClick() { model.suppressClickNearPlayhead() }
     @objc private func menuAddPointerHighlight() { model.addPointerHighlightAtPlayhead() }

--- a/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
+++ b/Sources/Sarvkrit/UI/Studio/StudioTimelineView.swift
@@ -216,6 +216,9 @@ final class StudioTimelineView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
+        // The clock stops writing the playhead for the length of any timeline drag. Otherwise
+        // playback and the drag write it alternately and the handle fights the pointer.
+        model.player.beginScrubbing()
 
         if zoomTrack.contains(point), let hit = zoom(at: point) {
             model.selectedZoom = hit.segment.id
@@ -270,6 +273,7 @@ final class StudioTimelineView: NSView {
     override func mouseUp(with event: NSEvent) {
         if case .none = drag {} else if case .playhead = drag {} else { model.endGesture() }
         drag = .none
+        model.player.endScrubbing()
     }
 
     /// Editing a zoom marks it as the user's, so "Re-detect" will not take it away again.

--- a/Tests/SarvkritTests/CaptionGrouperTests.swift
+++ b/Tests/SarvkritTests/CaptionGrouperTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import Sarvkrit
+
+/// Breaking a stream of timed words into caption lines.
+///
+/// This is where caption *quality* lives. A recogniser hands back words and timings; whether the
+/// result reads well is entirely a matter of where the lines break, and the answer is the same one
+/// a person would give: at a breath, at a full stop, and never so long that the eye has to travel.
+final class CaptionGrouperTests: XCTestCase {
+
+    /// Words at a steady pace, `gap` apart, unless a word is followed by an explicit pause.
+    private func words(_ text: String, from start: TimeInterval = 0,
+                       gap: TimeInterval = 0.3) -> [TranscriptWord] {
+        var t = start
+        return text.split(separator: " ").map { piece -> TranscriptWord in
+            let word = TranscriptWord(text: String(piece), start: t, duration: gap * 0.8)
+            t += gap
+            return word
+        }
+    }
+
+    func testNoWordsMakeNoCaptions() {
+        XCTAssertTrue(CaptionGrouper.lines(from: []).isEmpty)
+    }
+
+    func testAShortPhraseIsOneLine() {
+        XCTAssertEqual(CaptionGrouper.lines(from: words("you press command")).count, 1)
+    }
+
+    /// **Every word, exactly once, in order.** A grouper that drops or duplicates a word produces
+    /// captions that are subtly wrong in a way nobody proof-reads for.
+    func testEveryWordSurvivesExactlyOnce() {
+        let source = words("the quick brown fox jumps over the lazy dog again and again today")
+        let regrouped = CaptionGrouper.lines(from: source).flatMap(\.words)
+        XCTAssertEqual(regrouped.map(\.text), source.map(\.text))
+    }
+
+    /// A pause is where a person would breathe, and therefore where a line should end.
+    func testALongPauseBreaksTheLine() {
+        var source = words("down here")
+        let later = words("and now we format it", from: 5)
+        source.append(contentsOf: later)
+        XCTAssertEqual(CaptionGrouper.lines(from: source).count, 2)
+    }
+
+    func testAFullStopBreaksTheLine() {
+        let source = words("show US dollars. now the next thing")
+        XCTAssertGreaterThan(CaptionGrouper.lines(from: source).count, 1)
+    }
+
+    func testALongRunIsBrokenUp() {
+        let source = words(String(repeating: "alpha ", count: 30))
+        let lines = CaptionGrouper.lines(from: source)
+        XCTAssertGreaterThan(lines.count, 2)
+    }
+
+    func testNoLineExceedsTheCharacterBudgetByMuch() {
+        let source = words(String(repeating: "alpha ", count: 40))
+        let tuning = CaptionGrouper.Tuning()
+        for line in CaptionGrouper.lines(from: source) {
+            let characters = line.words.map(\.text).joined(separator: " ").count
+            XCTAssertLessThanOrEqual(characters, tuning.maximumCharacters + 12)
+        }
+    }
+
+    func testNoLineExceedsTheWordBudget() {
+        let source = words(String(repeating: "a ", count: 40))
+        let tuning = CaptionGrouper.Tuning()
+        for line in CaptionGrouper.lines(from: source) {
+            XCTAssertLessThanOrEqual(line.words.count, tuning.maximumWords)
+        }
+    }
+
+    /// A line holding one word looks like a mistake on screen.
+    func testASingleWordIsNotLeftStranded() {
+        let source = words(String(repeating: "alpha ", count: 19))
+        for line in CaptionGrouper.lines(from: source) where line.words.count == 1 {
+            XCTFail("a caption was left with one word")
+        }
+    }
+
+    func testALineIsTimedFromItsWords() {
+        let source = words("you press command and drag")
+        guard let line = CaptionGrouper.lines(from: source).first,
+              let first = line.words.first, let last = line.words.last else {
+            return XCTFail("expected a line")
+        }
+        XCTAssertEqual(line.start, first.start, accuracy: 0.0001)
+        XCTAssertEqual(line.end, last.start + last.duration, accuracy: 0.0001)
+    }
+
+    func testLinesComeBackInOrder() {
+        let source = words(String(repeating: "alpha ", count: 30))
+        let starts = CaptionGrouper.lines(from: source).map(\.start)
+        XCTAssertEqual(starts, starts.sorted())
+    }
+
+    // MARK: - Karaoke
+
+    /// Word-level highlighting is the thing that makes these captions look expensive, and it is
+    /// only possible because the recogniser gives per-word timings.
+    func testTheSpokenWordCountRisesThroughTheLine() {
+        let line = CaptionGrouper.lines(from: words("you press command and drag it")).first
+        XCTAssertEqual(line?.spokenWordCount(at: -1), 0)
+        XCTAssertEqual(line?.spokenWordCount(at: 100), line?.words.count)
+    }
+
+    func testAWordCountsAsSpokenOnceItHasStarted() {
+        let source = words("you press command")
+        let line = CaptionGrouper.lines(from: source).first
+        XCTAssertEqual(line?.spokenWordCount(at: source[1].start + 0.01), 2)
+    }
+}

--- a/Tests/SarvkritTests/CaptureSessionRunnerTests.swift
+++ b/Tests/SarvkritTests/CaptureSessionRunnerTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import Sarvkrit
+
+/// Ordering inside a capture graph.
+///
+/// **This suite exists because of a crash, and it is the second of its kind.**
+/// `AVCaptureSession.startRunning()` blocks until the graph is up, and anything that needs a
+/// running session — `AVCaptureMovieFileOutput.startRecording(to:)` — blocks until it is.
+/// `CameraRecorder` issued the first on a detached task and the second on the main actor, so the
+/// main thread sat inside AVFoundation waiting on work that had been handed to another thread.
+/// AVFoundation pumps the run loop while it waits, so a click reached a global event monitor with
+/// a main-actor frame still on the stack and the app died in the concurrency runtime's executor
+/// check, reading address `0x1e`.
+///
+/// The rule this suite pins is the one that was missing: **every call into a capture graph goes
+/// through one serial queue, in the order it was asked for, and never on the calling thread.**
+final class CaptureSessionRunnerTests: XCTestCase {
+
+    /// Collects call names from whichever thread runs them.
+    private final class Log: @unchecked Sendable {
+        private let lock = NSLock()
+        private var names: [String] = []
+
+        func record(_ name: String) {
+            lock.lock(); names.append(name); lock.unlock()
+        }
+
+        var recorded: [String] {
+            lock.lock(); defer { lock.unlock() }; return names
+        }
+    }
+
+    /// The whole bug in one assertion: a slow first call must still finish before the second
+    /// starts. `startRunning()` is the slow one, and `startRecording(to:)` is what used to
+    /// overtake it.
+    func testLaterWorkWaitsForSlowerEarlierWork() {
+        let runner = CaptureSessionRunner(label: "test-order")
+        let log = Log()
+        let done = expectation(description: "all three ran")
+        done.expectedFulfillmentCount = 3
+
+        runner.submit {
+            Thread.sleep(forTimeInterval: 0.2)
+            log.record("startRunning")
+            done.fulfill()
+        }
+        runner.submit { log.record("startRecording"); done.fulfill() }
+        runner.submit { log.record("stopRecording"); done.fulfill() }
+
+        wait(for: [done], timeout: 5)
+        XCTAssertEqual(log.recorded, ["startRunning", "startRecording", "stopRecording"])
+    }
+
+    /// A stop asked for in the same breath as a start must still land second, rather than running
+    /// against a session that has not come up yet — which is how the preview left the camera on
+    /// with nothing holding a reference to switch it off.
+    func testStopAskedForImmediatelyAfterStartStillRunsSecond() {
+        let runner = CaptureSessionRunner(label: "test-stop-after-start")
+        let log = Log()
+        let done = expectation(description: "both ran")
+        done.expectedFulfillmentCount = 2
+
+        runner.submit {
+            Thread.sleep(forTimeInterval: 0.15)
+            log.record("start")
+            done.fulfill()
+        }
+        runner.submit { log.record("stop"); done.fulfill() }
+
+        wait(for: [done], timeout: 5)
+        XCTAssertEqual(log.recorded, ["start", "stop"])
+    }
+
+    /// Nothing the graph does may happen on the main thread. This is the property that keeps the
+    /// main actor out of AVFoundation's blocking calls, and it is the one that was missing.
+    func testWorkNeverRunsOnTheMainThread() {
+        let runner = CaptureSessionRunner(label: "test-off-main")
+        let done = expectation(description: "ran")
+        let onMain = Log()
+
+        runner.submit {
+            if Thread.isMainThread { onMain.record("main") }
+            done.fulfill()
+        }
+
+        wait(for: [done], timeout: 2)
+        XCTAssertEqual(onMain.recorded, [], "graph calls must never run on the main thread")
+    }
+}

--- a/Tests/SarvkritTests/CaptureURLCommandTests.swift
+++ b/Tests/SarvkritTests/CaptureURLCommandTests.swift
@@ -352,7 +352,35 @@ final class RecordingURLCommandTests: XCTestCase {
     func testExportTakesADestination() {
         XCTAssertEqual(
             CaptureURLCommand.parse(URL(string: "sarvkrit://export?filepath=/tmp/out.mp4")!),
-            .exportEditor(URL(fileURLWithPath: "/tmp/out.mp4")))
+            .exportEditor(URL(fileURLWithPath: "/tmp/out.mp4"), preset: .web))
+    }
+
+    /// And the quality, so "is the sharpest export actually sharper" is answerable the same way
+    /// "does the export have sound" became answerable.
+    func testExportTakesAPreset() {
+        guard case .exportEditor(_, let preset) = CaptureURLCommand.parse(
+            URL(string: "sarvkrit://export?filepath=/tmp/out.mp4&preset=sharpest")!)
+        else { return XCTFail("not an export") }
+        XCTAssertEqual(preset.id, ExportPreset.sharpest.id)
+    }
+
+    /// A named height overrides the preset and permits the upscale, because naming a size is the
+    /// deliberate choice the no-upscale rule exists to protect against making by accident.
+    func testExportTakesAHeightAndAllowsItToUpscale() {
+        guard case .exportEditor(_, let preset) = CaptureURLCommand.parse(
+            URL(string: "sarvkrit://export?filepath=/tmp/out.mp4&height=2160")!)
+        else { return XCTFail("not an export") }
+        XCTAssertEqual(preset.height, 2160)
+        XCTAssertTrue(preset.allowsUpscale)
+    }
+
+    /// An unknown preset name falls back rather than refusing: a typo in a script should still
+    /// produce a file.
+    func testAnUnknownPresetFallsBack() {
+        guard case .exportEditor(_, let preset) = CaptureURLCommand.parse(
+            URL(string: "sarvkrit://export?filepath=/tmp/out.mp4&preset=nonsense")!)
+        else { return XCTFail("not an export") }
+        XCTAssertEqual(preset.id, ExportPreset.web.id)
     }
 
     func testExportWithoutADestinationIsRefused() {

--- a/Tests/SarvkritTests/CaptureURLCommandTests.swift
+++ b/Tests/SarvkritTests/CaptureURLCommandTests.swift
@@ -377,6 +377,17 @@ final class RecordingURLCommandTests: XCTestCase {
         XCTAssertNil(CaptureURLCommand.parse(URL(string: "sarvkrit://editor")!))
     }
 
+    /// Stamping a picture onto a recording from a script — a logo on every take, say.
+    func testAPictureTakesAFilePath() {
+        XCTAssertEqual(
+            CaptureURLCommand.parse(URL(string: "sarvkrit://picture?filepath=/tmp/logo.png")!),
+            .addPicture(URL(fileURLWithPath: "/tmp/logo.png")))
+    }
+
+    func testAPictureWithoutAPathIsRefused() {
+        XCTAssertNil(CaptureURLCommand.parse(URL(string: "sarvkrit://picture")!))
+    }
+
     func testStopIsItsOwnCommand() {
         XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://stop-recording")!),
                        .stopRecording)

--- a/Tests/SarvkritTests/CaptureURLCommandTests.swift
+++ b/Tests/SarvkritTests/CaptureURLCommandTests.swift
@@ -344,6 +344,21 @@ final class RecordingURLCommandTests: XCTestCase {
         XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://play")!), .playPause)
     }
 
+    /// Exporting from a script, to a named file.
+    ///
+    /// **This exists so "does the export have sound" can be answered.** Export was behind a save
+    /// panel, so verifying it needed a click — and every export shipped silent for exactly as long
+    /// as nobody could check one without a mouse.
+    func testExportTakesADestination() {
+        XCTAssertEqual(
+            CaptureURLCommand.parse(URL(string: "sarvkrit://export?filepath=/tmp/out.mp4")!),
+            .exportEditor(URL(fileURLWithPath: "/tmp/out.mp4")))
+    }
+
+    func testExportWithoutADestinationIsRefused() {
+        XCTAssertNil(CaptureURLCommand.parse(URL(string: "sarvkrit://export")!))
+    }
+
     func testStopIsItsOwnCommand() {
         XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://stop-recording")!),
                        .stopRecording)

--- a/Tests/SarvkritTests/CaptureURLCommandTests.swift
+++ b/Tests/SarvkritTests/CaptureURLCommandTests.swift
@@ -319,6 +319,25 @@ final class RecordingURLCommandTests: XCTestCase {
         XCTAssertNil(CaptureURLCommand.parse(URL(string: "sarvkrit://record?source=webcam")!))
     }
 
+    /// Moving the editor's playhead from a script.
+    ///
+    /// **This exists so the seekbar can be verified at all.** Three rounds of editor bugs have been
+    /// reported and none could be reproduced here, because this machine refuses synthetic input —
+    /// there is no way to drag a scrubber from a script. This is the smallest thing that makes the
+    /// picture-follows-the-handle question answerable without a mouse.
+    func testSeekTakesATimeInSeconds() {
+        XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://seek?t=22.5")!),
+                       .seek(22.5))
+    }
+
+    func testSeekWithoutATimeIsRefused() {
+        XCTAssertNil(CaptureURLCommand.parse(URL(string: "sarvkrit://seek")!))
+    }
+
+    func testANegativeSeekIsRefused() {
+        XCTAssertNil(CaptureURLCommand.parse(URL(string: "sarvkrit://seek?t=-3")!))
+    }
+
     func testStopIsItsOwnCommand() {
         XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://stop-recording")!),
                        .stopRecording)

--- a/Tests/SarvkritTests/CaptureURLCommandTests.swift
+++ b/Tests/SarvkritTests/CaptureURLCommandTests.swift
@@ -283,3 +283,51 @@ final class CaptureThumbnailCacheTests: XCTestCase {
         XCTAssertNil(store.thumbnail(for: item, height: 240))
     }
 }
+
+/// The recording commands.
+///
+/// **These exist so recording can be driven from a script**, which every previous round of
+/// debugging this feature needed and did not have — each one depended on somebody reproducing the
+/// failure by hand and describing what they saw.
+///
+/// The window selector is the part that matters: the failure that started all this was a *window*
+/// recording with a camera selected, and without a way to name a window a script cannot reach it.
+final class RecordingURLCommandTests: XCTestCase {
+
+    func testRecordDefaultsToTheWholeDisplay() {
+        XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://record")!),
+                       .record(.display, windowID: nil))
+    }
+
+    func testEachSourceIsReachable() {
+        for source in RecordingSource.allCases {
+            XCTAssertEqual(
+                CaptureURLCommand.parse(URL(string: "sarvkrit://record?source=\(source.rawValue)")!),
+                .record(source, windowID: nil))
+        }
+    }
+
+    func testAWindowCanBeNamedByID() {
+        XCTAssertEqual(
+            CaptureURLCommand.parse(URL(string: "sarvkrit://record?source=window&window=4231")!),
+            .record(.window, windowID: 4231))
+    }
+
+    /// A source we do not have is not silently a display recording: a typo in a script should do
+    /// nothing, the same rule the rest of this parser follows.
+    func testAnUnknownSourceIsRefused() {
+        XCTAssertNil(CaptureURLCommand.parse(URL(string: "sarvkrit://record?source=webcam")!))
+    }
+
+    func testStopIsItsOwnCommand() {
+        XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://stop-recording")!),
+                       .stopRecording)
+    }
+
+    /// Both appear in the settings list, so neither is a command only its author knows about.
+    func testBothAreListed() {
+        let names = CaptureURLCommand.all.map(\.name)
+        XCTAssertTrue(names.contains("record"))
+        XCTAssertTrue(names.contains("stop-recording"))
+    }
+}

--- a/Tests/SarvkritTests/CaptureURLCommandTests.swift
+++ b/Tests/SarvkritTests/CaptureURLCommandTests.swift
@@ -359,6 +359,24 @@ final class RecordingURLCommandTests: XCTestCase {
         XCTAssertNil(CaptureURLCommand.parse(URL(string: "sarvkrit://export")!))
     }
 
+    /// One command for the editor's own actions, by name.
+    ///
+    /// **A general door rather than a command per action.** The alternative was
+    /// `sarvkrit://split`, `sarvkrit://duplicate-clip` and so on, which is a lot of surface for
+    /// what is really "do the thing the keyboard already does" — and it is how the editor's edits
+    /// get verified at all without a mouse.
+    func testAnEditorCommandTakesItsNameFromTheKeyboard() {
+        XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://editor?do=split")!),
+                       .editorCommand(.split))
+        XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://editor?do=undo")!),
+                       .editorCommand(.undo))
+    }
+
+    func testAnUnknownEditorCommandIsRefused() {
+        XCTAssertNil(CaptureURLCommand.parse(URL(string: "sarvkrit://editor?do=fly")!))
+        XCTAssertNil(CaptureURLCommand.parse(URL(string: "sarvkrit://editor")!))
+    }
+
     func testStopIsItsOwnCommand() {
         XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://stop-recording")!),
                        .stopRecording)

--- a/Tests/SarvkritTests/CaptureURLCommandTests.swift
+++ b/Tests/SarvkritTests/CaptureURLCommandTests.swift
@@ -338,6 +338,12 @@ final class RecordingURLCommandTests: XCTestCase {
         XCTAssertNil(CaptureURLCommand.parse(URL(string: "sarvkrit://seek?t=-3")!))
     }
 
+    /// Starting and stopping playback from a script — the literal complaint was "when I click play
+    /// the seekbar never moves", and there is no other way for me to press it.
+    func testPlayPauseIsItsOwnCommand() {
+        XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://play")!), .playPause)
+    }
+
     func testStopIsItsOwnCommand() {
         XCTAssertEqual(CaptureURLCommand.parse(URL(string: "sarvkrit://stop-recording")!),
                        .stopRecording)

--- a/Tests/SarvkritTests/ClickTrackTests.swift
+++ b/Tests/SarvkritTests/ClickTrackTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import Sarvkrit
+
+/// The clicks a finished video shows, which are no longer only the ones that were recorded.
+///
+/// **Before this, a click could not be edited at all.** `StudioRenderer` read the recording's own
+/// `pressDowns` directly, `EventLog.clicks` is `private(set)`, and `ClickEffect` is a stateless
+/// namespace of pure functions — there was no per-click object anywhere to add, move or remove. A
+/// stray click during a take was in the video for good, and a point you wanted to emphasise but did
+/// not happen to click on could not be marked.
+///
+/// The recording is still never modified. Edits sit beside it, so re-detecting or undoing brings a
+/// suppressed click back.
+final class ClickTrackTests: XCTestCase {
+
+    private func recorded(_ times: [TimeInterval]) -> [ClickEvent] {
+        times.map { ClickEvent(t: $0, point: CGPoint(x: 10, y: 10), button: .left, isDown: true) }
+    }
+
+    func testWithNoEditsTheRecordedClicksComeBackUnchanged() {
+        let clicks = recorded([1, 2, 3])
+        XCTAssertEqual(ClickTrack.effective(recorded: clicks, edits: ClickEdits()), clicks)
+    }
+
+    func testAHandPlacedClickAppears() {
+        var edits = ClickEdits()
+        edits.added = [ManualClick(t: 5, point: CGPoint(x: 40, y: 60))]
+
+        let effective = ClickTrack.effective(recorded: recorded([1]), edits: edits)
+
+        XCTAssertEqual(effective.count, 2)
+        let placed = try? XCTUnwrap(effective.last)
+        XCTAssertEqual(placed?.t, 5)
+        XCTAssertEqual(placed?.point, CGPoint(x: 40, y: 60))
+        XCTAssertTrue(placed?.isDown ?? false, "a click effect only fires on a press")
+    }
+
+    func testTheResultIsInTimeOrderWhereverEditsLand() {
+        var edits = ClickEdits()
+        edits.added = [ManualClick(t: 1.5, point: .zero), ManualClick(t: 0.5, point: .zero)]
+
+        let times = ClickTrack.effective(recorded: recorded([1, 2]), edits: edits).map(\.t)
+
+        XCTAssertEqual(times, [0.5, 1, 1.5, 2])
+    }
+
+    /// A recorded click can be taken out without touching the recording.
+    func testASuppressedRecordedClickDoesNotAppear() {
+        var edits = ClickEdits()
+        edits.suppressed = [2]
+
+        let times = ClickTrack.effective(recorded: recorded([1, 2, 3]), edits: edits).map(\.t)
+
+        XCTAssertEqual(times, [1, 3])
+    }
+
+    /// Suppression matches on time, and a recorded time is a float that has been through JSON —
+    /// so it matches within a tolerance rather than exactly, or the click comes back on reload.
+    func testSuppressionSurvivesAFloatingPointRoundTrip() {
+        var edits = ClickEdits()
+        edits.suppressed = [2.0000000001]
+
+        let times = ClickTrack.effective(recorded: recorded([1, 2, 3]), edits: edits).map(\.t)
+
+        XCTAssertEqual(times, [1, 3])
+    }
+
+    /// Two clicks a frame apart are different clicks, and suppressing one must not take both.
+    func testSuppressionDoesNotTakeANeighbouringClick() {
+        var edits = ClickEdits()
+        edits.suppressed = [2]
+
+        let times = ClickTrack.effective(recorded: recorded([2, 2.1]), edits: edits).map(\.t)
+
+        XCTAssertEqual(times, [2.1])
+    }
+
+    /// Releases are not click effects and must not be invented for hand-placed ones either.
+    func testOnlyPressesAreReturned() {
+        let mixed = [
+            ClickEvent(t: 1, point: .zero, button: .left, isDown: true),
+            ClickEvent(t: 1.1, point: .zero, button: .left, isDown: false),
+        ]
+        XCTAssertEqual(ClickTrack.effective(recorded: mixed, edits: ClickEdits()).map(\.t), [1])
+    }
+}

--- a/Tests/SarvkritTests/CursorGlyphTests.swift
+++ b/Tests/SarvkritTests/CursorGlyphTests.swift
@@ -1,0 +1,107 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// The vector pointers drawn back into the video.
+///
+/// **Drawn, not scaled from a bitmap.** A 16×16 system cursor blown up to 3× is the blurry mess
+/// this whole feature exists to avoid, so each recognised pointer is a path — sharp at any size and
+/// any zoom, for the same reason `CaptureBackground`'s doc comment gives about gradients being data
+/// rather than image assets.
+///
+/// The macOS arrow is a specific shape and getting it wrong is uncanny in a way nobody can name but
+/// everybody notices, which is exactly the kind of thing that regresses invisibly.
+final class CursorGlyphTests: XCTestCase {
+
+    func testEveryKindHasAGlyph() {
+        for kind in CursorKind.allCases {
+            XCTAssertFalse(CursorGlyph.path(for: kind).isEmpty, "\(kind.rawValue) has no path")
+        }
+    }
+
+    /// The unit box is what makes size a single multiplier everywhere else.
+    func testEveryGlyphFitsInsideItsUnitBox() {
+        for kind in CursorKind.allCases {
+            let bounds = CursorGlyph.path(for: kind).boundingBoxOfPath
+            XCTAssertGreaterThanOrEqual(bounds.minX, -0.01, "\(kind.rawValue)")
+            XCTAssertGreaterThanOrEqual(bounds.minY, -0.01, "\(kind.rawValue)")
+            XCTAssertLessThanOrEqual(bounds.maxX, CursorGlyph.unitSize + 0.01, "\(kind.rawValue)")
+            XCTAssertLessThanOrEqual(bounds.maxY, CursorGlyph.unitSize + 0.01, "\(kind.rawValue)")
+        }
+    }
+
+    /// The hotspot is where the click actually happened. An arrow's is its tip; an I-beam's is its
+    /// middle. Getting this wrong offsets every click effect from the thing it clicked.
+    func testEveryHotspotIsInsideItsGlyph() {
+        for kind in CursorKind.allCases {
+            let hotspot = CursorGlyph.hotspot(for: kind)
+            XCTAssertTrue((0...1).contains(hotspot.x), "\(kind.rawValue) x")
+            XCTAssertTrue((0...1).contains(hotspot.y), "\(kind.rawValue) y")
+        }
+    }
+
+    func testTheArrowPointsFromItsTopLeftCorner() {
+        let hotspot = CursorGlyph.hotspot(for: .arrow)
+        XCTAssertEqual(hotspot.x, 0, accuracy: 0.05)
+        XCTAssertEqual(hotspot.y, 0, accuracy: 0.05)
+    }
+
+    func testACentredCursorIsGrabbedByItsMiddle() {
+        for kind in [CursorKind.iBeam, .crosshair, .resizeLeftRight, .resizeUpDown] {
+            let hotspot = CursorGlyph.hotspot(for: kind)
+            XCTAssertEqual(hotspot.x, 0.5, accuracy: 0.05, "\(kind.rawValue)")
+            XCTAssertEqual(hotspot.y, 0.5, accuracy: 0.05, "\(kind.rawValue)")
+        }
+    }
+
+    /// An unrecognised pointer keeps its own bitmap, so there is nothing to draw for `.custom` —
+    /// but a path is still returned rather than nothing, because a missing glyph must degrade to an
+    /// arrow instead of to an invisible cursor.
+    func testAnUnknownKindFallsBackToTheArrow() {
+        XCTAssertEqual(CursorGlyph.path(for: .unknown).boundingBoxOfPath,
+                       CursorGlyph.path(for: .arrow).boundingBoxOfPath)
+    }
+
+    // MARK: - Sizing
+
+    /// Cursor size is applied in canvas space, not screen-layer space. If it scaled with the zoom,
+    /// a 2.5× close-up would come with a comically large pointer.
+    func testTheCursorGrowsFarSlowerThanTheZoom() {
+        let atRest = CursorGlyph.drawnSize(base: 1.6, zoom: 1)
+        let zoomed = CursorGlyph.drawnSize(base: 1.6, zoom: 2.5)
+        XCTAssertGreaterThan(zoomed, atRest)
+        XCTAssertLessThan(zoomed / atRest, 1.5, "the cursor is tracking the zoom too closely")
+    }
+
+    /// The size is exactly what was asked for at rest. The user's own Accessibility pointer size
+    /// is not an input: the recording has no cursor in it, so theirs never reaches the video and
+    /// there is nothing for ours to compound with.
+    func testAtRestTheCursorIsExactlyTheRequestedSize() {
+        XCTAssertEqual(CursorGlyph.drawnSize(base: 2, zoom: 1),
+                       2 * Double(CursorGlyph.unitSize), accuracy: 0.0001)
+    }
+
+    // MARK: - Rendering
+
+    func testAGlyphRendersAtTheHeightItWasAskedFor() throws {
+        let rendered = try XCTUnwrap(CursorGlyph.rendered(for: .arrow, glyphHeight: 64))
+        XCTAssertEqual(rendered.glyphHeight, 64, accuracy: 0.0001)
+    }
+
+    /// The bitmap is deliberately bigger than the glyph — a shadow needs room. Treating the whole
+    /// bitmap as the pointer would shrink it and put its hotspot in the wrong place.
+    func testTheBitmapLeavesRoomForTheShadow() throws {
+        let rendered = try XCTUnwrap(CursorGlyph.rendered(for: .arrow, glyphHeight: 64))
+        XCTAssertGreaterThan(rendered.image.height, Int(rendered.glyphHeight))
+        XCTAssertGreaterThan(rendered.inset, 0)
+    }
+
+    /// Two different pointers must not render identically — the cheapest possible guard against a
+    /// switch that silently falls through to the arrow.
+    func testDifferentKindsRenderDifferently() throws {
+        let arrow = try XCTUnwrap(CursorGlyph.rendered(for: .arrow, glyphHeight: 64))
+        let hand = try XCTUnwrap(CursorGlyph.rendered(for: .pointingHand, glyphHeight: 64))
+        XCTAssertNotEqual(CaptureWriter.pngData(from: arrow.image),
+                          CaptureWriter.pngData(from: hand.image))
+    }
+}

--- a/Tests/SarvkritTests/CursorPathTests.swift
+++ b/Tests/SarvkritTests/CursorPathTests.swift
@@ -1,0 +1,160 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// Turning a sampled pointer path into one that looks like it has weight.
+///
+/// **The tension this suite exists to hold.** Smoothing removes the hand jitter that is invisible
+/// at 1× and obvious at 2.5× — but smoothing is lag, and a cursor that arrives after the click it
+/// made is far worse than a jittery one. So the smoother is suspended around clicks, and
+/// `testTheCursorIsExactlyOnTheClickPoint` is the test that matters most in the file.
+final class CursorPathTests: XCTestCase {
+
+    private func straightPath(count: Int = 60) -> [CursorSample] {
+        (0..<count).map {
+            CursorSample(t: Double($0) / 60, point: CGPoint(x: Double($0) * 10, y: 500))
+        }
+    }
+
+    /// A straight line with alternating noise on it — what a real hand produces.
+    private func jitteryPath(count: Int = 60) -> [CursorSample] {
+        (0..<count).map { index -> CursorSample in
+            let wobble: Double = index % 2 == 0 ? 6 : -6
+            let x: Double = Double(index) * 10 + wobble
+            return CursorSample(t: Double(index) / 60, point: CGPoint(x: x, y: 500))
+        }
+    }
+
+    /// Sum of second differences: how much the path changes direction. Lower is smoother.
+    ///
+    /// **Measured over the interior only.** Any symmetric filter has to invent something at the
+    /// ends of the array, and every choice about that shows up as curvature in the first and last
+    /// few samples. That is a question about boundary handling, not about the filter, and letting
+    /// it into the measurement makes these assertions fragile for a reason unrelated to what they
+    /// are checking.
+    private func wobble(_ samples: [CursorSample], margin: Int = 6) -> Double {
+        let usable = samples.dropFirst(margin).dropLast(margin)
+        guard usable.count > 2 else { return 0 }
+        let points = usable.map(\.point)
+        var total = 0.0
+        for index in 2..<points.count {
+            let a = points[index - 2], b = points[index - 1], c = points[index]
+            let dx = c.x - 2 * b.x + a.x
+            let dy = c.y - 2 * b.y + a.y
+            total += Double(hypot(dx, dy))
+        }
+        return total
+    }
+
+    // MARK: - Smoothing
+
+    /// Off means the raw path, not "a bit less". Some recordings — drawing apps, precise dragging
+    /// — are made worse by any smoothing at all, and the setting has to mean what it says.
+    func testSmoothingOffReturnsThePathUntouched() {
+        let path = jitteryPath()
+        XCTAssertEqual(CursorPath.smoothed(path, smoothing: .off), path)
+    }
+
+    func testSmoothingReducesWobble() {
+        let raw = jitteryPath()
+        let smoothed = CursorPath.smoothed(raw, smoothing: .standard)
+        XCTAssertLessThan(wobble(smoothed), wobble(raw) * 0.6)
+    }
+
+    func testHeavierSmoothingWobblesLess() {
+        let raw = jitteryPath()
+        XCTAssertLessThan(wobble(CursorPath.smoothed(raw, smoothing: .heavy)),
+                          wobble(CursorPath.smoothed(raw, smoothing: .light)))
+    }
+
+    func testSmoothingKeepsEverySample() {
+        let raw = jitteryPath()
+        XCTAssertEqual(CursorPath.smoothed(raw, smoothing: .heavy).count, raw.count)
+    }
+
+    func testSmoothingPreservesTheTimestamps() {
+        let raw = jitteryPath()
+        XCTAssertEqual(CursorPath.smoothed(raw, smoothing: .heavy).map(\.t), raw.map(\.t))
+    }
+
+    /// A straight path has nothing to smooth, so it should come back essentially unchanged rather
+    /// than being dragged behind by the filter.
+    func testSmoothingDoesNotDragAStraightPathOffCourse() {
+        let raw = straightPath()
+        let smoothed = CursorPath.smoothed(raw, smoothing: .standard)
+        let drift = zip(raw, smoothed).map { hypot($0.point.x - $1.point.x, $0.point.y - $1.point.y) }
+        XCTAssertLessThan(drift.max() ?? 999, 12)
+    }
+
+    // MARK: - Clicks
+
+    /// **The one that matters.** A click that lands somewhere the cursor visibly is not looks like
+    /// the app mis-clicked, and no amount of smoothness is worth it.
+    func testTheCursorIsExactlyOnThePointItClicked() {
+        let raw = jitteryPath()
+        let clickTime = raw[30].t
+        let smoothed = CursorPath.smoothed(raw, smoothing: .heavy, snappingTo: [clickTime])
+        XCTAssertEqual(smoothed[30].point.x, raw[30].point.x, accuracy: 0.001)
+        XCTAssertEqual(smoothed[30].point.y, raw[30].point.y, accuracy: 0.001)
+    }
+
+    /// Away from the click the smoother is doing its job again — the suspension is local.
+    func testSmoothingResumesAwayFromAClick() {
+        let raw = jitteryPath()
+        let smoothed = CursorPath.smoothed(raw, smoothing: .heavy, snappingTo: [raw[30].t])
+        XCTAssertLessThan(wobble(Array(smoothed[0..<24])), wobble(Array(raw[0..<24])))
+    }
+
+    // MARK: - Shakes
+
+    /// macOS enlarges the pointer when you shake it. The size never reaches us — we do not capture
+    /// the bitmap for known cursors — but the violent zigzag does, and the zoom planner would read
+    /// it as activity while the smoother chased it.
+    func testAShakeIsReplacedByAStraightLine() {
+        var samples = straightPath(count: 40)
+        for index in 15..<25 {
+            samples[index].point.x = 150 + (index % 2 == 0 ? 90 : -90)
+        }
+        let cleaned = CursorPath.removingShakes(samples)
+        XCTAssertLessThan(wobble(cleaned), wobble(samples) * 0.35)
+    }
+
+    func testAnOrdinaryPathIsLeftAlone() {
+        let path = straightPath()
+        XCTAssertEqual(CursorPath.removingShakes(path), path)
+    }
+
+    func testShakeRemovalKeepsEverySample() {
+        var samples = straightPath(count: 40)
+        for index in 15..<25 { samples[index].point.x = 150 + (index % 2 == 0 ? 90 : -90) }
+        XCTAssertEqual(CursorPath.removingShakes(samples).count, 40)
+    }
+
+    // MARK: - Looping
+
+    /// A recording meant to loop — a demo GIF, a landing-page hero — has an obvious seam if the
+    /// pointer ends far from where it started.
+    func testLoopingBringsTheCursorBackToWhereItStarted() {
+        let path = straightPath()
+        let looped = CursorPath.looped(path, over: 0.4)
+        XCTAssertEqual(looped.last?.point.x ?? -1, path.first?.point.x ?? -2, accuracy: 0.5)
+        XCTAssertEqual(looped.last?.point.y ?? -1, path.first?.point.y ?? -2, accuracy: 0.5)
+    }
+
+    /// Only the tail is rewritten; the demo itself must be untouched.
+    func testLoopingLeavesTheStartOfThePathAlone() {
+        let path = straightPath()
+        let looped = CursorPath.looped(path, over: 0.2)
+        XCTAssertEqual(looped[0].point.x, path[0].point.x, accuracy: 0.0001)
+        XCTAssertEqual(looped[10].point.x, path[10].point.x, accuracy: 0.0001)
+    }
+
+    func testLoopingAnEmptyPathIsSafe() {
+        XCTAssertTrue(CursorPath.looped([], over: 1).isEmpty)
+    }
+
+    func testLoopingOverNoTimeChangesNothing() {
+        let path = straightPath()
+        XCTAssertEqual(CursorPath.looped(path, over: 0), path)
+    }
+}

--- a/Tests/SarvkritTests/EntitlementsTests.swift
+++ b/Tests/SarvkritTests/EntitlementsTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import Sarvkrit
+
+/// What the app is allowed to ask for.
+///
+/// **This suite exists because of a silent failure.** Screen Recording's camera looked correct from
+/// every angle — the usage string was present, the code requested access, the UI reported the
+/// result honestly — and macOS never showed the prompt. Under Hardened Runtime the entitlement is
+/// required *to ask*, and without it `requestAccess` returns denied having asked nobody. The user
+/// is then sent to System Settings to find an app that is not listed there, because it never got
+/// far enough to be added.
+///
+/// Nothing about that is visible in Swift, so it is asserted against the built bundle instead.
+final class EntitlementsTests: XCTestCase {
+
+    private func entitlements() throws -> [String: Any] {
+        let url = try XCTUnwrap(Bundle.main.url(forResource: "Sarvkrit", withExtension: "entitlements")
+            ?? Bundle(for: Self.self).bundleURL
+                .deletingLastPathComponent().deletingLastPathComponent()
+                .appendingPathComponent("Sarvkrit.app/Contents/Resources/Sarvkrit.entitlements"),
+            "the entitlements file is not in the bundle")
+        let data = try Data(contentsOf: url)
+        return try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
+    }
+
+    /// Read from the source file rather than the bundle: entitlements are baked into the signature
+    /// at build time and are not copied in as a resource, so this is the only place to check them
+    /// without shelling out to codesign.
+    private func sourceEntitlements() throws -> [String: Any] {
+        let here = URL(fileURLWithPath: #filePath)
+        let root = here.deletingLastPathComponent().deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let url = root.appendingPathComponent("Sources/Sarvkrit/Resources/Sarvkrit.entitlements")
+        let data = try Data(contentsOf: url)
+        return try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
+    }
+
+    func testTheCameraEntitlementIsPresent() throws {
+        XCTAssertEqual(try sourceEntitlements()["com.apple.security.device.camera"] as? Bool, true,
+                       "without this, macOS will not even show the camera prompt")
+    }
+
+    func testTheMicrophoneEntitlementIsPresent() throws {
+        XCTAssertEqual(try sourceEntitlements()["com.apple.security.device.audio-input"] as? Bool,
+                       true, "without this, macOS will not even show the microphone prompt")
+    }
+
+    func testAppleEventsAutomationIsStillThere() throws {
+        XCTAssertEqual(
+            try sourceEntitlements()["com.apple.security.automation.apple-events"] as? Bool, true)
+    }
+
+    /// **The one that must never appear.** Event taps and the Accessibility API are incompatible
+    /// with the App Sandbox, and the README says so at length: the sandbox is off precisely because
+    /// this key is absent, and there is no build setting to flip. Adding it would break Finder
+    /// Cut & Paste, Window Management and the clipboard's global shortcuts at once.
+    func testTheAppSandboxIsNotEnabled() throws {
+        XCTAssertNil(try sourceEntitlements()["com.apple.security.app-sandbox"],
+                     "the App Sandbox must stay off — see the README")
+    }
+
+    /// A usage string is the other half; neither works without the other.
+    func testEveryDevicePermissionHasItsExplanation() throws {
+        let info = Bundle.main.infoDictionary ?? [:]
+        for key in ["NSCameraUsageDescription", "NSMicrophoneUsageDescription",
+                    "NSSpeechRecognitionUsageDescription"] {
+            let text = info[key] as? String ?? ""
+            XCTAssertFalse(text.isEmpty, "\(key) is missing from Info.plist")
+        }
+    }
+
+    /// The URL name is what System Settings looks the app up by; a stale bundle id there logs an
+    /// error in the privacy pane every time somebody opens it to grant a permission.
+    func testTheURLNameMatchesTheBundleIdentifier() throws {
+        let types = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]] ?? []
+        for type in types {
+            guard let name = type["CFBundleURLName"] as? String else { continue }
+            XCTAssertTrue(name.hasPrefix(AppIdentity.bundleID),
+                          "\(name) does not belong to \(AppIdentity.bundleID)")
+        }
+    }
+}

--- a/Tests/SarvkritTests/EventRecorderIsolationTests.swift
+++ b/Tests/SarvkritTests/EventRecorderIsolationTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import Sarvkrit
+
+/// Where the event log is allowed to be written from.
+///
+/// **This suite exists because of a crash, and it is the third in this feature.**
+///
+/// ```
+/// objc_opt_class → swift_getObjectType → swift_task_isMainExecutorImpl
+///   → MainActor.assumeIsolated → closure #1 in EventRecorder.installMonitors()
+///   → GlobalObserverHandler → DispatchEventToHandlers → … → NSApplicationMain
+/// EXC_BAD_ACCESS, KERN_INVALID_ADDRESS at 0x000000000000001e
+/// ```
+///
+/// The monitors were installed while `start()` was still blocked inside AVFoundation, which pumps
+/// the run loop as it waits. AppKit delivered a click to the global monitor with a main-actor frame
+/// still on the stack, `MainActor.assumeIsolated` asked the concurrency runtime which executor was
+/// current, and the answer was the address `0x1e`.
+///
+/// `CameraRecorder` no longer blocks, so that window is closed — but the recorder should never have
+/// been asserting its way onto an actor from an AppKit callback in the first place. AppKit makes no
+/// isolation promise the compiler can see. `RecordingWriter` learned this after the first crash in
+/// this same feature: *"the hot path must not touch the main actor."*
+///
+/// So the state is lock-guarded and the callbacks record where they land.
+final class EventRecorderIsolationTests: XCTestCase {
+
+    /// Every flag survives, from any thread, with no main actor anywhere in sight. Before this,
+    /// `EventRecorder` was `@MainActor` and this did not compile — which is what red looks like
+    /// for an isolation bug.
+    func testFlagsRecordedFromManyThreadsAreAllKept() {
+        let recorder = EventRecorder()
+        recorder.begin(mapping: { _ in nil })
+
+        let group = DispatchGroup()
+        for _ in 0..<200 {
+            DispatchQueue.global().async(group: group) { recorder.flag() }
+        }
+        group.wait()
+
+        let log = recorder.finish(anchoredTo: 0)
+        XCTAssertEqual(log.flags.count, 200, "a flag was lost between threads")
+    }
+
+    /// Beginning twice must not leave two sets of monitors installed. It used to, and then every
+    /// click and keystroke was recorded twice — doubled click rings and a doubled keystroke
+    /// overlay in the finished video.
+    func testBeginningTwiceDoesNotDoubleTheMonitors() {
+        let recorder = EventRecorder()
+        recorder.begin(mapping: { _ in nil })
+        recorder.begin(mapping: { _ in nil })
+
+        XCTAssertEqual(recorder.installedMonitorCount, 1,
+                       "a second begin() installed another monitor on top of the first")
+    }
+
+    /// A recording that never started still has to give its monitors back. `finish()` on the
+    /// service is gated behind `isRecording`, so when a start failed part-way nothing removed
+    /// them, and the app went on watching every click on the Mac for the rest of its life.
+    func testFinishingWithoutAnAnchorStillRemovesTheMonitors() {
+        let recorder = EventRecorder()
+        recorder.begin(mapping: { _ in nil })
+        XCTAssertEqual(recorder.installedMonitorCount, 1)
+
+        _ = recorder.finish(anchoredTo: nil)
+
+        XCTAssertEqual(recorder.installedMonitorCount, 0)
+    }
+}

--- a/Tests/SarvkritTests/ExportChoiceTests.swift
+++ b/Tests/SarvkritTests/ExportChoiceTests.swift
@@ -1,0 +1,195 @@
+import AVFoundation
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// What the export is allowed to come out as.
+///
+/// **Every export was 1080p and nothing said otherwise.** A frame pulled out of a real export of a
+/// 3024×1964 recording measured 1662×1080 — the capture is at the display's full backing
+/// resolution and the export threw away 45% of it linearly. The cause was one literal:
+/// `StudioEditorWindowController` passed `preset: .web`, and `.web` is `height: 1080`. Both the
+/// Export button and `sarvkrit://export` funnelled through it, and three of the four presets were
+/// constructed nowhere outside tests.
+final class ExportChoiceTests: XCTestCase {
+
+    /// A 3024×1964 Retina capture with the default 64pt background padding, which is the shape the
+    /// numbers in the report came from.
+    private let canvas = CGSize(width: 3152, height: 2092)
+
+    // MARK: - Native means native
+
+    /// The whole point of the round: the sharpest export keeps every pixel that was recorded.
+    func testTheSharpestPresetKeepsTheWholeCanvas() {
+        XCTAssertEqual(ExportPreset.sharpest.outputSize(forCanvas: canvas), canvas)
+    }
+
+    func testTheSharpestPresetUsesTheRecordingsOwnFrameRate() {
+        XCTAssertNil(ExportPreset.sharpest.fps,
+                     "nil means the recording's own rate; a fixed number would resample it")
+    }
+
+    /// **A 30fps recording exported at 60 is every frame duplicated.** `preset.fps` was always
+    /// taken literally and `manifest.fps` was never read, so choosing 30fps in the recording
+    /// settings produced a 60fps file of pairs.
+    func testAPresetWithNoFrameRateFollowsTheRecording() {
+        XCTAssertEqual(ExportPreset.sharpest.frameRate(forRecording: 30), 30)
+        XCTAssertEqual(ExportPreset.sharpest.frameRate(forRecording: 60), 60)
+    }
+
+    func testAPresetWithItsOwnFrameRateKeepsIt() {
+        XCTAssertEqual(ExportPreset.small.frameRate(forRecording: 60), 30)
+    }
+
+    // MARK: - Upscaling is offered, and only when asked for
+
+    /// A preset must never upscale by accident: a 720p recording exported at 4K is a bigger file
+    /// and not a better video.
+    func testAPresetNeverUpscalesOnItsOwn() {
+        let small = CGSize(width: 640, height: 360)
+        XCTAssertEqual(ExportPreset.web.outputSize(forCanvas: small).height, 360, accuracy: 1)
+    }
+
+    /// **But a deliberate choice is not overridden.** 4K is offered for a 2092-tall canvas because
+    /// it was asked for, and the dialog says it will upscale rather than silently capping.
+    func testADeliberateUpscaleIsHonoured() {
+        var chosen = ExportPreset.web
+        chosen.height = 2160
+        chosen.allowsUpscale = true
+        XCTAssertEqual(chosen.outputSize(forCanvas: canvas).height, 2160, accuracy: 1)
+    }
+
+    func testTheSameChoiceWithoutPermissionStillCaps() {
+        var chosen = ExportPreset.web
+        chosen.height = 2160
+        XCTAssertEqual(chosen.outputSize(forCanvas: canvas).height, canvas.height, accuracy: 1)
+    }
+
+    func testAnUpscaleKeepsTheAspect() {
+        var chosen = ExportPreset.web
+        chosen.height = 2160
+        chosen.allowsUpscale = true
+        let size = chosen.outputSize(forCanvas: canvas)
+        XCTAssertEqual(size.width / size.height, canvas.width / canvas.height, accuracy: 0.01)
+    }
+
+    func testEveryOutputSizeIsEven() {
+        for preset in ExportPreset.all {
+            let size = preset.outputSize(forCanvas: CGSize(width: 1919, height: 1081))
+            XCTAssertEqual(Int(size.width) % 2, 0, preset.name)
+            XCTAssertEqual(Int(size.height) % 2, 0, preset.name)
+        }
+    }
+
+    // MARK: - The offered list
+
+    /// Named against the canvas, so the menu says the pixels it will actually produce rather than
+    /// a label that means something different for every recording.
+    func testTheResolutionListNamesRealPixelSizes() {
+        let offered = ExportResolution.offered(forCanvas: canvas)
+        XCTAssertEqual(offered.first?.resolution, ExportResolution.Choice.native)
+        XCTAssertEqual(offered.first?.size, canvas)
+        XCTAssertTrue(offered.contains { $0.resolution == ExportResolution.Choice.height(2160) })
+        XCTAssertTrue(offered.contains { $0.resolution == ExportResolution.Choice.height(1080) })
+    }
+
+    /// Anything above the canvas is marked, because that is the difference between a bigger file
+    /// and a better video.
+    func testASizeAboveTheCanvasIsMarkedAsUpscaled() {
+        let offered = ExportResolution.offered(forCanvas: canvas)
+        let fourK = offered.first { $0.resolution == ExportResolution.Choice.height(2160) }
+        XCTAssertEqual(fourK?.upscales, true)
+        let hd = offered.first { $0.resolution == ExportResolution.Choice.height(1080) }
+        XCTAssertEqual(hd?.upscales, false)
+        XCTAssertEqual(offered.first?.upscales, false, "native never upscales")
+    }
+
+    /// **Padding costs resolution off the picture.** The height cap measures the padded canvas, so
+    /// "1080p" on a 3152×2092 canvas puts the recording's own content at about 1014 pixels. The
+    /// dialog has to be able to say so.
+    func testTheContentHeightIsReportedSeparatelyFromTheFrameHeight() {
+        let offered = ExportResolution.offered(forCanvas: canvas)
+        let hd = try? XCTUnwrap(offered.first { $0.resolution == ExportResolution.Choice.height(1080) })
+        XCTAssertEqual(hd?.contentHeight(forRecording: CGSize(width: 3024, height: 1964)) ?? 0,
+                       1014, accuracy: 2)
+    }
+
+    /// And says nothing when there is nothing to say — an unpadded canvas loses none.
+    func testAnUnpaddedCanvasLosesNothingToPadding() {
+        let unpadded = CGSize(width: 3024, height: 1964)
+        let offered = ExportResolution.offered(forCanvas: unpadded)
+        let native = try? XCTUnwrap(offered.first)
+        XCTAssertEqual(native?.contentHeight(forRecording: unpadded) ?? 0, 1964, accuracy: 1)
+    }
+
+    // MARK: - The container follows the codec
+
+    /// The save panel offered only `.mpeg4Movie` while the exporter writes `.mov` for ProRes, so
+    /// choosing the editor preset would have produced a file the panel would not name.
+    func testTheFileTypeFollowsTheCodec() {
+        XCTAssertEqual(ExportPreset.web.fileType, .mp4)
+        XCTAssertEqual(ExportPreset.forEditing.fileType, .mov)
+        XCTAssertEqual(ExportPreset.web.contentType, .mpeg4Movie)
+        XCTAssertEqual(ExportPreset.forEditing.contentType, .quickTimeMovie)
+    }
+
+    func testTheFileExtensionFollowsTheCodecToo() {
+        XCTAssertEqual(ExportPreset.web.fileExtension, "mp4")
+        XCTAssertEqual(ExportPreset.forEditing.fileExtension, "mov")
+    }
+
+    // MARK: - Bitrate
+
+    /// **The bitrate ignored the frame rate**, so 60fps and 30fps were given the same budget and
+    /// 60fps quietly got half the quality per frame.
+    func testTheBitrateRisesWithTheFrameRate() {
+        let size = CGSize(width: 1920, height: 1080)
+        let slow = ExportPreset.videoBitrate(size: size, fps: 30)
+        let fast = ExportPreset.videoBitrate(size: size, fps: 60)
+        XCTAssertGreaterThan(fast, slow)
+    }
+
+    func testTheBitrateRisesWithTheFrameSize() {
+        XCTAssertGreaterThan(
+            ExportPreset.videoBitrate(size: CGSize(width: 3840, height: 2160), fps: 60),
+            ExportPreset.videoBitrate(size: CGSize(width: 1920, height: 1080), fps: 60))
+    }
+
+    /// A 4K 60fps H.264 stream at a sane rate, so the estimate the dialog shows is not nonsense.
+    func testAFourKBitrateIsInAPlausibleRange() {
+        let rate = ExportPreset.videoBitrate(size: CGSize(width: 3840, height: 2160), fps: 60)
+        XCTAssertGreaterThan(rate, 20_000_000)
+        XCTAssertLessThan(rate, 200_000_000)
+    }
+
+    // MARK: - Saying how big it will be
+
+    func testTheEstimateGrowsWithDuration() {
+        let short = ExportPreset.web.estimatedBytes(forCanvas: canvas, seconds: 10, recordingFPS: 60)
+        let long = ExportPreset.web.estimatedBytes(forCanvas: canvas, seconds: 60, recordingFPS: 60)
+        XCTAssertGreaterThan(long, short * 4)
+    }
+
+    func testTheEstimateIsLargerForTheSharperPreset() {
+        XCTAssertGreaterThan(
+            ExportPreset.sharpest.estimatedBytes(forCanvas: canvas, seconds: 30, recordingFPS: 60),
+            ExportPreset.small.estimatedBytes(forCanvas: canvas, seconds: 30, recordingFPS: 60))
+    }
+
+    // MARK: - Every preset is reachable and honest
+
+    /// `.social` promised burnt-in captions through a `forcesCaptions` flag that nothing read, and
+    /// `.forEditing` promised split audio tracks through another. Both are gone rather than
+    /// wired up: captions already burn in whenever the project has them, so the preset could only
+    /// have promised something it does not do.
+    func testEveryPresetIsOfferedAndDistinct() {
+        XCTAssertEqual(Set(ExportPreset.all.map(\.id)).count, ExportPreset.all.count)
+        XCTAssertTrue(ExportPreset.all.contains { $0.id == ExportPreset.sharpest.id })
+        XCTAssertTrue(ExportPreset.all.contains { $0.id == ExportPreset.forEditing.id })
+    }
+
+    /// The default is the one that plays everywhere, not the one that is technically best.
+    func testTheDefaultPresetIsPlayableEverywhere() {
+        XCTAssertEqual(ExportPreset.web.codec, .h264)
+    }
+}

--- a/Tests/SarvkritTests/ExportChoiceTests.swift
+++ b/Tests/SarvkritTests/ExportChoiceTests.swift
@@ -13,8 +13,12 @@ import XCTest
 /// constructed nowhere outside tests.
 final class ExportChoiceTests: XCTestCase {
 
-    /// A 3024×1964 Retina capture with the default 64pt background padding, which is the shape the
-    /// numbers in the report came from.
+    /// A stand-in for a padded canvas: taller and wider than the recording inside it.
+    ///
+    /// **Not the exact canvas a 3024×1964 capture produces** — that is about 3221×2092, because
+    /// `.original` aspect widens the padded 3152×2092 back to the recording's own ratio, which is
+    /// also why the old export came out 1662 wide rather than 1628. The arithmetic under test does
+    /// not care which canvas it is handed; the live pass measures the real one.
     private let canvas = CGSize(width: 3152, height: 2092)
 
     // MARK: - Native means native

--- a/Tests/SarvkritTests/FadeCurtainTests.swift
+++ b/Tests/SarvkritTests/FadeCurtainTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import Sarvkrit
+
+/// The black wash: a fade up from black, a fade down to it, and a dip at a cut.
+///
+/// **One piece of arithmetic for three features**, because they are the same wash at different
+/// times. Dip-to-black rather than crossfade is a deliberate limit: a crossfade needs the outgoing
+/// *and* incoming frames at once, so a second decoder in the player and buffering in the exporter,
+/// where a dip needs the one frame it already has.
+final class FadeCurtainTests: XCTestCase {
+
+    func testWithNoFadesTheFrameIsNeverWashed() {
+        XCTAssertEqual(FadeCurtain.alpha(atOutput: 3, duration: 10, fadeIn: 0, fadeOut: 0), 0)
+    }
+
+    func testTheFirstFrameIsBlackAndItClearsByTheEndOfTheFade() {
+        XCTAssertEqual(FadeCurtain.alpha(atOutput: 0, duration: 10, fadeIn: 1, fadeOut: 0), 1,
+                       accuracy: 1e-9)
+        XCTAssertEqual(FadeCurtain.alpha(atOutput: 0.5, duration: 10, fadeIn: 1, fadeOut: 0), 0.5,
+                       accuracy: 1e-9)
+        XCTAssertEqual(FadeCurtain.alpha(atOutput: 1, duration: 10, fadeIn: 1, fadeOut: 0), 0,
+                       accuracy: 1e-9)
+    }
+
+    func testTheLastFrameFadesDownToBlack() {
+        XCTAssertEqual(FadeCurtain.alpha(atOutput: 10, duration: 10, fadeIn: 0, fadeOut: 2), 1,
+                       accuracy: 1e-9)
+        XCTAssertEqual(FadeCurtain.alpha(atOutput: 9, duration: 10, fadeIn: 0, fadeOut: 2), 0.5,
+                       accuracy: 1e-9)
+        XCTAssertEqual(FadeCurtain.alpha(atOutput: 7, duration: 10, fadeIn: 0, fadeOut: 2), 0,
+                       accuracy: 1e-9)
+    }
+
+    /// A dip is fully black at the cut and clear at either end of its length.
+    func testADipIsBlackAtTheCut() {
+        let dips = [FadeCurtain.Dip(at: 5, length: 1)]
+        XCTAssertEqual(FadeCurtain.alpha(atOutput: 5, duration: 10, fadeIn: 0, fadeOut: 0,
+                                         dips: dips), 1, accuracy: 1e-9)
+        XCTAssertEqual(FadeCurtain.alpha(atOutput: 4.75, duration: 10, fadeIn: 0, fadeOut: 0,
+                                         dips: dips), 0.5, accuracy: 1e-9)
+        XCTAssertEqual(FadeCurtain.alpha(atOutput: 4.4, duration: 10, fadeIn: 0, fadeOut: 0,
+                                         dips: dips), 0, accuracy: 1e-9)
+    }
+
+    /// Overlapping washes take the darkest rather than adding up, or a dip inside a fade would
+    /// go past black and clip.
+    func testOverlappingWashesTakeTheDarkest() {
+        let alpha = FadeCurtain.alpha(atOutput: 0.5, duration: 10, fadeIn: 2, fadeOut: 0,
+                                      dips: [FadeCurtain.Dip(at: 0.5, length: 1)])
+        XCTAssertEqual(alpha, 1, accuracy: 1e-9)
+    }
+
+    // MARK: - Where the dips fall
+
+    func testADipBelongsToTheClipThatStartsAtTheCut() {
+        var second = Clip(sourceStart: 10, sourceEnd: 14)
+        second.dipToBlack = 0.5
+        let timeline = Timeline(clips: [Clip(sourceStart: 0, sourceEnd: 6), second])
+
+        XCTAssertEqual(FadeCurtain.dips(in: timeline), [FadeCurtain.Dip(at: 6, length: 0.5)])
+    }
+
+    /// The first clip has no cut before it — a fade in is the setting for that.
+    func testTheFirstClipCannotDip() {
+        var first = Clip(sourceStart: 0, sourceEnd: 6)
+        first.dipToBlack = 1
+        XCTAssertTrue(FadeCurtain.dips(in: Timeline(clips: [first])).isEmpty)
+    }
+
+    /// Dips are placed in output time, so a speed change moves them with the picture.
+    func testDipsFollowSpeedChanges() {
+        var first = Clip(sourceStart: 0, sourceEnd: 8)
+        first.speed = 2
+        var second = Clip(sourceStart: 10, sourceEnd: 14)
+        second.dipToBlack = 0.4
+
+        XCTAssertEqual(FadeCurtain.dips(in: Timeline(clips: [first, second])),
+                       [FadeCurtain.Dip(at: 4, length: 0.4)])
+    }
+}

--- a/Tests/SarvkritTests/FeatureCategoryTests.swift
+++ b/Tests/SarvkritTests/FeatureCategoryTests.swift
@@ -36,6 +36,7 @@ final class FeatureCategoryTests: XCTestCase {
         XCTAssertEqual(byID["file-rules"], .files)
         XCTAssertEqual(byID["shelf"], .files)
         XCTAssertEqual(byID["screenshot"], .capture)
+        XCTAssertEqual(byID["screen-recording"], .capture)
         XCTAssertEqual(byID["pin-to-screen"], .capture)
         XCTAssertEqual(byID["audio-switcher"], .sound)
         XCTAssertEqual(byID["mute-microphone"], .sound)
@@ -117,7 +118,8 @@ final class FeatureCategoryTests: XCTestCase {
         MainActor.assumeIsolated {
             let needsOwnPane: Set<String> = [
                 "clipboard-history", "file-rules", "trash-cleanup", "app-sweep", "keep-awake",
-                "window-management", "text-snippets", "shelf", "screenshot", "pin-to-screen",
+                "window-management", "text-snippets", "shelf", "screenshot", "screen-recording",
+                "pin-to-screen",
                 "audio-switcher",
                 "mute-microphone", "music-blocker", "volume-mixer", "privacy-guard",
                 // Displays lists what is connected and which channel each one answers on, which

--- a/Tests/SarvkritTests/FeatureStoreTests.swift
+++ b/Tests/SarvkritTests/FeatureStoreTests.swift
@@ -62,7 +62,7 @@ final class FeatureStoreTests: XCTestCase {
         XCTAssertEqual(Set(ids).count, ids.count)
         XCTAssertEqual(ids, ["finder-cut-paste", "text-snippets", "clipboard-history",
                              "window-management", "quit-on-close", "file-rules", "trash-cleanup",
-                             "app-sweep", "shelf", "screenshot", "pin-to-screen", "audio-switcher",
+                             "app-sweep", "shelf", "screenshot", "screen-recording", "pin-to-screen", "audio-switcher",
                              "mute-microphone", "music-blocker",
                              "volume-mixer", "privacy-guard",
                              "displays", "keep-awake", "system-monitor"])

--- a/Tests/SarvkritTests/MediaOverlayTests.swift
+++ b/Tests/SarvkritTests/MediaOverlayTests.swift
@@ -55,4 +55,12 @@ final class MediaOverlayTests: XCTestCase {
         XCTAssertFalse(MediaStore.allowedExtensions.contains("mov"),
                        "a movie overlay wants its own decoder; see the note on MediaStore")
     }
+
+    /// **Visible where it was asked for.** An overlay whose range begins exactly at the playhead is
+    /// fully transparent there — the first frame of its own fade — so both kinds start a
+    /// fade-length early. Text learned this first; pictures shipped without it for one build.
+    func testAnOverlayIsOpaqueAFadeLengthAfterItsStart() {
+        let overlay = MediaOverlay(start: 5 - MediaOverlay.defaultFade, end: 9, asset: "a.png")
+        XCTAssertEqual(overlay.opacity(at: 5), 1, accuracy: 0.001)
+    }
 }

--- a/Tests/SarvkritTests/MediaOverlayTests.swift
+++ b/Tests/SarvkritTests/MediaOverlayTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import Sarvkrit
+
+/// Pictures composited over the recording.
+///
+/// **Copied into the bundle, not referenced.** A project pointing at a file on somebody's Desktop
+/// stops working the moment that file moves and cannot be opened on another Mac at all — the same
+/// reason the recording itself lives in the package.
+final class MediaOverlayTests: XCTestCase {
+
+    func testItCoversOnlyItsOwnRange() {
+        let overlay = MediaOverlay(start: 2, end: 5, asset: "logo.png")
+        XCTAssertFalse(overlay.covers(1.9))
+        XCTAssertTrue(overlay.covers(2))
+        XCTAssertFalse(overlay.covers(5), "the range is half-open, like every other track's")
+    }
+
+    func testItFadesAndRespectsItsOwnOpacity() {
+        var overlay = MediaOverlay(start: 0, end: 4, asset: "logo.png")
+        overlay.fadeSeconds = 0.5
+        overlay.opacity = 0.5
+
+        XCTAssertEqual(overlay.opacity(at: 2), 0.5, accuracy: 0.001,
+                       "the fade must scale the chosen opacity, not replace it")
+        XCTAssertLessThan(overlay.opacity(at: 0.1), 0.5)
+        XCTAssertEqual(overlay.opacity(at: 9), 0)
+    }
+
+    /// The trap that has bitten this feature three times now.
+    func testAnOlderOverlayWithMissingFieldsStillDecodes() throws {
+        let json = #"{"start":1,"end":4,"asset":"logo.png"}"#
+        let overlay = try JSONDecoder().decode(MediaOverlay.self, from: Data(json.utf8))
+
+        XCTAssertEqual(overlay.asset, "logo.png")
+        XCTAssertEqual(overlay.opacity, 1, accuracy: 1e-9)
+        XCTAssertEqual(overlay.rect.width, 0.32, accuracy: 1e-9)
+    }
+
+    func testItSurvivesARoundTrip() throws {
+        var overlay = MediaOverlay(start: 1, end: 3, asset: "shot.png")
+        overlay.rect = CGRect(x: 0.1, y: 0.2, width: 0.4, height: 0.4)
+        overlay.cornerRadiusFraction = 0.25
+
+        let decoded = try JSONDecoder().decode(
+            MediaOverlay.self, from: try JSONEncoder().encode(overlay))
+
+        XCTAssertEqual(decoded.rect, overlay.rect)
+        XCTAssertEqual(decoded.cornerRadiusFraction, 0.25, accuracy: 1e-9)
+        XCTAssertEqual(decoded.asset, "shot.png")
+    }
+
+    /// Only still pictures for now, and the list says so rather than the loader failing later.
+    func testOnlyStillPicturesAreAccepted() {
+        XCTAssertTrue(MediaStore.allowedExtensions.contains("png"))
+        XCTAssertFalse(MediaStore.allowedExtensions.contains("mov"),
+                       "a movie overlay wants its own decoder; see the note on MediaStore")
+    }
+}

--- a/Tests/SarvkritTests/OwnWindowHitTestTests.swift
+++ b/Tests/SarvkritTests/OwnWindowHitTestTests.swift
@@ -1,0 +1,73 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// Recognising our own windows before asking Accessibility about a point.
+///
+/// **This is a crash, not a nicety.** `AXUIElementCopyElementAtPosition` is served *in-process*
+/// when the point is over one of our own windows — AppKit answers it synchronously on the calling
+/// thread, routing through `NSHostingView.accessibilityHitTest` into SwiftUI, which evaluates a
+/// view body and asserts it is on the main actor. Both callers do that hit-test on a background
+/// queue, deliberately and correctly, because it costs up to four Accessibility round trips.
+///
+/// Both callers also already tried to skip our own process — and could not, because the check reads
+/// the PID of an element that the crashing call was supposed to return. The guard has to happen
+/// *before* the question is asked, which means answering it without Accessibility at all.
+final class OwnWindowHitTestTests: XCTestCase {
+
+    private func window(pid: pid_t, x: CGFloat, y: CGFloat,
+                        width: CGFloat, height: CGFloat) -> [String: Any] {
+        [kCGWindowOwnerPID as String: NSNumber(value: pid),
+         kCGWindowBounds as String: [
+            "X": x, "Y": y, "Width": width, "Height": height,
+         ] as [String: Any]]
+    }
+
+    func testAPointOverOneOfOurWindowsIsRecognised() {
+        let windows = [window(pid: 42, x: 100, y: 100, width: 400, height: 300)]
+        XCTAssertTrue(AX.isPoint(CGPoint(x: 200, y: 200), overWindowsOf: 42, in: windows))
+    }
+
+    func testAPointOverAnotherAppsWindowIsNot() {
+        let windows = [window(pid: 99, x: 100, y: 100, width: 400, height: 300)]
+        XCTAssertFalse(AX.isPoint(CGPoint(x: 200, y: 200), overWindowsOf: 42, in: windows))
+    }
+
+    func testAPointOutsideEveryWindowIsNot() {
+        let windows = [window(pid: 42, x: 100, y: 100, width: 400, height: 300)]
+        XCTAssertFalse(AX.isPoint(CGPoint(x: 900, y: 900), overWindowsOf: 42, in: windows))
+    }
+
+    /// The window list is front-to-back and holds every app; ours may be anywhere in it.
+    func testOursIsFoundBehindAnotherAppsEntry() {
+        let windows = [window(pid: 99, x: 0, y: 0, width: 50, height: 50),
+                       window(pid: 42, x: 100, y: 100, width: 400, height: 300)]
+        XCTAssertTrue(AX.isPoint(CGPoint(x: 200, y: 200), overWindowsOf: 42, in: windows))
+    }
+
+    /// Both spaces are top-left origin with y increasing downwards — `kCGWindowBounds` and the
+    /// coordinates `AXUIElementCopyElementAtPosition` takes agree, which is the only reason this
+    /// substitution is sound.
+    func testTheEdgesBelongToTheWindow() {
+        let windows = [window(pid: 42, x: 100, y: 100, width: 400, height: 300)]
+        XCTAssertTrue(AX.isPoint(CGPoint(x: 100, y: 100), overWindowsOf: 42, in: windows))
+        XCTAssertFalse(AX.isPoint(CGPoint(x: 500.5, y: 400.5), overWindowsOf: 42, in: windows))
+    }
+
+    func testAnEmptyListIsSafe() {
+        XCTAssertFalse(AX.isPoint(.zero, overWindowsOf: 42, in: []))
+    }
+
+    /// A malformed entry must not be read as a match — that would disable the snap hit-test
+    /// everywhere rather than only over our own windows.
+    func testAnEntryWithNoBoundsIsIgnored() {
+        let windows: [[String: Any]] = [[kCGWindowOwnerPID as String: NSNumber(value: 42)]]
+        XCTAssertFalse(AX.isPoint(CGPoint(x: 10, y: 10), overWindowsOf: 42, in: windows))
+    }
+
+    func testAnEntryWithNoOwnerIsIgnored() {
+        let windows: [[String: Any]] = [[kCGWindowBounds as String:
+            ["X": 0.0, "Y": 0.0, "Width": 100.0, "Height": 100.0] as [String: Any]]]
+        XCTAssertFalse(AX.isPoint(CGPoint(x: 10, y: 10), overWindowsOf: 42, in: windows))
+    }
+}

--- a/Tests/SarvkritTests/PlaybackClockTests.swift
+++ b/Tests/SarvkritTests/PlaybackClockTests.swift
@@ -79,14 +79,16 @@ final class PlaybackClockTests: XCTestCase {
 /// The clock itself, over a real file.
 final class StudioPlayerClockTests: XCTestCase {
 
-    /// **The test host has no key window, which is exactly the failing condition.** `NSScreen.main`
-    /// is nil here for the same reason it was nil when the editor opened, so a player whose clock
-    /// came from `NSScreen.main.displayLink` got nothing and never ticked again.
+    /// **The clock must not depend on window state at all.** It used to come from
+    /// `NSScreen.main.displayLink` — the screen holding the *key window* — and this player is built
+    /// before its window exists, in an accessory app that often has no key window, so it got nothing
+    /// and never ticked again.
+    ///
+    /// Deliberately asserts nothing about whether a key window happens to exist: that it no longer
+    /// matters is the whole point, and an earlier version of this test asserted the absence of one
+    /// and then broke the moment a sibling suite opened a real editor window.
     @MainActor
     func testAPlayerGetsAClockEvenWithNoKeyWindow() {
-        XCTAssertNil(NSApplication.shared.keyWindow,
-                     "precondition: this suite is meaningful only without a key window")
-
         let player = StudioPlayer(url: FileManager.default.temporaryDirectory
             .appendingPathComponent("no-such-recording.mov"))
 

--- a/Tests/SarvkritTests/PlaybackClockTests.swift
+++ b/Tests/SarvkritTests/PlaybackClockTests.swift
@@ -189,14 +189,16 @@ final class CameraTrackTimeTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(t), 7.57, accuracy: 1e-9)
     }
 
-    /// **The lead-in holds the camera's first frame.** For the couple of seconds before the capture
-    /// graph came up there is no true picture, and leaving the bubble out until it appears looks
-    /// exactly like the camera being broken — which is how it was reported in the first place. So
-    /// the earliest frame stands in, the way a poster frame does.
-    func testTheLeadInHoldsTheFirstCameraFrame() {
-        let t = PlaybackClock.cameraTime(forSource: 1.0, startOffset: offset,
-                                         cameraDuration: cameraDuration)
-        XCTAssertEqual(try XCTUnwrap(t), 0, accuracy: 1e-9)
+    /// **Nothing before the camera was running — not a frozen frame.**
+    ///
+    /// An earlier version held the camera's first frame through the lead-in, on the grounds that an
+    /// empty bubble looks like a broken camera. That was the wrong trade: for those couple of
+    /// seconds there is no narration either, so a motionless face sitting over silence reads as a
+    /// stall in the recording. The camera now appears when it actually started, faded in over
+    /// `CameraSettings.fadeSeconds` so it does not pop.
+    func testThereIsNoCameraBeforeItStarted() {
+        XCTAssertNil(PlaybackClock.cameraTime(forSource: 1.0, startOffset: offset,
+                                              cameraDuration: cameraDuration))
     }
 
     /// A recording with no camera track at all still has nothing to draw.

--- a/Tests/SarvkritTests/PlaybackClockTests.swift
+++ b/Tests/SarvkritTests/PlaybackClockTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import Sarvkrit
+
+/// How the playhead moves while a project is playing.
+///
+/// **This suite exists because the editor never played anything.** Two faults met here.
+///
+/// The clock that drives playback is a display link taken from `NSScreen.main` — the screen holding
+/// the *key window*. `StudioPlayer` is built by `StudioEditorController.open` before its window
+/// exists, in an accessory app that frequently has no key window at all, so the link was nil, and
+/// `tick()` never ran once. That is not just a still playhead: `tick()` is also the only thing that
+/// decodes a frame, so `FrameSources.screen` stayed nil and the editor composited a background over
+/// nothing.
+///
+/// And the arithmetic inside `tick()` assumed every tick was exactly 1/60 of a second, then forced a
+/// keyframe-exact seek on every one of them — sixty a second, on top of the real-time playback that
+/// setting `rate` had already started.
+///
+/// Both halves are pure arithmetic once separated from AVFoundation, which is what this pins.
+final class PlaybackClockTests: XCTestCase {
+
+    /// The bug, stated directly: a tick that is not 1/60 of a second must advance the playhead by
+    /// what actually elapsed. On a 120 Hz display the old arithmetic ran at double speed; on a
+    /// stalled frame it lost time outright.
+    func testThePlayheadAdvancesByRealElapsedTime() {
+        let step = PlaybackClock.advance(playhead: 1.0, elapsed: 1.0 / 120.0, rate: 1,
+                                         duration: 10)
+        XCTAssertEqual(step.playhead, 1.0 + 1.0 / 120.0, accuracy: 1e-9)
+        XCTAssertFalse(step.reachedEnd)
+    }
+
+    func testRateMultipliesElapsedTime() {
+        let doubled = PlaybackClock.advance(playhead: 0, elapsed: 0.5, rate: 2, duration: 10)
+        XCTAssertEqual(doubled.playhead, 1.0, accuracy: 1e-9)
+    }
+
+    /// J/K/L shuttles backwards with a negative rate, and reaching zero is an end too.
+    func testPlayingBackwardsStopsAtTheStart() {
+        let step = PlaybackClock.advance(playhead: 0.2, elapsed: 0.5, rate: -1, duration: 10)
+        XCTAssertEqual(step.playhead, 0, accuracy: 1e-9)
+        XCTAssertTrue(step.reachedEnd)
+    }
+
+    func testReachingTheEndClampsAndStops() {
+        let step = PlaybackClock.advance(playhead: 9.9, elapsed: 0.5, rate: 1, duration: 10)
+        XCTAssertEqual(step.playhead, 10, accuracy: 1e-9)
+        XCTAssertTrue(step.reachedEnd)
+    }
+
+    /// **The seek storm.** Output time and source time diverge only where the project cuts, so the
+    /// player needs nudging back into place there and nowhere else. Asking for a keyframe-exact
+    /// seek on every tick is what no decoder could service.
+    func testNoResyncWhenThePlayerIsAlreadyWhereItShouldBe() {
+        XCTAssertFalse(PlaybackClock.needsResync(playerTime: 4.001, wanted: 4.0, tolerance: 0.05))
+    }
+
+    func testResyncAcrossACut() {
+        XCTAssertTrue(PlaybackClock.needsResync(playerTime: 4.0, wanted: 9.0, tolerance: 0.05))
+    }
+
+    func testResyncAfterDriftingPastTheTolerance() {
+        XCTAssertTrue(PlaybackClock.needsResync(playerTime: 4.0, wanted: 4.2, tolerance: 0.05))
+    }
+}
+
+/// The clock itself, over a real file.
+final class StudioPlayerClockTests: XCTestCase {
+
+    /// **The test host has no key window, which is exactly the failing condition.** `NSScreen.main`
+    /// is nil here for the same reason it was nil when the editor opened, so a player that only
+    /// asks `NSScreen.main` gets no display link and never ticks again.
+    @MainActor
+    func testAPlayerGetsAClockEvenWithNoKeyWindow() {
+        XCTAssertNil(NSApplication.shared.keyWindow,
+                     "precondition: this suite is meaningful only without a key window")
+
+        let player = StudioPlayer(url: FileManager.default.temporaryDirectory
+            .appendingPathComponent("no-such-recording.mov"))
+
+        XCTAssertTrue(player.isTicking,
+                      "no display link, so tick() never runs: no playhead, no redraw, no decoded frame")
+    }
+}
+
+/// Where a moment in the recording lands inside `camera.mov`.
+///
+/// **The two tracks do not start together.** The capture graph takes time to come up, so in a real
+/// take here the screen ran 29.175 s and the camera 26.747 s — the camera began 2.43 s late. Drawing
+/// it at the screen's own time would put the picture two and a half seconds ahead of the action,
+/// against a standard this feature already sets for the cursor: *"getting it wrong by 80 ms puts the
+/// pointer visibly behind what it clicked."*
+final class CameraTrackTimeTests: XCTestCase {
+
+    private let offset: TimeInterval = 2.43
+    private let cameraDuration: TimeInterval = 26.747
+
+    func testTheCameraIsBehindTheScreenByItsStartOffset() {
+        let t = PlaybackClock.cameraTime(forSource: 10, startOffset: offset,
+                                         cameraDuration: cameraDuration)
+        XCTAssertEqual(try XCTUnwrap(t), 7.57, accuracy: 1e-9)
+    }
+
+    /// Before the camera existed there is no frame to draw, and that is not an error — `drawCamera`
+    /// already draws nothing for a nil image.
+    func testThereIsNoCameraBeforeItStarted() {
+        XCTAssertNil(PlaybackClock.cameraTime(forSource: 1.0, startOffset: offset,
+                                              cameraDuration: cameraDuration))
+    }
+
+    /// The whole take is covered once the offset is applied: a camera that started 2.43 s late and
+    /// ran 26.747 s reaches 29.177 s, which is the screen's 29.175 s. Both tracks stopped together;
+    /// only the start differed. Getting this wrong in the first draft of this test is why it is
+    /// spelled out.
+    func testTheOffsetCoversTheWholeTakeWhenBothTracksStoppedTogether() {
+        XCTAssertNotNil(PlaybackClock.cameraTime(forSource: 29.1, startOffset: offset,
+                                                 cameraDuration: cameraDuration))
+    }
+
+    /// A camera that genuinely stopped early — the file output failing part-way, which has happened
+    /// — leaves the tail with no picture, and that is not an error.
+    func testThereIsNoCameraAfterItEnded() {
+        XCTAssertNil(PlaybackClock.cameraTime(forSource: 29.1, startOffset: offset,
+                                              cameraDuration: 20))
+    }
+
+    /// An older bundle records no offset at all, so zero must behave exactly as before.
+    func testAZeroOffsetMapsStraightThrough() {
+        let t = PlaybackClock.cameraTime(forSource: 5, startOffset: 0, cameraDuration: 30)
+        XCTAssertEqual(try XCTUnwrap(t), 5, accuracy: 1e-9)
+    }
+}

--- a/Tests/SarvkritTests/PlaybackClockTests.swift
+++ b/Tests/SarvkritTests/PlaybackClockTests.swift
@@ -1,3 +1,5 @@
+import AVFoundation
+import CoreMedia
 import XCTest
 @testable import Sarvkrit
 
@@ -41,6 +43,17 @@ final class PlaybackClockTests: XCTestCase {
         XCTAssertTrue(step.reachedEnd)
     }
 
+    /// **Playing forward from a standstill must not immediately stop.** The first tick has no
+    /// previous tick to measure against, so its elapsed time is zero — and a naive "at or before
+    /// zero means we reached the start" check fires on the very first tick of every playback,
+    /// pausing before anything moves. Found by the end-to-end play test, which is exactly what it
+    /// is for.
+    func testPlayingForwardFromTheStartDoesNotImmediatelyStop() {
+        let first = PlaybackClock.advance(playhead: 0, elapsed: 0, rate: 1, duration: 10)
+        XCTAssertEqual(first.playhead, 0)
+        XCTAssertFalse(first.reachedEnd, "playback stopped on its own first tick")
+    }
+
     func testReachingTheEndClampsAndStops() {
         let step = PlaybackClock.advance(playhead: 9.9, elapsed: 0.5, rate: 1, duration: 10)
         XCTAssertEqual(step.playhead, 10, accuracy: 1e-9)
@@ -67,8 +80,8 @@ final class PlaybackClockTests: XCTestCase {
 final class StudioPlayerClockTests: XCTestCase {
 
     /// **The test host has no key window, which is exactly the failing condition.** `NSScreen.main`
-    /// is nil here for the same reason it was nil when the editor opened, so a player that only
-    /// asks `NSScreen.main` gets no display link and never ticks again.
+    /// is nil here for the same reason it was nil when the editor opened, so a player whose clock
+    /// came from `NSScreen.main.displayLink` got nothing and never ticked again.
     @MainActor
     func testAPlayerGetsAClockEvenWithNoKeyWindow() {
         XCTAssertNil(NSApplication.shared.keyWindow,
@@ -79,6 +92,80 @@ final class StudioPlayerClockTests: XCTestCase {
 
         XCTAssertTrue(player.isTicking,
                       "no display link, so tick() never runs: no playhead, no redraw, no decoded frame")
+    }
+
+    /// **Pressing Play, end to end, over a real file.**
+    ///
+    /// This is the user's report — "when I click on play the streaming does not actually work on
+    /// the scroll bar" — as an assertion. Before the fix the playhead never moved at all: the clock
+    /// came from `NSScreen.main.displayLink`, which was nil here for the same reason it was nil in
+    /// the app.
+    ///
+    /// **Only the transport is asserted, not the picture.** `AVPlayerItemVideoOutput` delivers
+    /// nothing in a headless test host, so a decode assertion here would fail for reasons that have
+    /// nothing to do with the code. Real decoded pixels are covered where they can be:
+    /// `StudioExportTests.testTheExportContainsTheCamera` compares two exported files byte for
+    /// byte.
+    @MainActor
+    func testPlayingAdvancesThePlayheadAndProducesAFrame() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("player-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let url = directory.appendingPathComponent("screen.mov")
+        try await Self.writeRecording(to: url, seconds: 2)
+
+        let player = StudioPlayer(url: url)
+        player.duration = 2
+        XCTAssertEqual(player.playhead, 0)
+
+        player.play()
+        XCTAssertTrue(player.isPlaying, "play() refused, and said nothing")
+
+        // The clock runs on the main run loop, so the test has to let it turn.
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline, player.playhead < 0.3 {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+        player.pause()
+
+        XCTAssertGreaterThan(player.playhead, 0.2, "the playhead never moved, so nothing plays")
+        XCTAssertFalse(player.isPlaying)
+    }
+
+    /// A small, real, decodable movie — solid frames written the way the recorder writes them.
+    private static func writeRecording(to url: URL, seconds: Double) async throws {
+        let size = CGSize(width: 160, height: 120)
+        let writer = try RecordingWriter(url: url, size: size, fps: 60)
+        for index in 0..<Int(seconds * 60) {
+            var pixelBuffer: CVPixelBuffer?
+            CVPixelBufferCreate(nil, Int(size.width), Int(size.height),
+                                kCVPixelFormatType_32BGRA, nil, &pixelBuffer)
+            let buffer = try XCTUnwrap(pixelBuffer)
+            CVPixelBufferLockBaseAddress(buffer, [])
+            if let base = CVPixelBufferGetBaseAddress(buffer) {
+                memset(base, Int32(40 + index % 180),
+                       CVPixelBufferGetBytesPerRow(buffer) * Int(size.height))
+            }
+            CVPixelBufferUnlockBaseAddress(buffer, [])
+
+            var format: CMFormatDescription?
+            CMVideoFormatDescriptionCreateForImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                         formatDescriptionOut: &format)
+            var timing = CMSampleTimingInfo(
+                duration: CMTime(value: 1, timescale: 60),
+                presentationTimeStamp: CMTime(seconds: Double(index) / 60,
+                                              preferredTimescale: 600),
+                decodeTimeStamp: .invalid)
+            var sample: CMSampleBuffer?
+            CMSampleBufferCreateReadyWithImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                     formatDescription: try XCTUnwrap(format),
+                                                     sampleTiming: &timing,
+                                                     sampleBufferOut: &sample)
+            writer.append(try XCTUnwrap(sample))
+        }
+        await writer.finish()
     }
 }
 

--- a/Tests/SarvkritTests/PlaybackClockTests.swift
+++ b/Tests/SarvkritTests/PlaybackClockTests.swift
@@ -227,4 +227,32 @@ final class CameraTrackTimeTests: XCTestCase {
         let t = PlaybackClock.cameraTime(forSource: 5, startOffset: 0, cameraDuration: 30)
         XCTAssertEqual(try XCTUnwrap(t), 5, accuracy: 1e-9)
     }
+    // MARK: - Sound drifts differently
+
+    /// **Audio tolerates more drift than the picture, because correcting it is audible.** A seek
+    /// on a video player costs a decode; a seek on an audio player is a click in the middle of a
+    /// word. So the soundtrack is left alone through the drift a frame would be corrected for, and
+    /// resynced only when it is far enough out to hear as lip-sync error.
+    func testTheSoundtrackToleratesMoreDriftThanThePicture() {
+        XCTAssertGreaterThan(PlaybackClock.audioResyncTolerance, PlaybackClock.resyncTolerance)
+    }
+
+    func testASmallSoundtrackDriftIsLeftAlone() {
+        XCTAssertFalse(PlaybackClock.needsResync(
+            playerTime: 5.1, wanted: 5.0,
+            tolerance: PlaybackClock.audioResyncTolerance))
+    }
+
+    /// Far enough out to hear. A third of a second of lip-sync error is obvious on speech.
+    func testALargeSoundtrackDriftIsCorrected() {
+        XCTAssertTrue(PlaybackClock.needsResync(
+            playerTime: 5.4, wanted: 5.0,
+            tolerance: PlaybackClock.audioResyncTolerance))
+    }
+
+    /// And the same drift would have been corrected for the picture, which is the point of having
+    /// two numbers rather than one.
+    func testThePictureIsCorrectedForDriftTheSoundtrackIgnores() {
+        XCTAssertTrue(PlaybackClock.needsResync(playerTime: 5.1, wanted: 5.0))
+    }
 }

--- a/Tests/SarvkritTests/PlaybackClockTests.swift
+++ b/Tests/SarvkritTests/PlaybackClockTests.swift
@@ -187,11 +187,19 @@ final class CameraTrackTimeTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(t), 7.57, accuracy: 1e-9)
     }
 
-    /// Before the camera existed there is no frame to draw, and that is not an error — `drawCamera`
-    /// already draws nothing for a nil image.
-    func testThereIsNoCameraBeforeItStarted() {
-        XCTAssertNil(PlaybackClock.cameraTime(forSource: 1.0, startOffset: offset,
-                                              cameraDuration: cameraDuration))
+    /// **The lead-in holds the camera's first frame.** For the couple of seconds before the capture
+    /// graph came up there is no true picture, and leaving the bubble out until it appears looks
+    /// exactly like the camera being broken — which is how it was reported in the first place. So
+    /// the earliest frame stands in, the way a poster frame does.
+    func testTheLeadInHoldsTheFirstCameraFrame() {
+        let t = PlaybackClock.cameraTime(forSource: 1.0, startOffset: offset,
+                                         cameraDuration: cameraDuration)
+        XCTAssertEqual(try XCTUnwrap(t), 0, accuracy: 1e-9)
+    }
+
+    /// A recording with no camera track at all still has nothing to draw.
+    func testThereIsNoCameraWithoutATrack() {
+        XCTAssertNil(PlaybackClock.cameraTime(forSource: 1.0, startOffset: 0, cameraDuration: 0))
     }
 
     /// The whole take is covered once the offset is applied: a camera that started 2.43 s late and

--- a/Tests/SarvkritTests/PointerSpotlightTests.swift
+++ b/Tests/SarvkritTests/PointerSpotlightTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import Sarvkrit
+
+/// Emphasising where the pointer is, for a stretch.
+///
+/// **There was no way to point at anything.** `CursorSettings` is entirely global — not one field is
+/// time-ranged — so "look here, now" could not be expressed at all. The nearest thing was
+/// `StudioMask.Mode.highlight`, a hand-drawn rectangle with a start and end, which does not move and
+/// is not attached to the pointer.
+///
+/// This follows the pointer, which is the thing worth pointing at: the cursor's own recorded position
+/// is the centre, so it tracks whatever was being demonstrated without anybody drawing a box.
+final class PointerSpotlightTests: XCTestCase {
+
+    private let frame = CGSize(width: 1000, height: 600)
+    private func highlight(_ start: TimeInterval, _ end: TimeInterval) -> PointerHighlight {
+        PointerHighlight(start: start, end: end)
+    }
+
+    func testNothingOutsideItsRange() {
+        XCTAssertNil(PointerSpotlight.state(at: 9, highlights: [highlight(1, 3)],
+                                            cursor: CGPoint(x: 100, y: 100), frameSize: frame))
+    }
+
+    func testCentredOnTheCursor() throws {
+        let state = try XCTUnwrap(PointerSpotlight.state(
+            at: 2, highlights: [highlight(1, 3)],
+            cursor: CGPoint(x: 420, y: 380), frameSize: frame))
+
+        XCTAssertEqual(state.centre, CGPoint(x: 420, y: 380))
+    }
+
+    /// **From the shorter side.** Taking it from the width would make the same setting a very
+    /// different spotlight on a wide recording than on a tall one.
+    func testTheRadiusComesFromTheShorterSide() throws {
+        var spot = highlight(1, 3)
+        spot.radiusFraction = 0.1
+        let state = try XCTUnwrap(PointerSpotlight.state(
+            at: 2, highlights: [spot], cursor: .zero, frameSize: frame))
+
+        XCTAssertEqual(state.radius, 60, accuracy: 0.001)
+    }
+
+    /// With no cursor sample there is nothing to point at, and inventing a centre would put the
+    /// spotlight in the corner.
+    func testNothingWhenTheCursorIsUnknown() {
+        XCTAssertNil(PointerSpotlight.state(at: 2, highlights: [highlight(1, 3)],
+                                            cursor: nil, frameSize: frame))
+    }
+
+    /// It fades in and out rather than snapping, the way the camera's layout changes do — a
+    /// spotlight appearing between two frames reads as a flash.
+    func testItFadesInAndOutRatherThanSnapping() throws {
+        var spot = highlight(0, 4)
+        spot.transition = 0.5
+        spot.dimming = 0.6
+
+        let entering = try XCTUnwrap(PointerSpotlight.state(
+            at: 0.1, highlights: [spot], cursor: .zero, frameSize: frame))
+        let middle = try XCTUnwrap(PointerSpotlight.state(
+            at: 2, highlights: [spot], cursor: .zero, frameSize: frame))
+        let leaving = try XCTUnwrap(PointerSpotlight.state(
+            at: 3.9, highlights: [spot], cursor: .zero, frameSize: frame))
+
+        XCTAssertLessThan(entering.dimming, middle.dimming)
+        XCTAssertLessThan(leaving.dimming, middle.dimming)
+        XCTAssertEqual(middle.dimming, 0.6, accuracy: 0.001)
+    }
+
+    /// Overlapping spotlights are the user's business; the first that covers the moment wins, so
+    /// the result is never two dimmings multiplied into darkness.
+    func testOnlyOneSpotlightAtATime() throws {
+        let state = try XCTUnwrap(PointerSpotlight.state(
+            at: 2, highlights: [highlight(1, 3), highlight(1.5, 4)],
+            cursor: .zero, frameSize: frame))
+        XCTAssertNotNil(state)
+    }
+}

--- a/Tests/SarvkritTests/PreviewFrameRendererTests.swift
+++ b/Tests/SarvkritTests/PreviewFrameRendererTests.swift
@@ -1,0 +1,110 @@
+import AVFoundation
+import CoreMedia
+import XCTest
+@testable import Sarvkrit
+
+/// Turning a camera frame into a bitmap, on the queue it arrived on.
+///
+/// **The second instance of one mistake, which is why this suite is about the pattern rather than
+/// the function.** Both the screen recorder and the camera preview reached back to the main actor
+/// from a capture callback with `MainActor.assumeIsolated` — an assertion, not a hop — and both
+/// trapped on their first frame. Every existing test called into that code from the main thread,
+/// where the assertion holds and the bug is invisible.
+///
+/// So the rule these tests encode: **anything AVFoundation hands to a delegate queue must be
+/// exercised from a background queue.** Testing it from the main thread proves nothing at all.
+final class PreviewFrameRendererTests: XCTestCase {
+
+    private func sample() throws -> CMSampleBuffer {
+        var pixelBuffer: CVPixelBuffer?
+        CVPixelBufferCreate(nil, 64, 48, kCVPixelFormatType_32BGRA, nil, &pixelBuffer)
+        let buffer = try XCTUnwrap(pixelBuffer)
+
+        var format: CMFormatDescription?
+        CMVideoFormatDescriptionCreateForImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                     formatDescriptionOut: &format)
+        var timing = CMSampleTimingInfo(duration: CMTime(value: 1, timescale: 30),
+                                        presentationTimeStamp: .zero, decodeTimeStamp: .invalid)
+        var sample: CMSampleBuffer?
+        CMSampleBufferCreateReadyWithImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                 formatDescription: try XCTUnwrap(format),
+                                                 sampleTiming: &timing, sampleBufferOut: &sample)
+        return try XCTUnwrap(sample)
+    }
+
+    /// **The regression test.** This is precisely what AVFoundation does, and precisely what the
+    /// crashing version could not survive.
+    func testAFrameConvertsFromABackgroundQueue() throws {
+        let renderer = PreviewFrameRenderer()
+        let sample = try self.sample()
+        let queue = DispatchQueue(label: "test.preview")
+        let done = expectation(description: "converted off the main thread")
+        var produced: CGImage?
+
+        queue.async {
+            XCTAssertFalse(Thread.isMainThread, "the point of this test is the other thread")
+            produced = renderer.image(from: sample)
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 5)
+
+        let image = try XCTUnwrap(produced, "no bitmap came back")
+        XCTAssertEqual(image.width, 64)
+        XCTAssertEqual(image.height, 48)
+    }
+
+    /// A capture queue delivers frame after frame; one conversion working is not the same as the
+    /// stream surviving.
+    func testManyFramesConvertInARow() throws {
+        let renderer = PreviewFrameRenderer()
+        let queue = DispatchQueue(label: "test.preview")
+        let done = expectation(description: "all converted")
+        var count = 0
+
+        queue.async {
+            for _ in 0..<30 {
+                if let sample = try? self.sample(), renderer.image(from: sample) != nil {
+                    count += 1
+                }
+            }
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 20)
+        XCTAssertEqual(count, 30)
+    }
+
+    /// The renderer is shared across a session's lifetime, so it has to tolerate being used from
+    /// more than one place at once.
+    func testTheRendererIsSafeFromSeveralQueuesAtOnce() throws {
+        let renderer = PreviewFrameRenderer()
+        let done = expectation(description: "all queues finished")
+        done.expectedFulfillmentCount = 4
+
+        for index in 0..<4 {
+            DispatchQueue(label: "test.preview.\(index)").async {
+                for _ in 0..<10 {
+                    if let sample = try? self.sample() { _ = renderer.image(from: sample) }
+                }
+                done.fulfill()
+            }
+        }
+        wait(for: [done], timeout: 30)
+    }
+
+    /// A buffer with no image is a real thing on a capture queue — a metadata-only sample — and it
+    /// must be skipped rather than crashed on.
+    func testASampleWithNoImageIsIgnored() throws {
+        let renderer = PreviewFrameRenderer()
+        var format: CMFormatDescription?
+        CMFormatDescriptionCreate(allocator: nil, mediaType: kCMMediaType_Metadata,
+                                  mediaSubType: 0, extensions: nil,
+                                  formatDescriptionOut: &format)
+        var sample: CMSampleBuffer?
+        CMSampleBufferCreate(allocator: nil, dataBuffer: nil, dataReady: true,
+                             makeDataReadyCallback: nil, refcon: nil,
+                             formatDescription: format, sampleCount: 0, sampleTimingEntryCount: 0,
+                             sampleTimingArray: nil, sampleSizeEntryCount: 0,
+                             sampleSizeArray: nil, sampleBufferOut: &sample)
+        XCTAssertNil(renderer.image(from: try XCTUnwrap(sample)))
+    }
+}

--- a/Tests/SarvkritTests/RecordingAreaTests.swift
+++ b/Tests/SarvkritTests/RecordingAreaTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Sarvkrit
+
+/// Which rectangle the aiming overlay opens with.
+///
+/// The report this answers is *"if I select an area when recording, it should be like a rectangle
+/// already on screen that can be resized, it should always remember the last size."* So there is
+/// always a rectangle, and it is last time's whenever last time's still exists.
+final class RecordingAreaTests: XCTestCase {
+
+    private let primary = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+
+    func testTheRememberedRectIsUsedAsItIs() {
+        let remembered = CGRect(x: 300, y: 200, width: 800, height: 450)
+        XCTAssertEqual(RecordingArea.seed(remembered: remembered, displays: [primary]), remembered)
+    }
+
+    /// `SelectionView.settle` drops a rect that touches no display, so a remembered rect from a
+    /// monitor that has since been unplugged would leave the overlay empty — the very thing this
+    /// is here to prevent. It has to fall back rather than be passed through.
+    func testARectOnAVanishedDisplayFallsBackToTheDefault() {
+        let offscreen = CGRect(x: 4000, y: 4000, width: 800, height: 450)
+        let seed = RecordingArea.seed(remembered: offscreen, displays: [primary])
+        XCTAssertNotEqual(seed, offscreen)
+        XCTAssertEqual(seed.map { primary.intersects($0) }, true)
+    }
+
+    /// Even the first time. "A rectangle already on screen" is the request, and an empty screen to
+    /// drag on is what it is asking not to see.
+    func testWithNothingRememberedThereIsStillARectangle() {
+        guard let seed = RecordingArea.seed(remembered: nil, displays: [primary]) else {
+            return XCTFail("the first area recording still needs something to resize")
+        }
+        XCTAssertTrue(primary.contains(seed))
+        XCTAssertGreaterThan(seed.width, 0)
+        XCTAssertGreaterThan(seed.height, 0)
+    }
+
+    func testTheDefaultIsCentredOnTheDisplay() {
+        guard let seed = RecordingArea.seed(remembered: nil, displays: [primary]) else {
+            return XCTFail("no seed")
+        }
+        XCTAssertEqual(seed.midX, primary.midX, accuracy: 0.5)
+        XCTAssertEqual(seed.midY, primary.midY, accuracy: 0.5)
+    }
+
+    /// A 16:9 default, because that is the shape of everything it will be exported into.
+    func testTheDefaultIsWidescreen() {
+        guard let seed = RecordingArea.seed(remembered: nil, displays: [primary]) else {
+            return XCTFail("no seed")
+        }
+        XCTAssertEqual(seed.width / seed.height, 16.0 / 9.0, accuracy: 0.01)
+    }
+
+    /// A tall or tiny display must not produce a box hanging off the edge, where two of its
+    /// handles cannot be reached.
+    func testTheDefaultFitsATallDisplay() {
+        let tall = CGRect(x: 0, y: 0, width: 900, height: 1600)
+        guard let seed = RecordingArea.seed(remembered: nil, displays: [tall]) else {
+            return XCTFail("no seed")
+        }
+        XCTAssertTrue(tall.contains(seed), "\(seed) escaped \(tall)")
+    }
+
+    /// A display to the left of the primary has a negative origin, and that is not an error state.
+    func testTheDefaultFollowsANegativeOrigin() {
+        let left = CGRect(x: -1920, y: -200, width: 1920, height: 1080)
+        guard let seed = RecordingArea.seed(remembered: nil, displays: [left]) else {
+            return XCTFail("no seed")
+        }
+        XCTAssertTrue(left.contains(seed), "\(seed) escaped \(left)")
+    }
+
+    func testWithNoDisplaysThereIsNothingToSeed() {
+        XCTAssertNil(RecordingArea.seed(remembered: nil, displays: []))
+    }
+}

--- a/Tests/SarvkritTests/RecordingBundleTests.swift
+++ b/Tests/SarvkritTests/RecordingBundleTests.swift
@@ -1,0 +1,127 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// The `.sarvrec` bundle: what is written while recording, and what survives a crash.
+///
+/// A recording is hundreds of megabytes of somebody's afternoon. The manifest is written *before*
+/// the first frame and says `recording`; a bundle still saying that on next launch is one the app
+/// died in the middle of, and the only acceptable outcome is to keep what exists.
+final class RecordingBundleTests: XCTestCase {
+
+    private var root: URL!
+
+    override func setUp() {
+        super.setUp()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sarvrec-tests-\(UUID().uuidString)")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: root)
+        super.tearDown()
+    }
+
+    // MARK: - Layout
+
+    func testCreatingABundleMakesItsDirectory() throws {
+        let bundle = try RecordingBundle.create(at: root)
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: bundle.root.path,
+                                                     isDirectory: &isDirectory))
+        XCTAssertTrue(isDirectory.boolValue)
+    }
+
+    func testEveryPieceLivesInsideTheBundle() throws {
+        let bundle = try RecordingBundle.create(at: root)
+        for url in [bundle.screenURL, bundle.eventsURL, bundle.manifestURL, bundle.cursorsDirectory] {
+            XCTAssertTrue(url.path.hasPrefix(bundle.root.path), "\(url.lastPathComponent) escaped")
+        }
+    }
+
+    func testTheScreenTrackIsAQuickTimeMovie() throws {
+        XCTAssertEqual(try RecordingBundle.create(at: root).screenURL.pathExtension, "mov")
+    }
+
+    // MARK: - Manifest
+
+    func testAManifestSurvivesARoundTrip() throws {
+        let bundle = try RecordingBundle.create(at: root)
+        var manifest = RecordingManifest(source: .area,
+                                         pixelSize: CGSize(width: 1920, height: 1080),
+                                         pointPixelScale: 2,
+                                         fps: 60)
+        manifest.duration = 12.5
+        manifest.droppedFrames = 4
+        try bundle.write(manifest)
+        XCTAssertEqual(try bundle.readManifest(), manifest)
+    }
+
+    /// Written before the first frame, so a bundle found in this state was interrupted.
+    func testAFreshManifestSaysItIsStillRecording() {
+        let manifest = RecordingManifest(source: .display,
+                                         pixelSize: CGSize(width: 100, height: 100),
+                                         pointPixelScale: 1, fps: 60)
+        XCTAssertEqual(manifest.state, .recording)
+    }
+
+    func testAManifestFromAnUnfinishedRecordingIsRecognised() throws {
+        let bundle = try RecordingBundle.create(at: root)
+        try bundle.write(RecordingManifest(source: .display,
+                                           pixelSize: CGSize(width: 100, height: 100),
+                                           pointPixelScale: 1, fps: 60))
+        XCTAssertTrue(try bundle.readManifest().needsRecovery)
+    }
+
+    func testAFinishedRecordingDoesNotNeedRecovery() throws {
+        let bundle = try RecordingBundle.create(at: root)
+        var manifest = RecordingManifest(source: .display,
+                                         pixelSize: CGSize(width: 100, height: 100),
+                                         pointPixelScale: 1, fps: 60)
+        manifest.state = .complete
+        try bundle.write(manifest)
+        XCTAssertFalse(try bundle.readManifest().needsRecovery)
+    }
+
+    /// A manifest written by a newer build must open. Same contract as the project document.
+    func testAManifestMissingKeysDecodesToDefaults() throws {
+        let json = #"{"source":"area","pixelSize":{"width":800,"height":600}}"#.data(using: .utf8)!
+        let manifest = try JSONDecoder().decode(RecordingManifest.self, from: json)
+        XCTAssertEqual(manifest.source, .area)
+        XCTAssertEqual(manifest.fps, RecordingManifest.defaultFPS)
+        XCTAssertEqual(manifest.state, .recording)
+    }
+
+    // MARK: - Geometry
+
+    /// **Odd dimensions cost quality for nothing.** H.264 and HEVC work in macroblocks, so an odd
+    /// width makes the encoder pad the frame — and unlike an export, the recording is the master
+    /// everything else is derived from.
+    func testTheRecordedSizeIsAlwaysEven() {
+        let awkward = [CGRect(x: 0, y: 0, width: 100.5, height: 66.5),
+                       CGRect(x: 0, y: 0, width: 999, height: 501),
+                       CGRect(x: 0, y: 0, width: 1, height: 1)]
+        for rect in awkward {
+            for scale in [CGFloat(1), 2, 3] {
+                let size = RecordingGeometry.pixelSize(contentRect: rect, pointPixelScale: scale)
+                XCTAssertEqual(size.width % 2, 0, "\(rect) @\(scale)")
+                XCTAssertEqual(size.height % 2, 0, "\(rect) @\(scale)")
+            }
+        }
+    }
+
+    func testTheRecordedSizeIsNeverZero() {
+        let size = RecordingGeometry.pixelSize(contentRect: .zero, pointPixelScale: 2)
+        XCTAssertGreaterThanOrEqual(size.width, 2)
+        XCTAssertGreaterThanOrEqual(size.height, 2)
+    }
+
+    /// Retina is captured at its real resolution. Downscaling at capture time throws away the
+    /// detail a 2x zoom exists to show.
+    func testRetinaIsCapturedAtFullResolution() {
+        let size = RecordingGeometry.pixelSize(
+            contentRect: CGRect(x: 0, y: 0, width: 800, height: 600), pointPixelScale: 2)
+        XCTAssertEqual(size.width, 1600)
+        XCTAssertEqual(size.height, 1200)
+    }
+}

--- a/Tests/SarvkritTests/RecordingEventLogTests.swift
+++ b/Tests/SarvkritTests/RecordingEventLogTests.swift
@@ -1,0 +1,127 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// The log that makes the cursor re-drawable.
+///
+/// The screen is captured with `showsCursor = false`, so **the only record of where the pointer
+/// was is this log**. If the lookup between samples is wrong the cursor lands near but not on the
+/// thing it clicked, which reads as a rendering fault rather than an arithmetic one — the exact
+/// failure `CaptureGeometry` exists to prevent on the screenshot side.
+final class RecordingEventLogTests: XCTestCase {
+
+    private func sample(_ t: TimeInterval, _ x: CGFloat, _ y: CGFloat,
+                        kind: CursorKind = .arrow, inside: Bool = true) -> CursorSample {
+        CursorSample(t: t, point: CGPoint(x: x, y: y), kind: kind, isInside: inside)
+    }
+
+    // MARK: - Position
+
+    func testAPositionIsReadStraightBackAtASampledTime() {
+        let log = EventLog(cursor: [sample(0, 10, 10), sample(1, 20, 20)])
+        XCTAssertEqual(log.cursorPoint(at: 0)?.x ?? -1, 10, accuracy: 0.0001)
+    }
+
+    /// Samples arrive at the display's refresh rate; frames are asked for at arbitrary times.
+    func testAPositionBetweenSamplesIsInterpolated() {
+        let log = EventLog(cursor: [sample(0, 0, 0), sample(1, 100, 200)])
+        let point = log.cursorPoint(at: 0.25)
+        XCTAssertEqual(point?.x ?? -1, 25, accuracy: 0.0001)
+        XCTAssertEqual(point?.y ?? -1, 50, accuracy: 0.0001)
+    }
+
+    func testAPositionBeforeTheFirstSampleHoldsAtTheFirst() {
+        let log = EventLog(cursor: [sample(5, 30, 40)])
+        XCTAssertEqual(log.cursorPoint(at: 0)?.x ?? -1, 30, accuracy: 0.0001)
+    }
+
+    func testAPositionAfterTheLastSampleHoldsAtTheLast() {
+        let log = EventLog(cursor: [sample(0, 1, 2), sample(1, 30, 40)])
+        XCTAssertEqual(log.cursorPoint(at: 99)?.x ?? -1, 30, accuracy: 0.0001)
+    }
+
+    func testAnEmptyLogHasNoPosition() {
+        XCTAssertNil(EventLog().cursorPoint(at: 1))
+    }
+
+    /// In area and window modes the pointer spends time outside what is being recorded. Drawing it
+    /// pinned to the frame edge is worse than not drawing it.
+    func testAPositionOutsideTheRecordedRegionIsReportedAsSuch() {
+        let log = EventLog(cursor: [sample(0, 10, 10, inside: false)])
+        XCTAssertFalse(log.isCursorInside(at: 0))
+    }
+
+    func testAPositionInsideTheRecordedRegionIsReportedAsSuch() {
+        let log = EventLog(cursor: [sample(0, 10, 10, inside: true)])
+        XCTAssertTrue(log.isCursorInside(at: 0))
+    }
+
+    // MARK: - Kind
+
+    /// The kind holds until the next sample says otherwise — it is a state, not an event.
+    func testTheCursorKindHoldsUntilItChanges() {
+        let log = EventLog(cursor: [sample(0, 0, 0, kind: .arrow),
+                                    sample(2, 0, 0, kind: .iBeam)])
+        XCTAssertEqual(log.cursorKind(at: 1.9), .arrow)
+        XCTAssertEqual(log.cursorKind(at: 2.1), .iBeam)
+    }
+
+    func testTheCursorKindDefaultsToArrowWithNoSamples() {
+        XCTAssertEqual(EventLog().cursorKind(at: 0), .arrow)
+    }
+
+    /// An app with its own pointers records the bitmap instead of a kind, so a Photoshop demo does
+    /// not show an arrow where the brush was.
+    func testACustomCursorCarriesItsBitmapHash() {
+        var custom = sample(0, 0, 0, kind: .custom)
+        custom.customCursorHash = "abc123"
+        XCTAssertEqual(EventLog(cursor: [custom]).customCursorHash(at: 0), "abc123")
+    }
+
+    func testAKnownCursorKindCarriesNoBitmapHash() {
+        XCTAssertNil(EventLog(cursor: [sample(0, 0, 0)]).customCursorHash(at: 0))
+    }
+
+    // MARK: - Ordering
+
+    /// The log is appended from a serial queue but a recovered recording may be truncated
+    /// mid-write, so the reader sorts rather than trusting.
+    func testSamplesAreSortedOnConstruction() {
+        let log = EventLog(cursor: [sample(2, 20, 0), sample(0, 0, 0), sample(1, 10, 0)])
+        XCTAssertEqual(log.cursor.map(\.t), [0, 1, 2])
+    }
+
+    func testClicksAreSortedOnConstruction() {
+        let log = EventLog(clicks: [ClickEvent(t: 3, point: .zero, button: .left, isDown: true),
+                                    ClickEvent(t: 1, point: .zero, button: .left, isDown: true)])
+        XCTAssertEqual(log.clicks.map(\.t), [1, 3])
+    }
+
+    // MARK: - Truncation
+
+    /// Crash recovery keeps the video up to the last complete fragment, so the sidecars have to be
+    /// cut to match or the cursor outlives the picture.
+    func testTruncatingDropsEventsPastTheCut() {
+        let log = EventLog(cursor: [sample(0, 0, 0), sample(1, 0, 0), sample(5, 0, 0)],
+                           clicks: [ClickEvent(t: 4, point: .zero, button: .left, isDown: true)],
+                           keys: [KeyEvent(t: 6, label: "A", isModifierCombination: false)])
+            .truncated(to: 2)
+        XCTAssertEqual(log.cursor.count, 2)
+        XCTAssertTrue(log.clicks.isEmpty)
+        XCTAssertTrue(log.keys.isEmpty)
+    }
+
+    // MARK: - Coding
+
+    func testTheLogSurvivesARoundTrip() throws {
+        var custom = sample(1, 5, 6, kind: .custom)
+        custom.customCursorHash = "deadbeef"
+        let original = EventLog(
+            cursor: [sample(0, 1, 2), custom],
+            clicks: [ClickEvent(t: 0.5, point: CGPoint(x: 3, y: 4), button: .right, isDown: true)],
+            keys: [KeyEvent(t: 0.7, label: "⌘C", isModifierCombination: true)],
+            flags: [1.25])
+        let data = try JSONEncoder().encode(original)
+        XCTAssertEqual(try JSONDecoder().decode(EventLog.self, from: data), original)
+    }
+}

--- a/Tests/SarvkritTests/RecordingEventLogTests.swift
+++ b/Tests/SarvkritTests/RecordingEventLogTests.swift
@@ -91,6 +91,27 @@ final class RecordingEventLogTests: XCTestCase {
         XCTAssertEqual(log.cursor.map(\.t), [0, 1, 2])
     }
 
+    /// **The synthesised decoder does not call the sorting initialiser.** It assigns the stored
+    /// properties directly, so a log read back from disk skips the one line that makes every
+    /// lookup in this type safe — and the fixture in the round-trip test above is already in
+    /// order, so it cannot catch it. This is that test.
+    ///
+    /// The JSON is built by re-ordering what the encoder itself produced, rather than written by
+    /// hand, so the test says nothing about the wire format and cannot break when it changes.
+    func testSamplesAreSortedWhenReadBackFromDisk() throws {
+        let ordered = EventLog(cursor: [sample(0, 0, 0), sample(1, 10, 0), sample(2, 20, 0)])
+        var asDictionary = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try JSONEncoder().encode(ordered))
+                as? [String: Any])
+        let cursorEntries = try XCTUnwrap(asDictionary["cursor"] as? [Any])
+        asDictionary["cursor"] = Array(cursorEntries.reversed())
+
+        let shuffled = try JSONSerialization.data(withJSONObject: asDictionary)
+        let log = try JSONDecoder().decode(EventLog.self, from: shuffled)
+        XCTAssertEqual(log.cursor.map(\.t), [0, 1, 2],
+                       "a log read back from disk was left in the order the file happened to have")
+    }
+
     func testClicksAreSortedOnConstruction() {
         let log = EventLog(clicks: [ClickEvent(t: 3, point: .zero, button: .left, isDown: true),
                                     ClickEvent(t: 1, point: .zero, button: .left, isDown: true)])

--- a/Tests/SarvkritTests/RecordingFailureMessageTests.swift
+++ b/Tests/SarvkritTests/RecordingFailureMessageTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import Sarvkrit
+
+/// The wording shown when a recording will not start.
+///
+/// Every one of these used to be the same sentence — "Couldn't start recording" — which is why a
+/// window that had closed, a disk with no room, and a screen grant that had gone stale were all
+/// reported as "it does nothing".
+final class RecordingFailureMessageTests: XCTestCase {
+
+    func testEachCauseGetsItsOwnSentence() {
+        let causes: [RecordingError] = [
+            .noDisplays, .displayGone, .windowGone, .cannotWrite,
+            .alreadyRecording, .outOfSpace(freeBytes: 1), .cancelled,
+        ]
+        let sentences = causes.map { RecordingFailureMessage.describe($0).text }
+
+        XCTAssertEqual(Set(sentences).count, causes.count,
+                       "two different failures produced the same message")
+        XCTAssertFalse(sentences.contains { $0.isEmpty })
+    }
+
+    func testFreeSpaceIsNamedInGigabytes() {
+        let (text, _) = RecordingFailureMessage.describe(RecordingError.outOfSpace(freeBytes: 2_400_000_000))
+        XCTAssertEqual(text, "Only 2.4 GB free")
+    }
+
+    /// An error from AVFoundation or ScreenCaptureKit that we have no case for still says
+    /// something specific rather than falling back to the generic line.
+    func testAnUnknownErrorKeepsItsOwnDescription() {
+        let underlying = NSError(domain: "SCStream", code: -3801,
+                                 userInfo: [NSLocalizedDescriptionKey: "The stream failed to start"])
+        XCTAssertEqual(RecordingFailureMessage.describe(underlying).text, "The stream failed to start")
+    }
+}

--- a/Tests/SarvkritTests/RecordingHUDDimmingTests.swift
+++ b/Tests/SarvkritTests/RecordingHUDDimmingTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Sarvkrit
+
+/// When the recording pill gets out of the way.
+///
+/// **It sits over the thing being demonstrated.** A panel at full strength in the middle of a
+/// screen recording is in every frame of the finished video, so it fades back once the recording
+/// is under way — and comes straight back when the pointer arrives, because stopping must never
+/// involve a hunt.
+final class RecordingHUDDimmingTests: XCTestCase {
+
+    func testItIsFullyVisibleWhenItAppears() {
+        XCTAssertEqual(HUDDimming.opacity(sinceWake: 0), 1)
+    }
+
+    func testItStaysUpLongEnoughToBeRead() {
+        XCTAssertEqual(HUDDimming.opacity(sinceWake: HUDDimming.wakeSeconds - 0.1), 1)
+    }
+
+    func testItFadesBackOnceTheRecordingIsUnderWay() {
+        XCTAssertEqual(HUDDimming.opacity(sinceWake: HUDDimming.wakeSeconds + 1),
+                       HUDDimming.restingOpacity)
+    }
+
+    /// The pointer arriving is the whole way back. Anything else would mean hunting for the stop
+    /// button on a panel you can barely see.
+    func testHoveringWakesIt() {
+        XCTAssertEqual(HUDDimming.opacity(sinceWake: 60, isHovered: true), 1)
+    }
+
+    /// **A paused recording must not look like a running one, or like nothing at all.** This is
+    /// the state where somebody has stepped away and needs to find their way back.
+    func testAPausedRecordingStaysVisible() {
+        XCTAssertEqual(HUDDimming.opacity(sinceWake: 60, isPaused: true), 1)
+    }
+
+    /// A warning that fades out is not a warning. Dropped frames mean the file is stuttering, and
+    /// producing that in silence is the failure the counter exists to prevent.
+    func testDroppedFramesKeepItVisible() {
+        XCTAssertEqual(HUDDimming.opacity(sinceWake: 60, isWarning: true), 1)
+    }
+
+    /// Never invisible. A pill nobody can find is the same as no pill, and there would then be no
+    /// way to stop a recording except a shortcut you may not remember.
+    func testItNeverDisappearsCompletely() {
+        XCTAssertGreaterThan(HUDDimming.restingOpacity, 0.2)
+    }
+}

--- a/Tests/SarvkritTests/RecordingLibraryTests.swift
+++ b/Tests/SarvkritTests/RecordingLibraryTests.swift
@@ -110,6 +110,42 @@ final class RecordingLibraryTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(RecordingLibrary.entries(in: directory).first).canOpen)
     }
 
+    // MARK: - Two names for one recording
+
+    /// **`open` hands a package over with a trailing slash.** It is a directory on disk, so the
+    /// Finder's URL is `…/Recording.sarvrec/` while the one the recorder built is
+    /// `…/Recording.sarvrec`. `URL` equality is string equality, so the two do not match — and the
+    /// editor's "this recording is already open" check quietly failed, opening a second window
+    /// over the same bundle. Two editors autosaving into one bundle means the last to close wins.
+    func testTheSameRecordingIsTheSameIdentityWithOrWithoutATrailingSlash() throws {
+        let url = try make("shared")
+        let withSlash = URL(fileURLWithPath: url.path, isDirectory: true)
+        XCTAssertNotEqual(withSlash, url, "the premise of this test has gone")
+
+        XCTAssertEqual(RecordingBundle(root: withSlash).identity,
+                       RecordingBundle(root: url).identity)
+    }
+
+    /// And two genuinely different recordings stay different.
+    func testDifferentRecordingsHaveDifferentIdentities() throws {
+        let one = try make("one")
+        let other = try make("other")
+        XCTAssertNotEqual(RecordingBundle(root: one).identity,
+                          RecordingBundle(root: other).identity)
+    }
+
+    /// A path with a `..` in it names the same bundle. Reached by an Open panel that started
+    /// somewhere else, or by a URL typed by hand.
+    func testAnUnresolvedPathIsTheSameIdentity() throws {
+        let url = try make("winding")
+        let winding = directory
+            .appendingPathComponent("nowhere")
+            .appendingPathComponent("..")
+            .appendingPathComponent("winding.sarvrec")
+        XCTAssertEqual(RecordingBundle(root: winding).identity,
+                       RecordingBundle(root: url).identity)
+    }
+
     // MARK: - Saying how long it is
 
     func testALengthIsSaidInMinutesAndSeconds() {

--- a/Tests/SarvkritTests/RecordingLibraryTests.swift
+++ b/Tests/SarvkritTests/RecordingLibraryTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import Sarvkrit
+
+/// Finding the recordings that are already on disk.
+///
+/// **A recording was saved correctly and then unreachable.** `project.json` is written on every
+/// edit and flushed again as the window closes, so nothing was ever lost — but the only caller of
+/// `StudioEditorController.open` was `stopRecording`, so the only way back into a take was to not
+/// have closed it. This is the list that fixes that, and it needs no index: the bundles all live in
+/// one directory and each carries its own manifest.
+final class RecordingLibraryTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("library-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: directory)
+        super.tearDown()
+    }
+
+    @discardableResult
+    private func make(_ name: String, duration: TimeInterval = 12,
+                      hasCamera: Bool = false,
+                      state: RecordingManifest.State = .complete) throws -> URL {
+        let url = directory.appendingPathComponent("\(name).sarvrec")
+        let bundle = try RecordingBundle.create(at: url)
+        var manifest = RecordingManifest(source: .display,
+                                         pixelSize: CGSize(width: 200, height: 120),
+                                         pointPixelScale: 1, fps: 60)
+        manifest.state = state
+        manifest.duration = duration
+        manifest.hasCamera = hasCamera
+        try bundle.write(manifest)
+        return url
+    }
+
+    func testAnEmptyDirectoryHasNoRecordings() {
+        XCTAssertTrue(RecordingLibrary.entries(in: directory).isEmpty)
+    }
+
+    /// A directory that has never held a recording is not an error — it is a new install.
+    func testAMissingDirectoryHasNoRecordings() {
+        XCTAssertTrue(RecordingLibrary.entries(
+            in: directory.appendingPathComponent("never-existed")).isEmpty)
+    }
+
+    func testARecordingIsFound() throws {
+        try make("one", duration: 42, hasCamera: true)
+        let entries = RecordingLibrary.entries(in: directory)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.name, "one")
+        XCTAssertEqual(entries.first?.duration ?? -1, 42, accuracy: 0.001)
+        XCTAssertEqual(entries.first?.hasCamera, true)
+        XCTAssertFalse(entries.first?.needsRecovery ?? true)
+    }
+
+    /// Newest first, because the recording somebody wants back is almost always the last one.
+    func testTheNewestComesFirst() throws {
+        let older = try make("older")
+        Thread.sleep(forTimeInterval: 0.05)
+        let newer = try make("newer")
+
+        // Set explicitly rather than trusted to the filesystem's own clock, whose resolution is
+        // not guaranteed to separate two writes this close together.
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1_000)], ofItemAtPath: older.path)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 2_000)], ofItemAtPath: newer.path)
+
+        XCTAssertEqual(RecordingLibrary.entries(in: directory).map { $0.name }, ["newer", "older"])
+    }
+
+    /// Screenshots and stray files share no directory with these, but a `.DS_Store` does.
+    func testOnlyRecordingsAreListed() throws {
+        try make("real")
+        try Data().write(to: directory.appendingPathComponent(".DS_Store"))
+        try FileManager.default.createDirectory(
+            at: directory.appendingPathComponent("notes"), withIntermediateDirectories: true)
+
+        XCTAssertEqual(RecordingLibrary.entries(in: directory).map { $0.name }, ["real"])
+    }
+
+    /// **A bundle the app died inside is offered back rather than ignored.** `needsRecovery`
+    /// existed, was written faithfully, and was read by nothing but its own tests — so a crashed
+    /// take was indistinguishable from no take at all.
+    func testABundleLeftMidRecordingIsFlagged() throws {
+        try make("interrupted", state: .recording)
+        let entry = try XCTUnwrap(RecordingLibrary.entries(in: directory).first)
+        XCTAssertTrue(entry.needsRecovery)
+    }
+
+    /// Listed rather than hidden. There is nothing to open, but there is something taking up disk
+    /// space, and hiding it leaves no way to be rid of it except the Finder.
+    func testABundleWithNoManifestIsStillListed() throws {
+        try RecordingBundle.create(at: directory.appendingPathComponent("broken.sarvrec"))
+        let entry = try XCTUnwrap(RecordingLibrary.entries(in: directory).first)
+        XCTAssertEqual(entry.name, "broken")
+        XCTAssertNil(entry.duration)
+        XCTAssertFalse(entry.canOpen)
+    }
+
+    func testAGoodRecordingCanBeOpened() throws {
+        try make("fine")
+        XCTAssertTrue(try XCTUnwrap(RecordingLibrary.entries(in: directory).first).canOpen)
+    }
+
+    // MARK: - Saying how long it is
+
+    func testALengthIsSaidInMinutesAndSeconds() {
+        XCTAssertEqual(RecordingLibrary.Entry.lengthDescription(for: 9), "0:09")
+        XCTAssertEqual(RecordingLibrary.Entry.lengthDescription(for: 75), "1:15")
+        XCTAssertEqual(RecordingLibrary.Entry.lengthDescription(for: 3_601), "1:00:01")
+        XCTAssertEqual(RecordingLibrary.Entry.lengthDescription(for: nil), "—")
+    }
+}

--- a/Tests/SarvkritTests/RecordingManifestCodingTests.swift
+++ b/Tests/SarvkritTests/RecordingManifestCodingTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Sarvkrit
+
+/// The manifest round-tripping through JSON.
+///
+/// **The decoder is hand-written and the encoder is not, so they drift.** Adding a property gets it
+/// written to disk for free and silently dropped on the way back — which is exactly what happened
+/// to `cameraStartOffset`: the recorder measured the camera as starting 2.546 s after the screen,
+/// wrote that number into `manifest.json`, and the editor then read it back as zero and put the
+/// camera two and a half seconds ahead of the action.
+///
+/// `EventLog` had the same shape of bug for the same reason. One round-trip test per field is the
+/// cheap way to stop it happening a third time.
+final class RecordingManifestCodingTests: XCTestCase {
+
+    private func roundTrip(_ manifest: RecordingManifest) throws -> RecordingManifest {
+        let data = try JSONEncoder().encode(manifest)
+        return try JSONDecoder().decode(RecordingManifest.self, from: data)
+    }
+
+    func testEveryFieldSurvivesTheRoundTrip() throws {
+        var manifest = RecordingManifest(source: .window, pixelSize: CGSize(width: 640, height: 480),
+                                         pointPixelScale: 2, fps: 60)
+        manifest.state = .complete
+        manifest.duration = 29.175
+        manifest.hasCamera = true
+        manifest.hasMicrophone = true
+        manifest.hasSystemAudio = true
+        manifest.cameraStartOffset = 2.546
+        manifest.droppedFrames = 7
+        manifest.accessibilityCursorScale = 1.5
+        manifest.displayID = 3
+
+        let decoded = try roundTrip(manifest)
+
+        XCTAssertEqual(decoded.state, .complete)
+        XCTAssertEqual(decoded.source, .window)
+        XCTAssertEqual(decoded.duration, 29.175, accuracy: 1e-9)
+        XCTAssertTrue(decoded.hasCamera)
+        XCTAssertTrue(decoded.hasMicrophone)
+        XCTAssertTrue(decoded.hasSystemAudio)
+        XCTAssertEqual(decoded.cameraStartOffset, 2.546, accuracy: 1e-9,
+                       "the camera offset was dropped, so the camera plays out of step")
+        XCTAssertEqual(decoded.droppedFrames, 7)
+        XCTAssertEqual(decoded.accessibilityCursorScale, 1.5, accuracy: 1e-9)
+        XCTAssertEqual(decoded.displayID, 3)
+    }
+
+    /// A bundle recorded before the offset existed has no such key, and must read as zero rather
+    /// than throwing — the manifest is the one file that has to stay readable.
+    func testAnOlderManifestWithNoOffsetStillReads() throws {
+        let json = """
+        {"formatVersion":1,"state":"complete","source":"display",
+         "pixelSize":{"width":100,"height":100},"pointPixelScale":2,"fps":60,
+         "duration":5,"hasCamera":true}
+        """
+        let decoded = try JSONDecoder().decode(RecordingManifest.self,
+                                               from: Data(json.utf8))
+        XCTAssertEqual(decoded.cameraStartOffset, 0)
+        XCTAssertTrue(decoded.hasCamera)
+    }
+}

--- a/Tests/SarvkritTests/RecordingSetupTests.swift
+++ b/Tests/SarvkritTests/RecordingSetupTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import Sarvkrit
+
+/// What the user chose before pressing Record.
+///
+/// Pure, and persisted, because **the single most costly failure this feature has is discovering
+/// after a ten-minute take that the camera was off or pointed at the ceiling.** Remembering the
+/// last choice is most of the defence; the live preview in the bar is the rest.
+final class RecordingSetupTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "ai.psylief.sarvkrit.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func testAFreshSetupRecordsTheWholeDisplay() {
+        XCTAssertEqual(RecordingSetup(defaults: defaults).source, .display)
+    }
+
+    /// Nothing is switched on for you. A recorder that turns the camera on by default is a
+    /// recorder that has filmed somebody without them deciding to be filmed.
+    func testNothingIsOnByDefault() {
+        let setup = RecordingSetup(defaults: defaults)
+        XCTAssertNil(setup.cameraID)
+        XCTAssertNil(setup.microphoneID)
+        XCTAssertFalse(setup.capturesSystemAudio)
+    }
+
+    func testTheChoicesSurviveARelaunch() {
+        let first = RecordingSetup(defaults: defaults)
+        first.source = .area
+        first.cameraID = "camera-1"
+        first.microphoneID = "mic-1"
+        first.capturesSystemAudio = true
+        first.countdownSeconds = 5
+
+        let second = RecordingSetup(defaults: defaults)
+        XCTAssertEqual(second.source, .area)
+        XCTAssertEqual(second.cameraID, "camera-1")
+        XCTAssertEqual(second.microphoneID, "mic-1")
+        XCTAssertTrue(second.capturesSystemAudio)
+        XCTAssertEqual(second.countdownSeconds, 5)
+    }
+
+    /// A device that has been unplugged since last time must not silently stay selected, or the
+    /// bar shows a camera that is not there and Record produces nothing.
+    func testADeviceThatHasGoneIsForgotten() {
+        let setup = RecordingSetup(defaults: defaults)
+        setup.cameraID = "unplugged"
+        setup.reconcile(cameraIDs: ["still-here"], microphoneIDs: [])
+        XCTAssertNil(setup.cameraID)
+    }
+
+    func testADeviceStillPresentIsKept() {
+        let setup = RecordingSetup(defaults: defaults)
+        setup.cameraID = "still-here"
+        setup.reconcile(cameraIDs: ["still-here"], microphoneIDs: [])
+        XCTAssertEqual(setup.cameraID, "still-here")
+    }
+
+    func testTheMicrophoneIsReconciledToo() {
+        let setup = RecordingSetup(defaults: defaults)
+        setup.microphoneID = "gone"
+        setup.reconcile(cameraIDs: [], microphoneIDs: ["present"])
+        XCTAssertNil(setup.microphoneID)
+    }
+
+    /// Only these three, and only these: the countdown exists to let you get to the window you are
+    /// about to demonstrate, and a menu of eleven durations is a decision nobody wants to make.
+    func testTheCountdownOffersAShortList() {
+        XCTAssertEqual(RecordingSetup.countdownChoices, [0, 3, 5, 10])
+    }
+
+    func testAnUnknownCountdownFallsBackToNone() {
+        defaults.set(97, forKey: "recording.countdown")
+        XCTAssertEqual(RecordingSetup(defaults: defaults).countdownSeconds, 0)
+    }
+
+    // MARK: - Turning a choice into a request
+
+    func testTheRequestCarriesTheChosenSource() {
+        let setup = RecordingSetup(defaults: defaults)
+        setup.source = .window
+        let request = setup.request(fps: 60, hidesDesktopIcons: true,
+                                    destination: URL(fileURLWithPath: "/tmp/x.sarvrec"))
+        XCTAssertEqual(request.source, .window)
+    }
+
+    func testTheRequestCarriesTheAudioChoice() {
+        let setup = RecordingSetup(defaults: defaults)
+        setup.capturesSystemAudio = true
+        let request = setup.request(fps: 30, hidesDesktopIcons: false,
+                                    destination: URL(fileURLWithPath: "/tmp/x.sarvrec"))
+        XCTAssertTrue(request.capturesSystemAudio)
+        XCTAssertEqual(request.fps, 30)
+        XCTAssertFalse(request.hidesDesktopIcons)
+    }
+
+    /// A source aimed by dragging needs the frozen overlay; the other two are pointed at something
+    /// that already has edges.
+    func testOnlyAnAreaNeedsTheSelectionOverlay() {
+        XCTAssertTrue(RecordingSource.area.aimsByDragging)
+        XCTAssertFalse(RecordingSource.display.aimsByDragging)
+        XCTAssertFalse(RecordingSource.window.aimsByDragging)
+    }
+}

--- a/Tests/SarvkritTests/RecordingSetupTests.swift
+++ b/Tests/SarvkritTests/RecordingSetupTests.swift
@@ -85,6 +85,45 @@ final class RecordingSetupTests: XCTestCase {
         XCTAssertEqual(RecordingSetup(defaults: defaults).countdownSeconds, 0)
     }
 
+    // MARK: - The area to record
+
+    func testAFreshSetupRemembersNoArea() {
+        XCTAssertNil(RecordingSetup(defaults: defaults).lastArea)
+    }
+
+    /// The whole point of item 3: the second area recording opens with the first one's rectangle
+    /// already on screen, so it can be nudged rather than redrawn.
+    func testTheAreaSurvivesARelaunch() {
+        let first = RecordingSetup(defaults: defaults)
+        first.lastArea = CGRect(x: 100, y: 200, width: 640, height: 480)
+
+        XCTAssertEqual(RecordingSetup(defaults: defaults).lastArea,
+                       CGRect(x: 100, y: 200, width: 640, height: 480))
+    }
+
+    /// An empty rect would seed the overlay with a selection that has no handles to grab, which is
+    /// worse than seeding nothing.
+    func testAnEmptyAreaIsNotRemembered() {
+        let setup = RecordingSetup(defaults: defaults)
+        setup.lastArea = CGRect(x: 10, y: 10, width: 0, height: 100)
+        XCTAssertNil(setup.lastArea)
+    }
+
+    func testTheAreaCanBeForgotten() {
+        let setup = RecordingSetup(defaults: defaults)
+        setup.lastArea = CGRect(x: 1, y: 2, width: 3, height: 4)
+        setup.lastArea = nil
+        XCTAssertNil(setup.lastArea)
+    }
+
+    /// Stored as four numbers rather than an archived rect, for the reason the screenshot path
+    /// gives: a change to how rects are persisted must not make an old value decode as something
+    /// plausible but wrong, because the failure there is recording the wrong part of the screen.
+    func testAHalfWrittenAreaIsIgnored() {
+        defaults.set([10.0, 20.0], forKey: "recording.lastArea")
+        XCTAssertNil(RecordingSetup(defaults: defaults).lastArea)
+    }
+
     // MARK: - Turning a choice into a request
 
     func testTheRequestCarriesTheChosenSource() {

--- a/Tests/SarvkritTests/RecordingWriterTests.swift
+++ b/Tests/SarvkritTests/RecordingWriterTests.swift
@@ -1,0 +1,153 @@
+import AVFoundation
+import CoreMedia
+import XCTest
+@testable import Sarvkrit
+
+/// The frame sink.
+///
+/// **This suite exists because of a crash.** `SCStream` delivers sample buffers on its own serial
+/// queue, and the first version of the recorder wrapped the handler in `MainActor.assumeIsolated`
+/// — which is an assertion, not a hop. The first frame of the first recording trapped with
+/// `EXC_BREAKPOINT`, so recording appeared impossible to switch on at all.
+///
+/// The lesson is narrow and worth keeping: **the hot path must not touch the main actor.** Hopping
+/// sixty times a second to append one frame would be wrong even if it were safe.
+final class RecordingWriterTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUp() {
+        super.setUp()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("writer-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: directory)
+        super.tearDown()
+    }
+
+    private func writer() throws -> RecordingWriter {
+        try RecordingWriter(url: directory.appendingPathComponent("screen.mov"),
+                            size: CGSize(width: 64, height: 64), fps: 60)
+    }
+
+    /// A frame with no image, which is all this needs: the crash was in the dispatch assertion
+    /// before the buffer was ever looked at.
+    private func sample(at seconds: Double) throws -> CMSampleBuffer {
+        var pixelBuffer: CVPixelBuffer?
+        CVPixelBufferCreate(nil, 64, 64, kCVPixelFormatType_32BGRA, nil, &pixelBuffer)
+        let buffer = try XCTUnwrap(pixelBuffer)
+
+        var format: CMFormatDescription?
+        CMVideoFormatDescriptionCreateForImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                     formatDescriptionOut: &format)
+        var timing = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: 60),
+            presentationTimeStamp: CMTime(seconds: seconds, preferredTimescale: 600),
+            decodeTimeStamp: .invalid)
+        var sample: CMSampleBuffer?
+        CMSampleBufferCreateReadyWithImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                 formatDescription: try XCTUnwrap(format),
+                                                 sampleTiming: &timing,
+                                                 sampleBufferOut: &sample)
+        return try XCTUnwrap(sample)
+    }
+
+    /// **The regression test.** Appending from a background queue must simply work — this is
+    /// exactly what ScreenCaptureKit does, and the old code trapped on it.
+    func testAFrameCanBeAppendedFromABackgroundQueue() throws {
+        let writer = try self.writer()
+        let queue = DispatchQueue(label: "test.frames")
+        let appended = expectation(description: "frame appended off the main thread")
+
+        queue.async {
+            XCTAssertFalse(Thread.isMainThread, "the point of this test is the other thread")
+            writer.append(try? self.sample(at: 0))
+            appended.fulfill()
+        }
+        wait(for: [appended], timeout: 5)
+        XCTAssertGreaterThan(writer.elapsed, -1)
+    }
+
+    /// The same serial queue delivers every frame, so the writer is exercised the way SCK uses it.
+    func testManyFramesFromTheStreamQueueAreAccepted() throws {
+        let writer = try self.writer()
+        let queue = DispatchQueue(label: "test.frames")
+        let done = expectation(description: "frames appended")
+
+        queue.async {
+            for index in 0..<30 {
+                writer.append(try? self.sample(at: Double(index) / 60))
+            }
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 10)
+        XCTAssertEqual(writer.elapsed, 29.0 / 60.0, accuracy: 0.05)
+    }
+
+    /// Elapsed and dropped are read from the main actor by the HUD while frames are still arriving
+    /// on the stream queue, so both sides have to be safe at once.
+    func testCountersCanBeReadWhileFramesArrive() throws {
+        let writer = try self.writer()
+        let queue = DispatchQueue(label: "test.frames")
+        let done = expectation(description: "frames appended")
+
+        queue.async {
+            for index in 0..<60 { writer.append(try? self.sample(at: Double(index) / 60)) }
+            done.fulfill()
+        }
+        for _ in 0..<50 {
+            _ = writer.elapsed
+            _ = writer.droppedFrames
+        }
+        wait(for: [done], timeout: 10)
+    }
+
+    /// Elapsed means *recorded* time. A paused recording must not appear to still be running.
+    func testPausingStopsTheClock() throws {
+        let writer = try self.writer()
+        writer.append(try sample(at: 0))
+        writer.append(try sample(at: 1))
+        writer.pause()
+        writer.append(try sample(at: 5))
+        writer.resume()
+        writer.append(try sample(at: 6))
+        // One second recorded before the pause, one after; the four-second gap is rebased out.
+        XCTAssertEqual(writer.elapsed, 2, accuracy: 0.1)
+    }
+
+    func testTheFirstFrameAnchorsTheClock() throws {
+        let writer = try self.writer()
+        // A stream that starts at a non-zero presentation time must still report from zero.
+        writer.append(try sample(at: 1000))
+        writer.append(try sample(at: 1002))
+        XCTAssertEqual(writer.elapsed, 2, accuracy: 0.05)
+    }
+
+    func testTheFirstFrameHostTimeIsReportedOnce() throws {
+        let writer = try self.writer()
+        XCTAssertNil(writer.firstFrameHostTime)
+        writer.append(try sample(at: 0))
+        let anchor = writer.firstFrameHostTime
+        XCTAssertNotNil(anchor)
+        writer.append(try sample(at: 1))
+        XCTAssertEqual(writer.firstFrameHostTime, anchor, "the anchor moved after the first frame")
+    }
+
+    func testANilBufferIsIgnoredRatherThanCounted() throws {
+        let writer = try self.writer()
+        writer.append(nil)
+        XCTAssertEqual(writer.droppedFrames, 0)
+    }
+
+    func testFinishingProducesAFile() async throws {
+        let writer = try self.writer()
+        writer.append(try sample(at: 0))
+        writer.append(try sample(at: 0.5))
+        await writer.finish()
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent("screen.mov").path))
+    }
+}

--- a/Tests/SarvkritTests/RecordingWriterTests.swift
+++ b/Tests/SarvkritTests/RecordingWriterTests.swift
@@ -150,4 +150,86 @@ final class RecordingWriterTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(
             atPath: directory.appendingPathComponent("screen.mov").path))
     }
+
+    // MARK: - System audio
+
+    /// **`capturesAudio` on the stream configuration did nothing on its own.**
+    ///
+    /// It was set, `hasSystemAudio` was written into the manifest, and no `.audio` stream output was
+    /// ever added — so ScreenCaptureKit never delivered a buffer, this writer had no audio input to
+    /// put one in, and the manifest's claim was simply false. Audio now rides in `screen.mov`
+    /// alongside the picture: one writer, one fragment interval, and a raw recording that plays
+    /// with sound.
+    func testSystemAudioReachesTheFile() async throws {
+        let url = directory.appendingPathComponent("with-system-audio.mov")
+        let writer = try RecordingWriter(url: url, size: CGSize(width: 160, height: 120), fps: 60,
+                                         capturesAudio: true)
+
+        // A video frame first: the session is anchored on it, so audio arriving earlier has no
+        // timeline to sit on and is deliberately dropped.
+        for index in 0..<30 {
+            writer.append(try sample(at: Double(index) / 60))
+            writer.appendAudio(try audioSample(at: Double(index) / 60))
+        }
+        await writer.finish()
+
+        let asset = AVURLAsset(url: url)
+        let audio = try await asset.loadTracks(withMediaType: .audio)
+        XCTAssertFalse(audio.isEmpty, "system audio never reached the recording")
+    }
+
+    /// Audio before the first frame is dropped rather than shifting the whole soundtrack earlier
+    /// than the picture.
+    func testAudioBeforeTheFirstFrameIsDropped() async throws {
+        let url = directory.appendingPathComponent("audio-first.mov")
+        let writer = try RecordingWriter(url: url, size: CGSize(width: 160, height: 120), fps: 60,
+                                         capturesAudio: true)
+
+        for index in 0..<10 {
+            writer.appendAudio(try audioSample(at: Double(index) / 60))
+        }
+        await writer.finish()
+
+        // No video frame ever landed, so there is no usable file at all — a writer with nothing in
+        // it produces something `AVURLAsset` refuses to open, and that is the existing behaviour
+        // for a video-only writer. What matters is that audio arriving first did not change it by
+        // sneaking a soundtrack in ahead of a picture that never came.
+        let asset = AVURLAsset(url: url)
+        let audio = (try? await asset.loadTracks(withMediaType: .audio)) ?? []
+        XCTAssertTrue(audio.isEmpty, "audio was written with no picture to anchor it to")
+    }
+
+    private func audioSample(at seconds: Double) throws -> CMSampleBuffer {
+        let rate = 48_000.0
+        let frames = 512
+        var format = AudioStreamBasicDescription(
+            mSampleRate: rate, mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 4, mFramesPerPacket: 1, mBytesPerFrame: 4,
+            mChannelsPerFrame: 2, mBitsPerChannel: 16, mReserved: 0)
+        var description: CMAudioFormatDescription?
+        CMAudioFormatDescriptionCreate(allocator: nil, asbd: &format, layoutSize: 0, layout: nil,
+                                       magicCookieSize: 0, magicCookie: nil, extensions: nil,
+                                       formatDescriptionOut: &description)
+
+        let bytes = frames * 4
+        let memory = malloc(bytes)!
+        memset(memory, 0x20, bytes)
+        var block: CMBlockBuffer?
+        CMBlockBufferCreateWithMemoryBlock(allocator: nil, memoryBlock: memory, blockLength: bytes,
+                                           blockAllocator: nil, customBlockSource: nil,
+                                           offsetToData: 0, dataLength: bytes, flags: 0,
+                                           blockBufferOut: &block)
+        var timing = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: CMTimeScale(rate)),
+            presentationTimeStamp: CMTime(seconds: seconds, preferredTimescale: 600),
+            decodeTimeStamp: .invalid)
+        var sample: CMSampleBuffer?
+        CMSampleBufferCreateReady(allocator: nil, dataBuffer: try XCTUnwrap(block),
+                                  formatDescription: try XCTUnwrap(description),
+                                  sampleCount: frames, sampleTimingEntryCount: 1,
+                                  sampleTimingArray: &timing, sampleSizeEntryCount: 1,
+                                  sampleSizeArray: [4], sampleBufferOut: &sample)
+        return try XCTUnwrap(sample)
+    }
 }

--- a/Tests/SarvkritTests/ScreenRecordingHotkeyBindingTests.swift
+++ b/Tests/SarvkritTests/ScreenRecordingHotkeyBindingTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import Sarvkrit
+
+/// When the recording shortcuts get bound, relative to when their closures exist.
+///
+/// **This suite exists because ⌃⇧R did nothing until the feature was switched off and on again.**
+///
+/// `AppState.shared`'s initialiser ends in `sync()`, and it is forced by `wireClipboardPicker()`
+/// at the top of `applicationDidFinishLaunching`. `wireRecording()` — which assigns `startStop`
+/// and its three siblings — runs four lines later. So `rebindHotkeys()` always runs with every
+/// closure still nil, and it used to read them by value:
+///
+/// ```swift
+/// case .startStop: return startStop        // nil, so `guard let handler … else { continue }`
+/// ```
+///
+/// Zero shortcuts were registered, and nothing ever registered them afterwards: `sync()` only
+/// activates features not already in `activeFeatureIDs`, so the single escape was to leave that
+/// set — which is exactly what toggling the feature off and on does.
+///
+/// `ScreenshotFeature` has the identical launch ordering and works, because its handlers read the
+/// property at fire time instead. Its own comment states the contract: *"Nil until then, and every
+/// call site tolerates that — a nil closure is how a not-yet-built half of the feature is absent
+/// rather than crashing."*
+final class ScreenRecordingHotkeyBindingTests: XCTestCase {
+
+    private func makeFeature() -> ScreenRecordingFeature {
+        ScreenRecordingFeature(defaults: UserDefaults(suiteName: "recording.\(UUID())")!)
+    }
+
+    /// The bug, stated directly: at the moment `rebindHotkeys()` runs, every action must still
+    /// have something to register.
+    func testEveryActionHasAHandlerBeforeItsClosureIsAssigned() {
+        let feature = makeFeature()
+
+        for action in RecordingAction.allCases {
+            XCTAssertNotNil(feature.handler(for: action),
+                            "\(action.rawValue) has no handler before AppDelegate wires it up, "
+                            + "so rebindHotkeys() skips it and the shortcut is never registered")
+        }
+    }
+
+    /// And the handler taken at registration time has to see a closure assigned afterwards —
+    /// which is the whole point of late binding, and the half a nil check would not catch.
+    func testAHandlerTakenBeforeAssignmentStillReachesTheClosure() {
+        let feature = makeFeature()
+        // Taken first, exactly as `rebindHotkeys()` does at launch.
+        let handlers = RecordingAction.allCases.map { ($0, feature.handler(for: $0)) }
+
+        var fired: Set<String> = []
+        feature.startStop = { fired.insert("startStop") }
+        feature.recordArea = { fired.insert("recordArea") }
+        feature.pauseResume = { fired.insert("pauseResume") }
+        feature.markMoment = { fired.insert("markMoment") }
+
+        for (_, handler) in handlers { handler?() }
+
+        XCTAssertEqual(fired, ["startStop", "recordArea", "pauseResume", "markMoment"])
+    }
+
+    /// A handler fired while its closure is still nil must do nothing rather than crash — the
+    /// window between registration and wiring is real, if short.
+    func testAHandlerFiredBeforeAssignmentDoesNothing() {
+        let feature = makeFeature()
+        for action in RecordingAction.allCases {
+            feature.handler(for: action)?()
+        }
+    }
+}

--- a/Tests/SarvkritTests/SecureFieldCheckTests.swift
+++ b/Tests/SarvkritTests/SecureFieldCheckTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import Sarvkrit
+
+/// The secure-field check, which is what keeps somebody's password out of `events.json`.
+///
+/// It used to reach the element with `unsafeBitCast`, doing no type check where every other
+/// Accessibility call site in this codebase does one. That was not the crash it was once blamed
+/// for — the crash report named a blocked main thread instead — but an unchecked cast of a
+/// `CFTypeRef` is a bug waiting for the day the attribute comes back as something else.
+final class SecureFieldCheckTests: XCTestCase {
+
+    /// Callable repeatedly, from a background thread, without tripping over itself. The keystroke
+    /// path runs it once per key, wherever AppKit delivered the event.
+    func testRepeatedCallsAreStableOffTheMainThread() {
+        let done = expectation(description: "checked")
+        DispatchQueue.global().async {
+            for _ in 0..<200 { _ = SecureFieldCheck.isFocusedElementSecure() }
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 10)
+    }
+
+    /// With nothing focused — which is the ordinary case in a test host — the answer is "not
+    /// secure" rather than a crash or a true that would silently stop recording keystrokes.
+    func testUnfocusedHostIsNotReportedSecure() {
+        XCTAssertFalse(SecureFieldCheck.isFocusedElementSecure())
+    }
+}

--- a/Tests/SarvkritTests/StudioAudioTests.swift
+++ b/Tests/SarvkritTests/StudioAudioTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import Sarvkrit
+
+/// Silence, typing bursts, loudness and ducking — all four over a plain amplitude envelope.
+///
+/// None of these opens an audio file. An envelope is an array of floats; a keystroke run is an
+/// array of timestamps. Keeping the judgements at that level is what makes them adjustable without
+/// an AVFoundation dependency in the test bundle, and it is the same reason `MixerLevels` and
+/// `SoftClip` are testable today.
+final class StudioAudioTests: XCTestCase {
+
+    private func envelope(_ amplitude: Float, seconds: Double, rate: Double = 100) -> [Float] {
+        [Float](repeating: amplitude, count: Int(seconds * rate))
+    }
+
+    // MARK: - Silence
+
+    func testLoudAudioHasNoSilences() {
+        XCTAssertTrue(SilenceDetector.silences(in: envelope(0.5, seconds: 5), sampleRate: 100)
+            .isEmpty)
+    }
+
+    func testALongQuietStretchIsFound() {
+        let signal = envelope(0.5, seconds: 1) + envelope(0.0001, seconds: 3)
+            + envelope(0.5, seconds: 1)
+        let found = SilenceDetector.silences(in: signal, sampleRate: 100)
+        XCTAssertEqual(found.count, 1)
+    }
+
+    /// A breath between sentences is not dead air, and cutting it makes speech sound gasped.
+    func testAShortGapIsLeftAlone() {
+        let signal = envelope(0.5, seconds: 1) + envelope(0.0001, seconds: 0.3)
+            + envelope(0.5, seconds: 1)
+        XCTAssertTrue(SilenceDetector.silences(in: signal, sampleRate: 100).isEmpty)
+    }
+
+    /// Cutting exactly at the threshold clips the attack of the next word. The pad is what stops
+    /// a de-silenced recording sounding like it was edited with a hatchet.
+    func testTheDetectedRangeIsPaddedInFromBothEnds() {
+        let signal = envelope(0.5, seconds: 1) + envelope(0.0001, seconds: 3)
+            + envelope(0.5, seconds: 1)
+        guard let range = SilenceDetector.silences(in: signal, sampleRate: 100).first else {
+            return XCTFail("expected a silence")
+        }
+        let pad = SilenceDetector.Tuning().pad
+        XCTAssertEqual(range.lowerBound, 1 + pad, accuracy: 0.05)
+        XCTAssertEqual(range.upperBound, 4 - pad, accuracy: 0.05)
+    }
+
+    func testAnEmptyEnvelopeHasNoSilences() {
+        XCTAssertTrue(SilenceDetector.silences(in: [], sampleRate: 100).isEmpty)
+    }
+
+    func testEverySilenceIsAtLeastTheMinimumLong() {
+        let signal = envelope(0.5, seconds: 0.5) + envelope(0.0001, seconds: 0.8)
+            + envelope(0.5, seconds: 0.5) + envelope(0.0001, seconds: 2)
+        let tuning = SilenceDetector.Tuning()
+        for range in SilenceDetector.silences(in: signal, sampleRate: 100) {
+            XCTAssertGreaterThanOrEqual(range.upperBound - range.lowerBound,
+                                        tuning.minimumDuration - tuning.pad * 2 - 0.02)
+        }
+    }
+
+    // MARK: - Typing
+
+    private func keys(from start: Double, count: Int, every gap: Double) -> [KeyEvent] {
+        (0..<count).map {
+            KeyEvent(t: start + Double($0) * gap, label: "A", isModifierCombination: false)
+        }
+    }
+
+    /// Watching someone type is boring at 1× and fine at 4×.
+    func testATypingBurstIsSuggested() {
+        XCTAssertEqual(TypingDetector.runs(in: keys(from: 5, count: 12, every: 0.12)).count, 1)
+    }
+
+    func testAStrayKeypressIsNotATypingBurst() {
+        XCTAssertTrue(TypingDetector.runs(in: keys(from: 5, count: 2, every: 0.12)).isEmpty)
+    }
+
+    func testTwoSeparatedBurstsAreSuggestedSeparately() {
+        let both = keys(from: 5, count: 10, every: 0.12) + keys(from: 40, count: 10, every: 0.12)
+        XCTAssertEqual(TypingDetector.runs(in: both).count, 2)
+    }
+
+    func testASuggestionSpansTheBurst() {
+        guard let run = TypingDetector.runs(in: keys(from: 5, count: 10, every: 0.2)).first else {
+            return XCTFail("expected a run")
+        }
+        XCTAssertEqual(run.start, 5, accuracy: 0.001)
+        XCTAssertEqual(run.end, 6.8, accuracy: 0.001)
+    }
+
+    /// A suggestion, never an application. A speed change silently inserted into someone's
+    /// timeline is the kind of helpfulness that makes a tool untrustworthy.
+    func testASuggestionCarriesASpeedRatherThanApplyingOne() {
+        let run = TypingDetector.runs(in: keys(from: 5, count: 10, every: 0.12)).first
+        XCTAssertEqual(run?.suggestedSpeed ?? 0, TypingDetector.Tuning().suggestedSpeed)
+    }
+
+    // MARK: - Loudness
+
+    func testSilenceMeasuresVeryQuiet() {
+        XCTAssertLessThan(LoudnessMeter.loudness(of: envelope(0.00001, seconds: 1)), -80)
+    }
+
+    func testFullScaleMeasuresNearZero() {
+        XCTAssertEqual(LoudnessMeter.loudness(of: envelope(1, seconds: 1)), 0, accuracy: 0.5)
+    }
+
+    func testHalfScaleMeasuresAboutMinusSix() {
+        XCTAssertEqual(LoudnessMeter.loudness(of: envelope(0.5, seconds: 1)), -6, accuracy: 0.5)
+    }
+
+    /// One constant gain, not a compressor. A demo recorded slightly too quiet is the actual
+    /// problem, and dynamic-range compression on speech is a taste decision the app should not
+    /// make on someone's behalf.
+    func testTheGainIsWhateverClosesTheGapToTheTarget() {
+        XCTAssertEqual(LoudnessMeter.gain(from: -26, to: -16), 10, accuracy: 0.0001)
+    }
+
+    func testAnEmptyEnvelopeIsTreatedAsSilent() {
+        XCTAssertLessThan(LoudnessMeter.loudness(of: []), -80)
+    }
+
+    // MARK: - Ducking
+
+    func testWithNoSpeechTheOtherTrackIsUntouched() {
+        let gains = Ducker.gains(forSpeech: envelope(0.0001, seconds: 2), sampleRate: 100)
+        XCTAssertTrue(gains.allSatisfy { abs($0 - 1) < 0.001 })
+    }
+
+    func testSustainedSpeechPullsTheOtherTrackDown() {
+        let gains = Ducker.gains(forSpeech: envelope(0.5, seconds: 3), sampleRate: 100)
+        let target = Ducker.Tuning().depthGain
+        XCTAssertEqual(Double(gains.last ?? 1), target, accuracy: 0.02)
+    }
+
+    func testTheGainNeverLeavesItsRange() {
+        let speech = envelope(0.6, seconds: 1) + envelope(0.0001, seconds: 1)
+            + envelope(0.6, seconds: 1)
+        let target = Ducker.Tuning().depthGain
+        for gain in Ducker.gains(forSpeech: speech, sampleRate: 100) {
+            XCTAssertLessThanOrEqual(Double(gain), 1.0001)
+            XCTAssertGreaterThanOrEqual(Double(gain), target - 0.0001)
+        }
+    }
+
+    /// Ducking has to be quick to get out of the way and slow to come back, or the music pumps on
+    /// every syllable.
+    func testItDucksFasterThanItRecovers() {
+        let tuning = Ducker.Tuning()
+        XCTAssertLessThan(tuning.attack, tuning.release)
+
+        let speech = envelope(0.6, seconds: 0.5) + envelope(0.0001, seconds: 0.5)
+        let gains = Ducker.gains(forSpeech: speech, sampleRate: 100)
+        let duckedBy = 1 - Double(gains[49])
+        let recoveredBy = Double(gains[99]) - Double(gains[50])
+        XCTAssertGreaterThan(duckedBy, recoveredBy)
+    }
+
+    func testAnEmptySpeechTrackProducesNoGains() {
+        XCTAssertTrue(Ducker.gains(forSpeech: [], sampleRate: 100).isEmpty)
+    }
+}

--- a/Tests/SarvkritTests/StudioChromeLogicTests.swift
+++ b/Tests/SarvkritTests/StudioChromeLogicTests.swift
@@ -1,0 +1,215 @@
+import AppKit
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// The small decisions the editor's chrome rests on: click effects, export presets, key routing
+/// and the recording sources. All pure, all exhaustively enumerable, none of them needing a window.
+final class StudioChromeLogicTests: XCTestCase {
+
+    // MARK: - Click effects
+
+    func testNoEffectNeverDrawsAnything() {
+        XCTAssertNil(ClickEffect.state(.none, secondsSinceClick: 0))
+        XCTAssertNil(ClickEffect.state(.none, secondsSinceClick: 0.1))
+    }
+
+    func testAnEffectDrawsNothingBeforeTheClick() {
+        XCTAssertNil(ClickEffect.state(.ripple, secondsSinceClick: -0.01))
+    }
+
+    func testAnEffectIsOverAfterItsDuration() {
+        XCTAssertNil(ClickEffect.state(.ripple, secondsSinceClick: ClickEffect.duration + 0.001))
+    }
+
+    func testARippleExpands() {
+        var previous = -1.0
+        for step in 0...20 {
+            let t = ClickEffect.duration * Double(step) / 20
+            let radius = ClickEffect.state(.ripple, secondsSinceClick: t)?.ringRadius ?? -1
+            XCTAssertGreaterThanOrEqual(radius, previous)
+            previous = radius
+        }
+    }
+
+    /// A ripple that is still solid when it stops reads as a rendering glitch rather than an
+    /// effect ending.
+    func testARippleFadesOutCompletely() {
+        let end = ClickEffect.state(.ripple, secondsSinceClick: ClickEffect.duration * 0.999)
+        XCTAssertLessThan(end?.ringAlpha ?? 1, 0.05)
+    }
+
+    func testARippleStartsSolid() {
+        XCTAssertGreaterThan(ClickEffect.state(.ripple, secondsSinceClick: 0)?.ringAlpha ?? 0, 0.5)
+    }
+
+    /// The subtle one: the pointer itself dips, which reads as "the mouse was pressed" rather than
+    /// as "an effect played".
+    func testShrinkPullsTheCursorInAndPutsItBack() {
+        XCTAssertLessThan(ClickEffect.state(.shrink, secondsSinceClick: 0.02)?.cursorScale ?? 1, 1)
+        let end = ClickEffect.state(.shrink, secondsSinceClick: ClickEffect.duration * 0.999)
+        XCTAssertEqual(end?.cursorScale ?? 0, 1, accuracy: 0.05)
+    }
+
+    func testShrinkNeverMovesTheRing() {
+        XCTAssertEqual(ClickEffect.state(.shrink, secondsSinceClick: 0.05)?.ringAlpha ?? 1, 0)
+    }
+
+    func testAHighlightFades() {
+        let early = ClickEffect.state(.highlight, secondsSinceClick: 0.01)?.fillAlpha ?? 0
+        let late = ClickEffect.state(.highlight, secondsSinceClick: 0.18)?.fillAlpha ?? 1
+        XCTAssertGreaterThan(early, late)
+    }
+
+    func testEveryStyleKeepsItsAlphasInRange() {
+        for style in ClickEffectStyle.allCases {
+            for step in 0...30 {
+                let t = ClickEffect.duration * Double(step) / 30
+                guard let state = ClickEffect.state(style, secondsSinceClick: t) else { continue }
+                XCTAssertTrue((0...1).contains(state.ringAlpha), "\(style.rawValue)")
+                XCTAssertTrue((0...1).contains(state.fillAlpha), "\(style.rawValue)")
+                XCTAssertGreaterThan(state.cursorScale, 0, "\(style.rawValue)")
+            }
+        }
+    }
+
+    // MARK: - Export presets
+
+    func testEveryPresetHasItsOwnIdentity() {
+        let ids = ExportPreset.all.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count)
+    }
+
+    /// The default has to play everywhere — a Slack preview, a PowerPoint slide, a PR comment.
+    func testTheDefaultPresetIsPlayableEverywhere() {
+        XCTAssertEqual(ExportPreset.web.codec, .h264)
+        XCTAssertEqual(ExportPreset.web.height, 1080)
+    }
+
+    func testTheEditorPresetKeepsTheAudioTracksApart() {
+        XCTAssertTrue(ExportPreset.forEditing.separatesAudioTracks)
+        XCTAssertEqual(ExportPreset.forEditing.codec, .proRes422)
+    }
+
+    func testAPresetPreservesTheCanvasAspect() {
+        let size = ExportPreset.web.outputSize(forCanvas: CGSize(width: 3000, height: 2000))
+        XCTAssertEqual(size.width / size.height, 1.5, accuracy: 0.01)
+    }
+
+    /// **Odd dimensions cost quality for nothing.** H.264 and HEVC work in macroblocks, and an odd
+    /// width forces the encoder to pad — so every size this hands back is even.
+    func testEveryOutputSizeIsEven() {
+        let canvases = [CGSize(width: 1001, height: 667), CGSize(width: 2557, height: 1439),
+                        CGSize(width: 999, height: 999)]
+        for preset in ExportPreset.all where preset.codec != .gif {
+            for canvas in canvases {
+                let size = preset.outputSize(forCanvas: canvas)
+                XCTAssertEqual(Int(size.width) % 2, 0, "\(preset.id) \(canvas)")
+                XCTAssertEqual(Int(size.height) % 2, 0, "\(preset.id) \(canvas)")
+            }
+        }
+    }
+
+    func testAPresetWithNoHeightKeepsTheCanvasSize() {
+        let canvas = CGSize(width: 2560, height: 1440)
+        XCTAssertEqual(ExportPreset.forEditing.outputSize(forCanvas: canvas), canvas)
+    }
+
+    /// Upscaling a 720p recording to 4K makes a bigger file and not a better video.
+    func testAPresetNeverUpscales() {
+        let size = ExportPreset.web.outputSize(forCanvas: CGSize(width: 640, height: 360))
+        XCTAssertEqual(size.height, 360)
+    }
+
+    // MARK: - Key routing
+
+    private func action(_ characters: String, _ modifiers: NSEvent.ModifierFlags = [],
+                        editing: Bool = false) -> StudioKeyRouting.Action? {
+        StudioKeyRouting.action(forCharacters: characters, modifiers: modifiers,
+                                isEditingText: editing)
+    }
+
+    func testSpacePlaysAndPauses() {
+        XCTAssertEqual(action(" "), .playPause)
+    }
+
+    func testArrowsStepAFrame() {
+        XCTAssertEqual(action("\u{F702}"), .stepFrames(-1))
+        XCTAssertEqual(action("\u{F703}"), .stepFrames(1))
+    }
+
+    func testShiftedArrowsStepASecond() {
+        XCTAssertEqual(action("\u{F703}", .shift), .stepSeconds(1))
+    }
+
+    /// J/K/L is the shuttle every editor has, and anyone who has used one reaches for it without
+    /// thinking about it.
+    func testTheShuttleKeysShuttle() {
+        XCTAssertEqual(action("l"), .shuttle(1))
+        XCTAssertEqual(action("j"), .shuttle(-1))
+        XCTAssertEqual(action("k"), .shuttle(0))
+    }
+
+    /// Two different deletions, and conflating them is a daily annoyance: one lifts the clip and
+    /// leaves the gap, the other closes it.
+    func testRippleDeleteIsNotPlainDelete() {
+        XCTAssertEqual(action("x"), .rippleDelete)
+        XCTAssertEqual(action("\u{7F}"), .deleteSelection)
+    }
+
+    func testSplitIsOnItsUsualKey() {
+        XCTAssertEqual(action("b", .command), .split)
+    }
+
+    func testUndoAndRedo() {
+        XCTAssertEqual(action("z", .command), .undo)
+        XCTAssertEqual(action("z", [.command, .shift]), .redo)
+    }
+
+    func testDigitsSetTheSelectedZoomLevel() {
+        XCTAssertEqual(action("3"), .setZoomLevel(3))
+        XCTAssertEqual(action("9"), .setZoomLevel(9))
+    }
+
+    /// **The rule that keeps the editor usable.** Every bare-key shortcut here is a letter someone
+    /// might type into the transcript editor or a caption, so while a field has focus none of them
+    /// may fire.
+    func testBareKeysDoNothingWhileTextIsBeingEdited() {
+        for key in [" ", "x", "l", "j", "k", "3"] {
+            XCTAssertNil(action(key, editing: true), "\(key) fired while editing")
+        }
+    }
+
+    /// …but the command-key ones still work, because that is what everybody expects of ⌘Z.
+    func testCommandShortcutsStillWorkWhileEditingText() {
+        XCTAssertEqual(action("z", .command, editing: true), .undo)
+        XCTAssertEqual(action("s", .command, editing: true), .save)
+    }
+
+    func testAnUnboundKeyIsNotClaimed() {
+        XCTAssertNil(action("q"))
+    }
+
+    // MARK: - Sources
+
+    /// Raw values reach the project file, so renaming one silently orphans a saved recording.
+    func testEverySourceHasAStableRawValue() {
+        XCTAssertEqual(Set(RecordingSource.allCases.map(\.rawValue)),
+                       ["display", "window", "area"])
+    }
+
+    func testEverySourceNamesItselfAndHasAGlyph() {
+        for source in RecordingSource.allCases {
+            XCTAssertFalse(source.title.isEmpty)
+            XCTAssertFalse(source.symbolName.isEmpty)
+        }
+    }
+
+    /// Only an area is aimed by dragging a rectangle, which is what decides whether the frozen
+    /// overlay is shown at all.
+    func testOnlyAnAreaIsAimedByDragging() {
+        XCTAssertTrue(RecordingSource.area.aimsByDragging)
+        XCTAssertFalse(RecordingSource.window.aimsByDragging)
+        XCTAssertFalse(RecordingSource.display.aimsByDragging)
+    }
+}

--- a/Tests/SarvkritTests/StudioChromeLogicTests.swift
+++ b/Tests/SarvkritTests/StudioChromeLogicTests.swift
@@ -86,9 +86,14 @@ final class StudioChromeLogicTests: XCTestCase {
         XCTAssertEqual(ExportPreset.web.height, 1080)
     }
 
-    func testTheEditorPresetKeepsTheAudioTracksApart() {
-        XCTAssertTrue(ExportPreset.forEditing.separatesAudioTracks)
+    /// **This asserted `separatesAudioTracks`, a flag nothing implemented.** The exporter writes
+    /// one AAC track whatever the preset says, so the test was pinning a promise the app did not
+    /// keep — the worst kind of green. The flag is gone; what the editor preset actually offers is
+    /// ProRes at full size, and that is what is asserted.
+    func testTheEditorPresetIsProResAtFullSize() {
         XCTAssertEqual(ExportPreset.forEditing.codec, .proRes422)
+        XCTAssertNil(ExportPreset.forEditing.height)
+        XCTAssertEqual(ExportPreset.forEditing.fileType, .mov)
     }
 
     func testAPresetPreservesTheCanvasAspect() {

--- a/Tests/SarvkritTests/StudioEditorIntegrationTests.swift
+++ b/Tests/SarvkritTests/StudioEditorIntegrationTests.swift
@@ -1,0 +1,141 @@
+import AVFoundation
+import AppKit
+import CoreMedia
+import XCTest
+@testable import Sarvkrit
+
+/// The editor, assembled the way the app assembles it, over a recording long enough to be real.
+///
+/// **This suite exists because I could not press the button.** Play and the seekbar were both
+/// reported dead, twice, and this machine refuses synthetic input — so every previous round verified
+/// the transport by reasoning rather than by driving it. This drives it: the real window controller,
+/// the real view hierarchy, the real clock, through the same call the Play button's action makes.
+///
+/// **And it is thirty seconds, not one.** Every other test in this feature uses a one- or two-second
+/// clip, which is why nothing had ever exercised a seek that has real decoding to do between
+/// keyframes — precisely the case a scrub hits.
+///
+/// **What this suite deliberately does not assert: the picture.** `AVPlayerItemVideoOutput` delivers
+/// no frames in this test host — not even the opening one, which the running app plainly does show —
+/// so a pixel assertion here would fail for reasons that have nothing to do with the code. Decoded
+/// pixels are covered where they can be, by `StudioExportTests`, and the on-screen picture is
+/// verified by driving the running app through `sarvkrit://seek`.
+final class StudioEditorIntegrationTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUp() {
+        super.setUp()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("editor-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: directory)
+        super.tearDown()
+    }
+
+    private static let seconds: Double = 30
+    private static let fps = 30
+
+    /// A real, decodable recording of `seconds` length, with a moving picture so one frame can be
+    /// told from another.
+    private func makeRecording() async throws -> RecordingBundle {
+        let bundle = try RecordingBundle.create(at: directory.appendingPathComponent("r.sarvrec"))
+        let size = CGSize(width: 320, height: 240)
+        let writer = try RecordingWriter(url: bundle.screenURL, size: size, fps: Self.fps)
+
+        for index in 0..<Int(Self.seconds * Double(Self.fps)) {
+            var pixelBuffer: CVPixelBuffer?
+            CVPixelBufferCreate(nil, Int(size.width), Int(size.height),
+                                kCVPixelFormatType_32BGRA, nil, &pixelBuffer)
+            let buffer = try XCTUnwrap(pixelBuffer)
+            CVPixelBufferLockBaseAddress(buffer, [])
+            if let base = CVPixelBufferGetBaseAddress(buffer) {
+                // Ramps across the whole length, so any two moments differ.
+                memset(base, Int32(20 + (index * 200) / Int(Self.seconds * Double(Self.fps))),
+                       CVPixelBufferGetBytesPerRow(buffer) * Int(size.height))
+            }
+            CVPixelBufferUnlockBaseAddress(buffer, [])
+
+            var format: CMFormatDescription?
+            CMVideoFormatDescriptionCreateForImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                         formatDescriptionOut: &format)
+            var timing = CMSampleTimingInfo(
+                duration: CMTime(value: 1, timescale: CMTimeScale(Self.fps)),
+                presentationTimeStamp: CMTime(seconds: Double(index) / Double(Self.fps),
+                                              preferredTimescale: 600),
+                decodeTimeStamp: .invalid)
+            var sample: CMSampleBuffer?
+            CMSampleBufferCreateReadyWithImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                     formatDescription: try XCTUnwrap(format),
+                                                     sampleTiming: &timing,
+                                                     sampleBufferOut: &sample)
+            writer.append(try XCTUnwrap(sample))
+        }
+        await writer.finish()
+
+        var manifest = RecordingManifest(source: .display, pixelSize: size,
+                                         pointPixelScale: 1, fps: Self.fps)
+        manifest.state = .complete
+        manifest.duration = Self.seconds
+        try bundle.write(manifest)
+        try bundle.writeEvents(EventLog())
+        return bundle
+    }
+
+    /// Everything the app builds when a recording finishes, including a shown window — which is what
+    /// makes the clock and the decoder behave as they do in use.
+    @MainActor
+    private func openEditor(over bundle: RecordingBundle) throws
+        -> (StudioDocumentModel, StudioEditorWindowController) {
+        let manifest = try bundle.readManifest()
+        let events = (try? bundle.readEvents()) ?? EventLog()
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: events)
+        let controller = StudioEditorWindowController(model: model) { _ in }
+        controller.show()
+        return (model, controller)
+    }
+
+    private func pump(_ seconds: TimeInterval, until done: () -> Bool = { false }) {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline, !done() {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+    }
+
+    /// **Play.** The same call the button's action makes, on the real window.
+    @MainActor
+    func testPlayAdvancesThePlayheadInARealEditorWindow() async throws {
+        let bundle = try await makeRecording()
+        let (model, _) = try openEditor(over: bundle)
+        defer { model.player.pause() }
+
+        XCTAssertEqual(model.playhead, 0)
+        model.player.toggle()
+        XCTAssertTrue(model.player.isPlaying, "the transport refused to start")
+
+        pump(3) { model.playhead > 0.5 }
+        model.player.pause()
+
+        XCTAssertGreaterThan(model.playhead, 0.4,
+                             "the playhead did not move, so playback does nothing visible")
+    }
+
+    /// The playhead itself must land where it was asked to, at the far end of a long recording.
+    @MainActor
+    func testScrubbingNearTheEndLandsWhereAsked() async throws {
+        let bundle = try await makeRecording()
+        let (model, _) = try openEditor(over: bundle)
+        defer { model.player.pause() }
+
+        model.player.scrub(to: Self.seconds - 0.5)
+        XCTAssertEqual(model.playhead, Self.seconds - 0.5, accuracy: 0.01)
+
+        // And past the end clamps rather than running away.
+        model.player.scrub(to: Self.seconds + 10)
+        XCTAssertEqual(model.playhead, Self.seconds, accuracy: 0.01)
+    }
+
+}

--- a/Tests/SarvkritTests/StudioExportTests.swift
+++ b/Tests/SarvkritTests/StudioExportTests.swift
@@ -26,9 +26,10 @@ final class StudioExportTests: XCTestCase {
 
     /// A real, decodable recording: solid colour frames at 60 fps, written the way the recorder
     /// writes them.
-    private func makeRecording(seconds: Double) throws -> RecordingBundle {
+    private func makeRecording(seconds: Double,
+                               size: CGSize = CGSize(width: 160, height: 120))
+        throws -> RecordingBundle {
         let bundle = try RecordingBundle.create(at: directory.appendingPathComponent("r.sarvrec"))
-        let size = CGSize(width: 160, height: 120)
         let writer = try RecordingWriter(url: bundle.screenURL, size: size, fps: 60)
 
         let frames = Int(seconds * 60)
@@ -347,6 +348,40 @@ final class StudioExportTests: XCTestCase {
     private static func peak(of url: URL) async throws -> Float {
         let envelope = try await AudioEnvelope.read(url: url, samplesPerSecond: 20)
         return envelope.max() ?? 0
+    }
+
+    /// A longer export with sound comes out whole — both tracks, the right length.
+    ///
+    /// **This does not catch the deadlock it was written for, and that is worth recording.** An
+    /// `AVAssetWriter` with two open inputs holds `isReadyForMoreMediaData` down to force
+    /// interleaving, so writing every frame and then every audio sample hangs — the video input
+    /// waits for audio the loop has not reached. A real twenty-second 3024×1964 export sat at zero
+    /// bytes for two minutes; five seconds at 640×480 still fits in the writer's queue and passes
+    /// either way. I checked, by putting the old ordering back.
+    ///
+    /// So the guard against it is structural rather than a test: the audio track is written and
+    /// closed before a single frame goes in, and the reason is stated at that line. A fixture large
+    /// enough to reproduce it would cost minutes per run, which is a poor trade for a rule that is
+    /// visible in the code.
+    func testALongerExportWithAudioDoesNotStall() async throws {
+        let bundle = try makeRecording(seconds: 5, size: CGSize(width: 640, height: 480))
+        try await writeNarration(to: bundle.microphoneURL, seconds: 5)
+        var manifest = try bundle.readManifest()
+        manifest.hasMicrophone = true
+        try bundle.write(manifest)
+
+        let destination = directory.appendingPathComponent("long-with-sound.mp4")
+        try await StudioExporter().export(
+            project: try project(over: bundle, seconds: 5), events: EventLog(),
+            recording: bundle, preset: .web, to: destination, onProgress: { _ in })
+
+        let asset = AVURLAsset(url: destination)
+        let audio = try await asset.loadTracks(withMediaType: .audio)
+        let video = try await asset.loadTracks(withMediaType: .video)
+        XCTAssertFalse(audio.isEmpty, "no audio track")
+        XCTAssertFalse(video.isEmpty, "no video track")
+        let duration = try await asset.load(.duration)
+        XCTAssertEqual(CMTimeGetSeconds(duration), 5, accuracy: 0.5)
     }
 
     func testProgressReachesTheEnd() async throws {

--- a/Tests/SarvkritTests/StudioExportTests.swift
+++ b/Tests/SarvkritTests/StudioExportTests.swift
@@ -48,14 +48,58 @@ final class StudioExportTests: XCTestCase {
         return bundle
     }
 
-    private func sample(at seconds: Double, size: CGSize) throws -> CMSampleBuffer {
+    /// The same, plus a real `camera.mov`.
+    ///
+    /// **This fixture is the point.** Every export test before it wrote only `screen.mov`, so "is
+    /// the camera in the finished file" was not a question the suite could ask — and the answer, for
+    /// the whole life of the feature, was no: nothing ever opened `camera.mov` after recording it.
+    private func makeRecordingWithCamera(seconds: Double) throws -> RecordingBundle {
+        let bundle = try makeRecording(seconds: seconds)
+        let size = CGSize(width: 160, height: 120)
+        let writer = try RecordingWriter(url: bundle.cameraURL, size: size, fps: 60)
+        for index in 0..<Int(seconds * 60) {
+            // Near-white, so the picture-in-picture cannot be confused with the screen beneath it.
+            writer.append(try sample(at: Double(index) / 60, size: size, luma: 250))
+        }
+        let written = expectation(description: "camera written")
+        Task { await writer.finish(); written.fulfill() }
+        wait(for: [written], timeout: 20)
+
+        var manifest = try bundle.readManifest()
+        manifest.hasCamera = true
+        try bundle.write(manifest)
+        return bundle
+    }
+
+    /// The bytes of the first exported frame, for comparing two exports of the same project.
+    private func firstFrame(of url: URL) async throws -> Data {
+        let asset = AVURLAsset(url: url)
+        let tracks = try await asset.loadTracks(withMediaType: .video)
+        let track = try XCTUnwrap(tracks.first)
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(
+            track: track,
+            outputSettings: [kCVPixelBufferPixelFormatTypeKey as String:
+                                kCVPixelFormatType_32BGRA])
+        reader.add(output)
+        reader.startReading()
+        let sample = try XCTUnwrap(output.copyNextSampleBuffer())
+        let buffer = try XCTUnwrap(CMSampleBufferGetImageBuffer(sample))
+        CVPixelBufferLockBaseAddress(buffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(buffer, .readOnly) }
+        let base = try XCTUnwrap(CVPixelBufferGetBaseAddress(buffer))
+        return Data(bytes: base,
+                    count: CVPixelBufferGetBytesPerRow(buffer) * CVPixelBufferGetHeight(buffer))
+    }
+
+    private func sample(at seconds: Double, size: CGSize, luma: Int? = nil) throws -> CMSampleBuffer {
         var pixelBuffer: CVPixelBuffer?
         CVPixelBufferCreate(nil, Int(size.width), Int(size.height),
                             kCVPixelFormatType_32BGRA, nil, &pixelBuffer)
         let buffer = try XCTUnwrap(pixelBuffer)
         CVPixelBufferLockBaseAddress(buffer, [])
         if let base = CVPixelBufferGetBaseAddress(buffer) {
-            memset(base, Int32(40 + Int(seconds * 60) % 180),
+            memset(base, Int32(luma ?? (40 + Int(seconds * 60) % 180)),
                    CVPixelBufferGetBytesPerRow(buffer) * Int(size.height))
         }
         CVPixelBufferUnlockBaseAddress(buffer, [])
@@ -131,6 +175,37 @@ final class StudioExportTests: XCTestCase {
         }
         XCTAssertGreaterThan(signatures.count, 1,
                              "every exported frame is identical — the reader never advanced")
+    }
+
+    /// **The assertion that was impossible before, and the one that would have caught this.**
+    ///
+    /// The renderer's own snapshot test hands `drawCamera` a camera image directly, so it proved the
+    /// compositing worked and said nothing about whether anything ever supplied one. Nothing did:
+    /// both production call sites built `FrameSources(screen:)` and left the other three fields at
+    /// their defaults. The camera was recorded faithfully and then never read again.
+    func testTheExportContainsTheCamera() async throws {
+        let bundle = try makeRecordingWithCamera(seconds: 1)
+        let project = try project(over: bundle, seconds: 1)
+
+        let withCamera = directory.appendingPathComponent("with-camera.mp4")
+        try await StudioExporter().export(
+            project: project, events: EventLog(), recording: bundle,
+            preset: .web, to: withCamera, onProgress: { _ in })
+
+        // The same recording again with the camera switched off in its manifest, so the picture in
+        // picture is the only difference between the two files.
+        var manifest = try bundle.readManifest()
+        manifest.hasCamera = false
+        try bundle.write(manifest)
+
+        let without = directory.appendingPathComponent("without-camera.mp4")
+        try await StudioExporter().export(
+            project: project, events: EventLog(), recording: bundle,
+            preset: .web, to: without, onProgress: { _ in })
+
+        let a = try await firstFrame(of: withCamera)
+        let b = try await firstFrame(of: without)
+        XCTAssertNotEqual(a, b, "the exported file is identical with and without a camera track")
     }
 
     func testProgressReachesTheEnd() async throws {

--- a/Tests/SarvkritTests/StudioExportTests.swift
+++ b/Tests/SarvkritTests/StudioExportTests.swift
@@ -344,6 +344,52 @@ final class StudioExportTests: XCTestCase {
         XCTAssertLessThan(loudest, 0.01, "a muted clip still has sound in the exported file")
     }
 
+    /// **Narration starts late, and it must be put back where it belongs.**
+    ///
+    /// An `AVCaptureSession` takes a couple of seconds to come up, so the microphone file begins
+    /// that much after the screen — `cameraStartOffset` in the manifest, which is really the
+    /// capture session's offset whichever file the sound landed in. The composition read it as if
+    /// file time equalled screen time, so every word was heard seconds *before* it was said and
+    /// the tail of the recording lost its sound entirely.
+    ///
+    /// Here the narration covers the last three seconds of a five-second take: the first two
+    /// seconds of the finished video must be silent, and the rest must not.
+    func testNarrationIsAlignedToWhenItWasActuallySpoken() async throws {
+        let bundle = try makeRecording(seconds: 5)
+        // Three seconds of tone, recorded starting two seconds into the screen capture.
+        try await writeNarration(to: bundle.microphoneURL, seconds: 3)
+        var manifest = try bundle.readManifest()
+        manifest.hasMicrophone = true
+        manifest.cameraStartOffset = 2
+        try bundle.write(manifest)
+
+        let destination = directory.appendingPathComponent("aligned.mp4")
+        try await StudioExporter().export(
+            project: try project(over: bundle, seconds: 5), events: EventLog(),
+            recording: bundle, preset: .web, to: destination, onProgress: { _ in })
+
+        let envelope = try await AudioEnvelope.read(url: destination, samplesPerSecond: 10)
+        XCTAssertGreaterThan(envelope.count, 30, "the exported audio is too short to judge")
+
+        // **Indexed by proportion, not by an assumed sample rate.** `AudioEnvelope` derives its
+        // slice size from the track's natural time scale, so "ten a second" is a request rather
+        // than a promise — an earlier version of this test did the arithmetic itself and read the
+        // wrong window, then reported a working fix as broken.
+        func loudest(betweenFraction from: Double, and to: Double) -> Float {
+            let lower = Int(Double(envelope.count) * from)
+            let upper = min(envelope.count, Int(Double(envelope.count) * to))
+            guard upper > lower else { return 0 }
+            return envelope[lower..<upper].max() ?? 0
+        }
+
+        // The narration covers the last three seconds of five, so the first third is before the
+        // microphone existed and the last third is well inside it.
+        XCTAssertLessThan(loudest(betweenFraction: 0, and: 0.3), 0.02,
+                          "there is sound before the microphone was running, so narration is early")
+        XCTAssertGreaterThan(loudest(betweenFraction: 0.6, and: 0.95), 0.05,
+                             "the narration never arrived")
+    }
+
     /// The loudest sample in a file's audio track, 0…1.
     private static func peak(of url: URL) async throws -> Float {
         let envelope = try await AudioEnvelope.read(url: url, samplesPerSecond: 20)

--- a/Tests/SarvkritTests/StudioExportTests.swift
+++ b/Tests/SarvkritTests/StudioExportTests.swift
@@ -71,6 +71,70 @@ final class StudioExportTests: XCTestCase {
         return bundle
     }
 
+    /// A real audio file at the bundle's microphone path: a tone, so "is there sound in the
+    /// export" has an answer that is not zero.
+    private func writeNarration(to url: URL, seconds: Double) async throws {
+        let writer = try AVAssetWriter(outputURL: url, fileType: .m4a)
+        let input = AVAssetWriterInput(mediaType: .audio, outputSettings: [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: 44_100,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderBitRateKey: 64_000,
+        ])
+        input.expectsMediaDataInRealTime = false
+        writer.add(input)
+        XCTAssertTrue(writer.startWriting())
+        writer.startSession(atSourceTime: .zero)
+
+        let rate = 44_100.0
+        let frames = 1024
+        var format = AudioStreamBasicDescription(
+            mSampleRate: rate, mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 2, mFramesPerPacket: 1, mBytesPerFrame: 2,
+            mChannelsPerFrame: 1, mBitsPerChannel: 16, mReserved: 0)
+        var description: CMAudioFormatDescription?
+        CMAudioFormatDescriptionCreate(allocator: nil, asbd: &format, layoutSize: 0, layout: nil,
+                                       magicCookieSize: 0, magicCookie: nil, extensions: nil,
+                                       formatDescriptionOut: &description)
+        let audioFormat = try XCTUnwrap(description)
+
+        var index = 0
+        while Double(index * frames) / rate < seconds {
+            var samples = [Int16](repeating: 0, count: frames)
+            for n in 0..<frames {
+                let t = Double(index * frames + n) / rate
+                samples[n] = Int16(sin(2 * .pi * 440 * t) * 12_000)
+            }
+            var block: CMBlockBuffer?
+            let bytes = frames * 2
+            let memory = malloc(bytes)!
+            samples.withUnsafeBytes { _ = memcpy(memory, $0.baseAddress!, bytes) }
+            CMBlockBufferCreateWithMemoryBlock(allocator: nil, memoryBlock: memory,
+                                               blockLength: bytes, blockAllocator: nil,
+                                               customBlockSource: nil, offsetToData: 0,
+                                               dataLength: bytes, flags: 0, blockBufferOut: &block)
+            var sample: CMSampleBuffer?
+            var timing = CMSampleTimingInfo(
+                duration: CMTime(value: 1, timescale: CMTimeScale(rate)),
+                presentationTimeStamp: CMTime(value: CMTimeValue(index * frames),
+                                              timescale: CMTimeScale(rate)),
+                decodeTimeStamp: .invalid)
+            CMSampleBufferCreateReady(allocator: nil, dataBuffer: try XCTUnwrap(block),
+                                      formatDescription: audioFormat, sampleCount: frames,
+                                      sampleTimingEntryCount: 1, sampleTimingArray: &timing,
+                                      sampleSizeEntryCount: 1, sampleSizeArray: [2],
+                                      sampleBufferOut: &sample)
+            while !input.isReadyForMoreMediaData {
+                try? await Task.sleep(nanoseconds: 1_000_000)
+            }
+            input.append(try XCTUnwrap(sample))
+            index += 1
+        }
+        input.markAsFinished()
+        await writer.finishWriting()
+    }
+
     /// The bytes of the first exported frame, for comparing two exports of the same project.
     private func firstFrame(of url: URL) async throws -> Data {
         let asset = AVURLAsset(url: url)
@@ -206,6 +270,83 @@ final class StudioExportTests: XCTestCase {
         let a = try await firstFrame(of: withCamera)
         let b = try await firstFrame(of: without)
         XCTAssertNotEqual(a, b, "the exported file is identical with and without a camera track")
+    }
+
+    // MARK: - Sound
+
+    /// **The assertion whose absence let every export ship silent.**
+    ///
+    /// `StudioExporter` did not contain the word "audio" once. It wrote a single video input and
+    /// read only the screen's video track — while the recorder captured narration, the manifest
+    /// recorded `hasMicrophone`, and `Clip` carried `volume`, `systemAudioVolume` and `isMuted`.
+    /// Every one of those controls was editing a track that never reached a file.
+    func testTheExportHasAudioWhenTheRecordingHasNarration() async throws {
+        let bundle = try makeRecording(seconds: 1)
+        try await writeNarration(to: bundle.microphoneURL, seconds: 1)
+        var manifest = try bundle.readManifest()
+        manifest.hasMicrophone = true
+        try bundle.write(manifest)
+
+        let destination = directory.appendingPathComponent("with-sound.mp4")
+        try await StudioExporter().export(
+            project: try project(over: bundle, seconds: 1), events: EventLog(),
+            recording: bundle, preset: .web, to: destination, onProgress: { _ in })
+
+        let asset = AVURLAsset(url: destination)
+        let audio = try await asset.loadTracks(withMediaType: .audio)
+        XCTAssertFalse(audio.isEmpty, "the exported file has no audio track at all")
+
+        let loudest = try await Self.peak(of: destination)
+        XCTAssertGreaterThan(loudest, 0.01, "the exported audio track is silent")
+    }
+
+    /// Isolates the fixture from the pipeline: if this fails, the test's own tone file is wrong
+    /// rather than the exporter.
+    func testTheNarrationFixtureAndCompositionAreSound() async throws {
+        let bundle = try makeRecording(seconds: 1)
+        try await writeNarration(to: bundle.microphoneURL, seconds: 1)
+
+        let asset = AVURLAsset(url: bundle.microphoneURL)
+        let tracks = try await asset.loadTracks(withMediaType: .audio)
+        XCTAssertFalse(tracks.isEmpty, "the fixture wrote no audio track")
+        let tonePeak = try await Self.peak(of: bundle.microphoneURL)
+        XCTAssertGreaterThan(tonePeak, 0.01, "the fixture's tone is silent")
+
+        let found = await StudioAudio.narrationURL(in: bundle)
+        XCTAssertNotNil(found, "StudioAudio did not find the narration file")
+
+        let composition = await StudioAudio.composition(
+            project: try project(over: bundle, seconds: 1), recording: bundle)
+        XCTAssertNotNil(composition, "no audio composition was built")
+        let built = try XCTUnwrap(composition)
+        let composed = try await built.asset.loadTracks(withMediaType: .audio)
+        XCTAssertFalse(composed.isEmpty, "the composition has no audio track")
+    }
+
+    /// A muted clip must be silent in the file, not merely marked muted in the editor.
+    func testAMutedClipIsSilentInTheFile() async throws {
+        let bundle = try makeRecording(seconds: 1)
+        try await writeNarration(to: bundle.microphoneURL, seconds: 1)
+        var manifest = try bundle.readManifest()
+        manifest.hasMicrophone = true
+        try bundle.write(manifest)
+
+        var muted = try project(over: bundle, seconds: 1)
+        muted.timeline.clips[0].isMuted = true
+
+        let destination = directory.appendingPathComponent("muted.mp4")
+        try await StudioExporter().export(
+            project: muted, events: EventLog(), recording: bundle,
+            preset: .web, to: destination, onProgress: { _ in })
+
+        let loudest = try await Self.peak(of: destination)
+        XCTAssertLessThan(loudest, 0.01, "a muted clip still has sound in the exported file")
+    }
+
+    /// The loudest sample in a file's audio track, 0…1.
+    private static func peak(of url: URL) async throws -> Float {
+        let envelope = try await AudioEnvelope.read(url: url, samplesPerSecond: 20)
+        return envelope.max() ?? 0
     }
 
     func testProgressReachesTheEnd() async throws {

--- a/Tests/SarvkritTests/StudioExportTests.swift
+++ b/Tests/SarvkritTests/StudioExportTests.swift
@@ -1,0 +1,195 @@
+import AVFoundation
+import CoreMedia
+import XCTest
+@testable import Sarvkrit
+
+/// Exporting a project to a file.
+///
+/// **The whole pipeline, end to end, with no window.** A recording is written, a project is built
+/// over it, and the exporter is asked for a file — which is the one path that has to work for any
+/// of this to be worth anything, and the one nobody notices is broken until they try it.
+final class StudioExportTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUp() {
+        super.setUp()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("export-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: directory)
+        super.tearDown()
+    }
+
+    /// A real, decodable recording: solid colour frames at 60 fps, written the way the recorder
+    /// writes them.
+    private func makeRecording(seconds: Double) throws -> RecordingBundle {
+        let bundle = try RecordingBundle.create(at: directory.appendingPathComponent("r.sarvrec"))
+        let size = CGSize(width: 160, height: 120)
+        let writer = try RecordingWriter(url: bundle.screenURL, size: size, fps: 60)
+
+        let frames = Int(seconds * 60)
+        for index in 0..<frames {
+            writer.append(try sample(at: Double(index) / 60, size: size))
+        }
+        let expectation = expectation(description: "written")
+        Task { await writer.finish(); expectation.fulfill() }
+        wait(for: [expectation], timeout: 20)
+
+        var manifest = RecordingManifest(source: .display, pixelSize: size,
+                                         pointPixelScale: 1, fps: 60)
+        manifest.state = .complete
+        manifest.duration = seconds
+        try bundle.write(manifest)
+        try bundle.writeEvents(EventLog())
+        return bundle
+    }
+
+    private func sample(at seconds: Double, size: CGSize) throws -> CMSampleBuffer {
+        var pixelBuffer: CVPixelBuffer?
+        CVPixelBufferCreate(nil, Int(size.width), Int(size.height),
+                            kCVPixelFormatType_32BGRA, nil, &pixelBuffer)
+        let buffer = try XCTUnwrap(pixelBuffer)
+        CVPixelBufferLockBaseAddress(buffer, [])
+        if let base = CVPixelBufferGetBaseAddress(buffer) {
+            memset(base, Int32(40 + Int(seconds * 60) % 180),
+                   CVPixelBufferGetBytesPerRow(buffer) * Int(size.height))
+        }
+        CVPixelBufferUnlockBaseAddress(buffer, [])
+
+        var format: CMFormatDescription?
+        CMVideoFormatDescriptionCreateForImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                     formatDescriptionOut: &format)
+        var timing = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: 60),
+            presentationTimeStamp: CMTime(seconds: seconds, preferredTimescale: 600),
+            decodeTimeStamp: .invalid)
+        var sample: CMSampleBuffer?
+        CMSampleBufferCreateReadyWithImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                 formatDescription: try XCTUnwrap(format),
+                                                 sampleTiming: &timing, sampleBufferOut: &sample)
+        return try XCTUnwrap(sample)
+    }
+
+    private func project(over bundle: RecordingBundle, seconds: Double) throws -> StudioProject {
+        let manifest = try bundle.readManifest()
+        return StudioProject(canvasSize: manifest.pixelSize.size,
+                             timeline: Timeline(clips: [Clip(sourceStart: 0, sourceEnd: seconds)]))
+    }
+
+    // MARK: - The pipeline
+
+    func testAProjectExportsToAPlayableFile() async throws {
+        let bundle = try makeRecording(seconds: 1)
+        let destination = directory.appendingPathComponent("out.mp4")
+
+        try await StudioExporter().export(
+            project: try project(over: bundle, seconds: 1), events: EventLog(),
+            recording: bundle, preset: .web, to: destination, onProgress: { _ in })
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path))
+        let asset = AVURLAsset(url: destination)
+        let track = try await asset.loadTracks(withMediaType: .video).first
+        XCTAssertNotNil(track, "the exported file has no video track")
+        let duration = try await asset.load(.duration)
+        XCTAssertEqual(CMTimeGetSeconds(duration), 1, accuracy: 0.2)
+    }
+
+    /// **The bug this guards against.** The reader is pulled forward frame by frame, so an
+    /// off-by-one in that loop yields a file of the right length made of one repeated frame — which
+    /// still opens, still reports the right duration, and is completely wrong.
+    func testTheExportIsNotOneFrameRepeated() async throws {
+        let bundle = try makeRecording(seconds: 1)
+        let destination = directory.appendingPathComponent("out.mp4")
+
+        try await StudioExporter().export(
+            project: try project(over: bundle, seconds: 1), events: EventLog(),
+            recording: bundle, preset: .web, to: destination, onProgress: { _ in })
+
+        let asset = AVURLAsset(url: destination)
+        let tracks = try await asset.loadTracks(withMediaType: .video)
+        let track = try XCTUnwrap(tracks.first)
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(
+            track: track,
+            outputSettings: [kCVPixelBufferPixelFormatTypeKey as String:
+                                kCVPixelFormatType_32BGRA])
+        reader.add(output)
+        reader.startReading()
+
+        var signatures: Set<Int> = []
+        while let sample = output.copyNextSampleBuffer() {
+            guard let buffer = CMSampleBufferGetImageBuffer(sample) else { continue }
+            CVPixelBufferLockBaseAddress(buffer, .readOnly)
+            if let base = CVPixelBufferGetBaseAddress(buffer) {
+                signatures.insert(base.load(as: UInt8.self).hashValue)
+            }
+            CVPixelBufferUnlockBaseAddress(buffer, .readOnly)
+        }
+        XCTAssertGreaterThan(signatures.count, 1,
+                             "every exported frame is identical — the reader never advanced")
+    }
+
+    func testProgressReachesTheEnd() async throws {
+        let bundle = try makeRecording(seconds: 1)
+        let destination = directory.appendingPathComponent("out.mp4")
+
+        let progress = LockedBox()
+        try await StudioExporter().export(
+            project: try project(over: bundle, seconds: 1), events: EventLog(),
+            recording: bundle, preset: .web, to: destination,
+            onProgress: { progress.set($0.fraction) })
+        XCTAssertEqual(progress.value, 1, accuracy: 0.05)
+    }
+
+    /// A cancelled export leaves nothing behind. A half-written file that looks finished is worse
+    /// than no file.
+    func testACancelledExportLeavesNoFile() async throws {
+        let bundle = try makeRecording(seconds: 2)
+        let destination = directory.appendingPathComponent("out.mp4")
+        let exporter = StudioExporter()
+
+        await exporter.cancel()
+        do {
+            try await exporter.export(
+                project: try project(over: bundle, seconds: 2), events: EventLog(),
+                recording: bundle, preset: .web, to: destination, onProgress: { _ in })
+            XCTFail("a cancelled export should throw")
+        } catch {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+        }
+    }
+
+    /// The preset decides the size, and it must never be odd — an odd dimension makes the encoder
+    /// pad the frame for nothing.
+    func testTheExportedSizeMatchesThePreset() async throws {
+        let bundle = try makeRecording(seconds: 1)
+        let destination = directory.appendingPathComponent("out.mp4")
+        let project = try project(over: bundle, seconds: 1)
+
+        try await StudioExporter().export(
+            project: project, events: EventLog(), recording: bundle,
+            preset: .web, to: destination, onProgress: { _ in })
+
+        let asset = AVURLAsset(url: destination)
+        let tracks = try await asset.loadTracks(withMediaType: .video)
+        let track = try XCTUnwrap(tracks.first)
+        let size = try await track.load(.naturalSize)
+        let (canvas, _) = StudioRenderer.layout(for: project)
+        XCTAssertEqual(size, ExportPreset.web.outputSize(forCanvas: canvas))
+        XCTAssertEqual(Int(size.width) % 2, 0)
+        XCTAssertEqual(Int(size.height) % 2, 0)
+    }
+}
+
+/// A box the export's progress callback can write to from whatever executor it runs on.
+private final class LockedBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Double = 0
+
+    func set(_ value: Double) { lock.lock(); stored = value; lock.unlock() }
+    var value: Double { lock.lock(); defer { lock.unlock() }; return stored }
+}

--- a/Tests/SarvkritTests/StudioExportTests.swift
+++ b/Tests/SarvkritTests/StudioExportTests.swift
@@ -390,6 +390,39 @@ final class StudioExportTests: XCTestCase {
                              "the narration never arrived")
     }
 
+    /// **Where exactly the narration starts.**
+    ///
+    /// The looser test above — first third silent, last third loud — passes whether the offset is
+    /// applied once or twice, which is no use for the bug it was written for. This one pins the
+    /// moment: with a two-second offset the sound must arrive at two seconds, not four.
+    func testNarrationStartsExactlyWhereTheOffsetSaysItShould() async throws {
+        let bundle = try makeRecording(seconds: 6)
+        try await writeNarration(to: bundle.microphoneURL, seconds: 4)
+        var manifest = try bundle.readManifest()
+        manifest.hasMicrophone = true
+        manifest.cameraStartOffset = 2
+        try bundle.write(manifest)
+
+        let destination = directory.appendingPathComponent("exact.mp4")
+        try await StudioExporter().export(
+            project: try project(over: bundle, seconds: 6), events: EventLog(),
+            recording: bundle, preset: .web, to: destination, onProgress: { _ in })
+
+        let envelope = try await AudioEnvelope.read(url: destination, samplesPerSecond: 10)
+        let asset = AVURLAsset(url: destination)
+        let seconds = CMTimeGetSeconds(try await asset.load(.duration))
+        XCTAssertGreaterThan(envelope.count, 20)
+        XCTAssertGreaterThan(seconds, 1)
+
+        /// The first moment carrying signal, in seconds of the finished video.
+        let perSecond = Double(envelope.count) / seconds
+        let firstSound = envelope.firstIndex { $0 > 0.02 }
+            .map { Double($0) / perSecond }
+
+        XCTAssertEqual(try XCTUnwrap(firstSound), 2, accuracy: 0.5,
+                       "the narration does not start where the capture offset says it does")
+    }
+
     /// The loudest sample in a file's audio track, 0…1.
     private static func peak(of url: URL) async throws -> Float {
         let envelope = try await AudioEnvelope.read(url: url, samplesPerSecond: 20)

--- a/Tests/SarvkritTests/StudioLayerTests.swift
+++ b/Tests/SarvkritTests/StudioLayerTests.swift
@@ -1,0 +1,218 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// Masks, the camera track and the keystroke overlay — the three layers that are decisions rather
+/// than drawing, kept pure so the decisions can be asserted without a pixel.
+final class StudioLayerTests: XCTestCase {
+
+    private let canvas = CGSize(width: 1000, height: 600)
+
+    // MARK: - Masks
+
+    private func mask(_ start: TimeInterval, _ end: TimeInterval,
+                      mode: StudioMask.Mode = .secureBlur) -> StudioMask {
+        StudioMask(mode: mode,
+                   rects: [CGRect(x: 100, y: 100, width: 200, height: 50)],
+                   start: start, end: end)
+    }
+
+    func testAMaskIsVisibleOnlyInsideItsRange() {
+        let one = mask(2, 5)
+        XCTAssertFalse(one.covers(1.9))
+        XCTAssertTrue(one.covers(3))
+        XCTAssertFalse(one.covers(5.1))
+    }
+
+    /// One mask, several rectangles: "hide every price in this table" is one object with one time
+    /// range, not nine to keep in sync.
+    func testAMaskCanCoverSeveralRectangles() {
+        var many = mask(0, 10)
+        many.rects.append(RectBox(CGRect(x: 400, y: 100, width: 120, height: 50)))
+        XCTAssertEqual(many.rects.count, 2)
+    }
+
+    /// **The safe failure direction, and it is worth a test.** A mask pinned to a window whose
+    /// window has gone must stay exactly where it is and stay opaque — uncovering what it was
+    /// hiding because the thing moved is the one outcome that must never happen.
+    func testAMaskWhoseWindowVanishesStaysPut() {
+        var pinned = mask(0, 10)
+        pinned.followsWindowID = 42
+        let original = pinned.rects
+        let resolved = pinned.resolved(windowFrames: [:], recordingSize: canvas)
+        XCTAssertEqual(resolved.rects, original)
+        XCTAssertTrue(resolved.covers(5), "a mask stopped covering when its window disappeared")
+    }
+
+    func testAPinnedMaskFollowsItsWindow() {
+        var pinned = mask(0, 10)
+        pinned.followsWindowID = 42
+        pinned.windowOriginAtCreation = CGPoint(x: 0, y: 0)
+        let moved = pinned.resolved(windowFrames: [42: CGRect(x: 50, y: 20, width: 800, height: 600)],
+                                    recordingSize: canvas)
+        XCTAssertEqual(moved.rects[0].x, 150, accuracy: 0.001)
+        XCTAssertEqual(moved.rects[0].y, 120, accuracy: 0.001)
+    }
+
+    /// Secure blur is the default because the README already argues the case: an ordinary blur is
+    /// a linear convolution and is routinely inverted, which is exactly the password situation.
+    func testTheDefaultMaskModeIsTheSafeOne() {
+        XCTAssertEqual(StudioMask(rects: [], start: 0, end: 1).mode, .secureBlur)
+    }
+
+    func testAMaskSurvivesARoundTrip() throws {
+        let original = mask(1, 4, mode: .pixellate)
+        let data = try JSONEncoder().encode(original)
+        XCTAssertEqual(try JSONDecoder().decode(StudioMask.self, from: data), original)
+    }
+
+    /// A highlight is the inverse — it dims everything outside itself — so it is one mode of the
+    /// same object rather than a second kind of thing.
+    func testAHighlightIsAMaskMode() {
+        XCTAssertTrue(StudioMask.Mode.allCases.contains(.highlight))
+    }
+
+    // MARK: - Camera
+
+    private func camera() -> CameraSettings { CameraSettings() }
+
+    func testWithNoSegmentsTheCameraIsAPictureInPicture() throws {
+        let state = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 1, segments: [], settings: camera(), canvas: canvas, zoom: 1))
+        XCTAssertLessThan(state.rect.width, canvas.width / 2)
+        XCTAssertEqual(state.opacity, 1, accuracy: 0.001)
+    }
+
+    func testAHiddenSegmentDrawsNoCamera() {
+        let hidden = CameraSegment(start: 0, end: 5, layout: .hidden)
+        XCTAssertNil(CameraLayoutResolver.state(at: 2, segments: [hidden],
+                                                settings: camera(), canvas: canvas, zoom: 1))
+    }
+
+    /// The shape a good demo takes: full-frame for the intro, picture-in-picture for the
+    /// walkthrough. A single "camera position" setting cannot express it, which is why this is a
+    /// track rather than a checkbox.
+    func testAFullFrameSegmentFillsTheCanvas() throws {
+        let intro = CameraSegment(start: 0, end: 5, layout: .fullFrame)
+        let state = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 2.5, segments: [intro], settings: camera(), canvas: canvas, zoom: 1))
+        XCTAssertEqual(state.rect.width, canvas.width, accuracy: 1)
+    }
+
+    /// A full-frame camera should *become* the small one rather than cutting to it.
+    func testTheLayoutChangeIsAnimatedRatherThanCut() throws {
+        let intro = CameraSegment(start: 0, end: 5, layout: .fullFrame)
+        let mid = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 4.9, segments: [intro], settings: camera(), canvas: canvas, zoom: 1))
+        XCTAssertLessThan(mid.rect.width, canvas.width)
+        XCTAssertGreaterThan(mid.rect.width, canvas.width * 0.3)
+    }
+
+    /// **The camera shrinks when the frame zooms in, not the other way round.** A zoom exists to
+    /// show something, and the camera covering it defeats the zoom.
+    func testTheCameraShrinksWhileTheFrameIsZoomed() throws {
+        let atRest = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 1, segments: [], settings: camera(), canvas: canvas, zoom: 1))
+        let zoomed = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 1, segments: [], settings: camera(), canvas: canvas, zoom: 2.5))
+        XCTAssertLessThan(zoomed.rect.width, atRest.rect.width)
+    }
+
+    func testTheCameraCanBeToldToHoldItsSize() throws {
+        var held = camera()
+        held.sizeDuringZoom = .hold
+        let atRest = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 1, segments: [], settings: held, canvas: canvas, zoom: 1))
+        let zoomed = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 1, segments: [], settings: held, canvas: canvas, zoom: 2.5))
+        XCTAssertEqual(zoomed.rect.width, atRest.rect.width, accuracy: 0.5)
+    }
+
+    /// The margin is measured from the canvas edge, not from the padding — otherwise raising the
+    /// project's padding appears to move the camera for no reason.
+    func testTheCameraKeepsAConstantMarginFromTheEdge() throws {
+        let state = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 1, segments: [], settings: camera(), canvas: canvas, zoom: 1))
+        XCTAssertEqual(state.rect.minX, canvas.width * CGFloat(camera().marginFraction),
+                       accuracy: 1)
+    }
+
+    /// Computed from the shorter side, so a non-square camera does not end up with lozenge ends.
+    func testTheCornerRadiusComesFromTheShorterSide() throws {
+        var wide = camera()
+        wide.aspect = 2
+        let state = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 1, segments: [], settings: wide, canvas: canvas, zoom: 1))
+        XCTAssertLessThanOrEqual(state.cornerRadius, min(state.rect.width, state.rect.height) / 2)
+    }
+
+    func testACircleIsFullyRounded() throws {
+        var round = camera()
+        round.shape = .circle
+        let state = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 1, segments: [], settings: round, canvas: canvas, zoom: 1))
+        XCTAssertEqual(state.cornerRadius, min(state.rect.width, state.rect.height) / 2,
+                       accuracy: 0.5)
+    }
+
+    // MARK: - Keystrokes
+
+    private func key(_ t: TimeInterval, _ label: String, combination: Bool = true) -> KeyEvent {
+        KeyEvent(t: t, label: label, isModifierCombination: combination)
+    }
+
+    func testNothingIsShownBeforeAnyKey() {
+        XCTAssertTrue(KeystrokeOverlay.pills(at: 0, keys: [key(5, "⌘C")],
+                                             settings: KeystrokeSettings()).isEmpty)
+    }
+
+    func testAKeyIsShownWhenItIsPressed() {
+        let pills = KeystrokeOverlay.pills(at: 5.1, keys: [key(5, "⌘C")],
+                                           settings: KeystrokeSettings())
+        XCTAssertEqual(pills.first?.label, "⌘C")
+    }
+
+    func testAKeyFadesAwayAfterwards() {
+        let settings = KeystrokeSettings()
+        let pills = KeystrokeOverlay.pills(at: 5 + settings.holdSeconds + 0.5,
+                                           keys: [key(5, "⌘C")], settings: settings)
+        XCTAssertTrue(pills.isEmpty)
+    }
+
+    /// Otherwise holding a key stacks a tower of identical pills, which is noise rather than
+    /// information.
+    func testARepeatedKeyCollapsesIntoACount() {
+        let repeated = (0..<5).map { key(5 + Double($0) * 0.1, "⌘V") }
+        let pills = KeystrokeOverlay.pills(at: 5.5, keys: repeated, settings: KeystrokeSettings())
+        XCTAssertEqual(pills.count, 1)
+        XCTAssertEqual(pills.first?.repeatCount, 5)
+    }
+
+    /// The default shows combinations only — ⌘C, ⌃⇧R — because that is what a demo needs, and
+    /// showing every letter somebody types is a much larger promise about what is being recorded.
+    func testByDefaultOnlyCombinationsAreShown() {
+        let mixed = [key(5, "⌘C"), key(5.1, "A", combination: false)]
+        let pills = KeystrokeOverlay.pills(at: 5.2, keys: mixed, settings: KeystrokeSettings())
+        XCTAssertEqual(pills.map(\.label), ["⌘C"])
+    }
+
+    func testBareKeysCanBeShownWhenAsked() {
+        var settings = KeystrokeSettings()
+        settings.showsBareKeys = true
+        let mixed = [key(5, "⌘C"), key(5.1, "A", combination: false)]
+        XCTAssertEqual(KeystrokeOverlay.pills(at: 5.2, keys: mixed, settings: settings).count, 2)
+    }
+
+    func testTheMostRecentKeyComesLast() {
+        let keys = [key(5, "⌘C"), key(5.4, "⌘V")]
+        let pills = KeystrokeOverlay.pills(at: 5.5, keys: keys, settings: KeystrokeSettings())
+        XCTAssertEqual(pills.last?.label, "⌘V")
+    }
+
+    /// A wall of pills is worse than the last few.
+    func testOnlyTheLastFewAreKept() {
+        let many = (0..<12).map { key(5 + Double($0) * 0.05, "⌘\($0)") }
+        let pills = KeystrokeOverlay.pills(at: 5.6, keys: many, settings: KeystrokeSettings())
+        XCTAssertLessThanOrEqual(pills.count, KeystrokeSettings().maximumPills)
+    }
+}

--- a/Tests/SarvkritTests/StudioLayerTests.swift
+++ b/Tests/SarvkritTests/StudioLayerTests.swift
@@ -99,6 +99,37 @@ final class StudioLayerTests: XCTestCase {
                        "the camera changed size or position under a zoom")
     }
 
+    /// **The camera fades in when it starts, rather than appearing at full strength.**
+    ///
+    /// It begins a couple of seconds after the screen, because that is how long a capture session
+    /// takes to come up. `CameraSettings.fadeSeconds` existed and was offered in the inspector, and
+    /// nothing rendered it — so the bubble arrived in one frame.
+    func testTheCameraFadesInFromWhereItStarted() throws {
+        var settings = camera()
+        settings.fadeSeconds = 0.4
+
+        let arriving = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 2.5, segments: [], settings: settings, canvas: canvas, zoom: 1,
+            cameraStart: 2.4))
+        let settled = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 6, segments: [], settings: settings, canvas: canvas, zoom: 1,
+            cameraStart: 2.4))
+
+        XCTAssertLessThan(arriving.opacity, 0.5, "the camera appeared at full strength")
+        XCTAssertGreaterThan(arriving.opacity, 0, "and it should be on its way in, not absent")
+        XCTAssertEqual(settled.opacity, 1, accuracy: 0.001)
+    }
+
+    /// With no fade asked for, it simply appears — the setting is honoured either way.
+    func testNoFadeMeansItAppearsAtOnce() throws {
+        var settings = camera()
+        settings.fadeSeconds = 0
+        let state = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 2.4, segments: [], settings: settings, canvas: canvas, zoom: 1,
+            cameraStart: 2.4))
+        XCTAssertEqual(state.opacity, 1, accuracy: 0.001)
+    }
+
     func testAHiddenSegmentDrawsNoCamera() {
         let hidden = CameraSegment(start: 0, end: 5, layout: .hidden)
         XCTAssertNil(CameraLayoutResolver.state(at: 2, segments: [hidden],

--- a/Tests/SarvkritTests/StudioLayerTests.swift
+++ b/Tests/SarvkritTests/StudioLayerTests.swift
@@ -120,6 +120,51 @@ final class StudioLayerTests: XCTestCase {
         XCTAssertEqual(settled.opacity, 1, accuracy: 0.001)
     }
 
+    /// **The fade softens an arrival, and there is no arrival if the camera was already running
+    /// when the visible material begins.**
+    ///
+    /// The trimmed lead-in put this exactly on the seam: a project whose first clip starts at the
+    /// capture offset opens at source == `cameraStart`, which is the first frame of the fade — so
+    /// the very frame the user looks at first had no camera on it at all. Trimming had moved the
+    /// hole rather than closed it.
+    func testACameraAlreadyRunningWhenTheClipBeginsIsNotFadedIn() throws {
+        var settings = camera()
+        settings.fadeSeconds = 0.4
+
+        let atTheSeam = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 2.4, segments: [], settings: settings, canvas: canvas, zoom: 1,
+            clipSource: 2.4..<20, cameraStart: 2.4))
+
+        XCTAssertEqual(atTheSeam.opacity, 1, accuracy: 0.001,
+                       "the first frame of a trimmed take opened with no camera on it")
+    }
+
+    /// A clip that starts after the camera did — anything past a split — is the same case.
+    func testALaterClipShowsTheCameraAtFullStrength() throws {
+        var settings = camera()
+        settings.fadeSeconds = 0.4
+
+        let later = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 10, segments: [], settings: settings, canvas: canvas, zoom: 1,
+            clipSource: 10..<20, cameraStart: 2.4))
+
+        XCTAssertEqual(later.opacity, 1, accuracy: 0.001)
+    }
+
+    /// And the fade is still there for the case it was written for: material that begins before
+    /// the camera does, so the bubble genuinely arrives while you are watching.
+    func testTheFadeSurvivesForAnUntrimmedTake() throws {
+        var settings = camera()
+        settings.fadeSeconds = 0.4
+
+        let arriving = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 2.5, segments: [], settings: settings, canvas: canvas, zoom: 1,
+            clipSource: 0..<20, cameraStart: 2.4))
+
+        XCTAssertLessThan(arriving.opacity, 0.5)
+        XCTAssertGreaterThan(arriving.opacity, 0)
+    }
+
     /// With no fade asked for, it simply appears — the setting is honoured either way.
     func testNoFadeMeansItAppearsAtOnce() throws {
         var settings = camera()

--- a/Tests/SarvkritTests/StudioLayerTests.swift
+++ b/Tests/SarvkritTests/StudioLayerTests.swift
@@ -83,6 +83,22 @@ final class StudioLayerTests: XCTestCase {
         XCTAssertEqual(state.opacity, 1, accuracy: 0.001)
     }
 
+    /// **The camera holds still while the frame zooms.** It is drawn in canvas space, so a zoom can
+    /// never move it — but `pipRect` also scaled it, and the default `sizeDuringZoom` of `.shrink`
+    /// meant it quietly got smaller every time the auto-zoom fired. Watching your own face change
+    /// size whenever the picture pushes in reads as a bug, because it is one.
+    ///
+    /// The setting keeps all three options; only the default changed.
+    func testTheCameraDoesNotChangeSizeWhenTheFrameZooms() throws {
+        let atRest = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 1, segments: [], settings: camera(), canvas: canvas, zoom: 1))
+        let zoomed = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 1, segments: [], settings: camera(), canvas: canvas, zoom: 2.5))
+
+        XCTAssertEqual(zoomed.rect, atRest.rect,
+                       "the camera changed size or position under a zoom")
+    }
+
     func testAHiddenSegmentDrawsNoCamera() {
         let hidden = CameraSegment(start: 0, end: 5, layout: .hidden)
         XCTAssertNil(CameraLayoutResolver.state(at: 2, segments: [hidden],
@@ -110,11 +126,17 @@ final class StudioLayerTests: XCTestCase {
 
     /// **The camera shrinks when the frame zooms in, not the other way round.** A zoom exists to
     /// show something, and the camera covering it defeats the zoom.
+    ///
+    /// Asked for explicitly, because this is no longer the default — a camera that changes size
+    /// whenever the auto-zoom fires reads as a glitch. See
+    /// `testTheCameraDoesNotChangeSizeWhenTheFrameZooms`.
     func testTheCameraShrinksWhileTheFrameIsZoomed() throws {
+        var shrinking = camera()
+        shrinking.sizeDuringZoom = .shrink
         let atRest = try XCTUnwrap(CameraLayoutResolver.state(
-            at: 1, segments: [], settings: camera(), canvas: canvas, zoom: 1))
+            at: 1, segments: [], settings: shrinking, canvas: canvas, zoom: 1))
         let zoomed = try XCTUnwrap(CameraLayoutResolver.state(
-            at: 1, segments: [], settings: camera(), canvas: canvas, zoom: 2.5))
+            at: 1, segments: [], settings: shrinking, canvas: canvas, zoom: 2.5))
         XCTAssertLessThan(zoomed.rect.width, atRest.rect.width)
     }
 

--- a/Tests/SarvkritTests/StudioLeadInTests.swift
+++ b/Tests/SarvkritTests/StudioLeadInTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import Sarvkrit
+
+/// The dead seconds at the head of a take.
+///
+/// A capture session needs two to three seconds to come up, so a recording with a camera or a
+/// microphone begins with no camera and no narration. Holding the camera's first frame was one
+/// wrong answer — it showed a frozen face — and leaving a hole is another. **The take starts when
+/// everything is running**, and the material is trimmed rather than cut, so it is one context-menu
+/// item away from coming back.
+final class StudioLeadInTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lead-in-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: directory)
+        super.tearDown()
+    }
+
+    private func bundle(offset: TimeInterval, duration: TimeInterval = 30) throws
+        -> (RecordingBundle, RecordingManifest) {
+        let bundle = try RecordingBundle.create(
+            at: directory.appendingPathComponent("r-\(UUID().uuidString).sarvrec"))
+        var manifest = RecordingManifest(source: .display,
+                                         pixelSize: CGSize(width: 200, height: 120),
+                                         pointPixelScale: 1, fps: 60)
+        manifest.state = .complete
+        manifest.duration = duration
+        manifest.hasCamera = offset > 0
+        manifest.cameraStartOffset = offset
+        try bundle.write(manifest)
+        try bundle.writeEvents(EventLog())
+        return (bundle, manifest)
+    }
+
+    @MainActor
+    func testANewProjectStartsWhereTheCaptureBecameReady() throws {
+        let (bundle, manifest) = try bundle(offset: 3.2)
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        XCTAssertEqual(model.project.timeline.clips.first?.sourceStart ?? -1, 3.2, accuracy: 0.001)
+        XCTAssertEqual(model.project.timeline.clips.first?.sourceEnd ?? -1, 30, accuracy: 0.001)
+    }
+
+    /// A screen-only take has nothing to wait for, so nothing is hidden from it.
+    @MainActor
+    func testAScreenOnlyTakeStartsAtZero() throws {
+        let (bundle, manifest) = try bundle(offset: 0)
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        XCTAssertEqual(model.project.timeline.clips.first?.sourceStart, 0)
+    }
+
+    /// **Only on first creation.** Re-trimming on every open would eat three more seconds each
+    /// time the editor was reopened — the thing item 1 exists to make possible.
+    @MainActor
+    func testReopeningDoesNotTrimAgain() throws {
+        let (bundle, manifest) = try bundle(offset: 3.2)
+        let first = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        first.markSaved()
+
+        let second = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        XCTAssertEqual(second.project.timeline.clips.first?.sourceStart ?? -1, 3.2, accuracy: 0.001)
+    }
+
+    /// Somebody who deliberately un-trims and closes must not find it trimmed again next time.
+    @MainActor
+    func testADeliberateUntrimSurvivesAReopen() throws {
+        let (bundle, manifest) = try bundle(offset: 3.2)
+        let first = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        let clipID = try XCTUnwrap(first.project.timeline.clips.first?.id)
+        first.untrimClip(clipID)
+        first.markSaved()
+
+        let second = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        XCTAssertEqual(second.project.timeline.clips.first?.sourceStart, 0)
+    }
+
+    /// The trim is a window, never a cut: putting it back reaches the real first frame.
+    @MainActor
+    func testTheHiddenMaterialCanBePutBack() throws {
+        let (bundle, manifest) = try bundle(offset: 3.2)
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        let clipID = try XCTUnwrap(model.project.timeline.clips.first?.id)
+        model.untrimClip(clipID)
+        XCTAssertEqual(model.project.timeline.clips.first?.sourceStart, 0)
+    }
+
+    /// An offset longer than the recording would leave an empty timeline — nothing to play, no way
+    /// back except a menu item on a clip that has no width to right-click.
+    @MainActor
+    func testAnAbsurdOffsetIsIgnored() throws {
+        let (bundle, manifest) = try bundle(offset: 9, duration: 9.4)
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        XCTAssertEqual(model.project.timeline.clips.first?.sourceStart, 0)
+    }
+
+    // MARK: - Saying so
+
+    /// The notice is the whole point of trimming rather than silently starting late: it is on
+    /// screen, it says how much, and it undoes itself in one click.
+    @MainActor
+    func testTheNoticeOffersThePutBack() throws {
+        let (bundle, manifest) = try bundle(offset: 3.2)
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        XCTAssertEqual(model.leadInNotice ?? -1, 3.2, accuracy: 0.001)
+
+        model.putBackLeadIn()
+        XCTAssertEqual(model.project.timeline.clips.first?.sourceStart, 0)
+        XCTAssertNil(model.leadInNotice, "the notice outlived the thing it was about")
+    }
+
+    /// Dismissing it is not the same as undoing it — somebody who agrees with the trim wants the
+    /// banner gone and the trim kept.
+    @MainActor
+    func testDismissingTheNoticeKeepsTheTrim() throws {
+        let (bundle, manifest) = try bundle(offset: 3.2)
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        model.dismissLeadInNotice()
+        XCTAssertNil(model.leadInNotice)
+        XCTAssertEqual(model.project.timeline.clips.first?.sourceStart ?? -1, 3.2, accuracy: 0.001)
+    }
+
+    /// A tenth of a second is not worth mentioning to anybody, and the timeline's own badge
+    /// threshold ignores anything under 0.15 s anyway.
+    @MainActor
+    func testATinyOffsetIsNotWorthTrimming() throws {
+        let (bundle, manifest) = try bundle(offset: 0.1)
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        XCTAssertEqual(model.project.timeline.clips.first?.sourceStart, 0)
+    }
+
+    /// The editor has to be able to say what it did, or the trim is another silent decision.
+    @MainActor
+    func testTheModelReportsWhatItHid() throws {
+        let (trimmed, trimmedManifest) = try bundle(offset: 3.2)
+        let model = StudioDocumentModel(bundle: trimmed, manifest: trimmedManifest,
+                                        events: EventLog())
+        XCTAssertEqual(model.trimmedLeadIn ?? -1, 3.2, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testAScreenOnlyTakeHasNothingToReport() throws {
+        let (plain, plainManifest) = try bundle(offset: 0)
+        let model = StudioDocumentModel(bundle: plain, manifest: plainManifest, events: EventLog())
+        XCTAssertNil(model.trimmedLeadIn)
+    }
+}

--- a/Tests/SarvkritTests/StudioLeadInTests.swift
+++ b/Tests/SarvkritTests/StudioLeadInTests.swift
@@ -115,6 +115,22 @@ final class StudioLeadInTests: XCTestCase {
         XCTAssertNil(model.leadInNotice, "the notice outlived the thing it was about")
     }
 
+    /// The banner is about the head of the take and nothing else.
+    ///
+    /// `untrimClip` restores *both* ends, so delegating to it would undo a tail trim the user made
+    /// deliberately — losing the end of their edit to a button that promised to fix the start.
+    @MainActor
+    func testPuttingBackTheLeadInLeavesTheTailAlone() throws {
+        let (bundle, manifest) = try bundle(offset: 3.2)
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        model.edit { $0.timeline.clips[0].sourceEnd = 18 }
+
+        model.putBackLeadIn()
+        XCTAssertEqual(model.project.timeline.clips.first?.sourceStart, 0)
+        XCTAssertEqual(model.project.timeline.clips.first?.sourceEnd, 18,
+                       "the banner threw away the tail the user had trimmed")
+    }
+
     /// Dismissing it is not the same as undoing it — somebody who agrees with the trim wants the
     /// banner gone and the trim kept.
     @MainActor

--- a/Tests/SarvkritTests/StudioMaskGeometryTests.swift
+++ b/Tests/SarvkritTests/StudioMaskGeometryTests.swift
@@ -1,0 +1,161 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// Moving and resizing a blur.
+///
+/// The report: *"When I do secure blur, how do I resize it? move it? it just enters in middle of
+/// the screen and that is it."* It did — `addMaskAtPlayhead` dropped a box at a fixed fraction of
+/// the canvas and nothing could touch it afterwards.
+///
+/// **The geometry is asserted against the renderer's own, not against a second copy of the same
+/// arithmetic.** A hit test that disagrees with what is drawn by even a few points is a mask you
+/// cannot grab, which is indistinguishable from the bug being unfixed.
+final class StudioMaskGeometryTests: XCTestCase {
+
+    private let canvas = CGSize(width: 800, height: 500)
+
+    private func project(masks: [StudioMask] = []) -> StudioProject {
+        var project = StudioProject(canvasSize: canvas,
+                                    timeline: Timeline(clips: [Clip(sourceStart: 0, sourceEnd: 10)]))
+        project.masks = masks
+        return project
+    }
+
+    private func mask(_ rect: CGRect) -> StudioMask {
+        StudioMask(rects: [rect], start: 0, end: 10)
+    }
+
+    // MARK: - Where the boxes are
+
+    func testAVisibleMaskHasABox() {
+        let project = project(masks: [mask(CGRect(x: 100, y: 200, width: 300, height: 100))])
+        let (_, imageRect) = StudioRenderer.layout(for: project)
+        let boxes = StudioRenderer.maskBoxes(project: project, sourceTime: 3, events: EventLog(),
+                                             imageRect: imageRect)
+        XCTAssertEqual(boxes.count, 1)
+        XCTAssertEqual(boxes.first?.id, project.masks.first?.id)
+        XCTAssertEqual(boxes.first?.index, 0)
+    }
+
+    /// Outside its time range it is not on screen, so it must not be grabbable either — clicking
+    /// where a mask *used to be* would select something invisible.
+    func testAMaskOutsideItsRangeHasNoBox() {
+        var mask = mask(CGRect(x: 100, y: 200, width: 300, height: 100))
+        mask.start = 5
+        mask.end = 7
+        let project = project(masks: [mask])
+        let (_, imageRect) = StudioRenderer.layout(for: project)
+        XCTAssertTrue(StudioRenderer.maskBoxes(project: project, sourceTime: 1,
+                                               events: EventLog(), imageRect: imageRect).isEmpty)
+    }
+
+    /// One object, several rectangles — "hide every price in this table" is one mask with nine
+    /// boxes, and each has to be grabbable on its own.
+    func testEveryRectangleOfAMaskIsAddressable() {
+        var many = mask(CGRect(x: 10, y: 10, width: 50, height: 20))
+        many.rects.append(RectBox(CGRect(x: 200, y: 300, width: 50, height: 20)))
+        let project = project(masks: [many])
+        let (_, imageRect) = StudioRenderer.layout(for: project)
+        let boxes = StudioRenderer.maskBoxes(project: project, sourceTime: 1, events: EventLog(),
+                                             imageRect: imageRect)
+        XCTAssertEqual(boxes.count, 2)
+        XCTAssertEqual(boxes.map { $0.index }, [0, 1])
+    }
+
+    // MARK: - Editing the box
+
+    func testAMaskRectangleCanBeMoved() {
+        var project = project(masks: [mask(CGRect(x: 100, y: 100, width: 200, height: 80))])
+        StudioProject.setMaskRect(&project, id: project.masks[0].id, index: 0,
+                                  to: CGRect(x: 400, y: 250, width: 200, height: 80))
+        XCTAssertEqual(project.masks[0].rects[0].rect,
+                       CGRect(x: 400, y: 250, width: 200, height: 80))
+    }
+
+    /// **A hand-moved mask stops following its window.**
+    ///
+    /// A pinned mask is redrawn at wherever its window is now, so a manual drag and the pin would
+    /// fight each other: you would let go and watch the box jump back. Moving it by hand is the
+    /// clearer intent, so the pin goes.
+    func testMovingAPinnedMaskUnpinsIt() {
+        var pinned = mask(CGRect(x: 100, y: 100, width: 200, height: 80))
+        pinned.followsWindowID = 42
+        pinned.windowOriginAtCreation = CGPoint(x: 10, y: 10)
+        var project = project(masks: [pinned])
+
+        StudioProject.setMaskRect(&project, id: project.masks[0].id, index: 0,
+                                  to: CGRect(x: 400, y: 250, width: 200, height: 80))
+
+        XCTAssertNil(project.masks[0].followsWindowID)
+        XCTAssertNil(project.masks[0].windowOriginAtCreation)
+    }
+
+    /// A rectangle that is not there must not silently write into a neighbour, or dragging the
+    /// second box of a mask whose first was deleted would move the wrong region — uncovering
+    /// something. The one outcome a redaction tool must never have.
+    func testAnUnknownRectangleIsIgnored() {
+        var project = project(masks: [mask(CGRect(x: 100, y: 100, width: 200, height: 80))])
+        let before = project
+        StudioProject.setMaskRect(&project, id: project.masks[0].id, index: 7,
+                                  to: CGRect(x: 0, y: 0, width: 10, height: 10))
+        XCTAssertEqual(project, before)
+    }
+
+    func testAnUnknownMaskIsIgnored() {
+        var project = project(masks: [mask(CGRect(x: 100, y: 100, width: 200, height: 80))])
+        let before = project
+        StudioProject.setMaskRect(&project, id: UUID(), index: 0,
+                                  to: CGRect(x: 0, y: 0, width: 10, height: 10))
+        XCTAssertEqual(project, before)
+    }
+
+    // MARK: - Canvas and source are inverses
+
+    /// **The property the drag depends on.** A resize reads a canvas rect out of `maskBoxes`,
+    /// applies the pointer to it, and writes it back through `sourceRect`. If the round trip is
+    /// not the identity the mask creeps every time it is touched.
+    func testCanvasAndSourceRoundTrip() throws {
+        let project = project()
+        let (_, imageRect) = StudioRenderer.layout(for: project)
+        let geometry = StudioRenderer.screenGeometry(project: project, sourceTime: 1,
+                                                     events: EventLog(), imageRect: imageRect)
+        let source = CGRect(x: 123, y: 217, width: 254, height: 96)
+
+        let onCanvas = try XCTUnwrap(StudioRenderer.canvasRect(
+            source, project: project, transform: geometry.transform,
+            imageRect: geometry.screenRect))
+        let back = try XCTUnwrap(StudioRenderer.sourceRect(
+            onCanvas, project: project, transform: geometry.transform,
+            imageRect: geometry.screenRect))
+
+        XCTAssertEqual(back.minX, source.minX, accuracy: 0.01)
+        XCTAssertEqual(back.minY, source.minY, accuracy: 0.01)
+        XCTAssertEqual(back.width, source.width, accuracy: 0.01)
+        XCTAssertEqual(back.height, source.height, accuracy: 0.01)
+    }
+
+    /// And under a zoom, which is where a single forgotten scale factor hides.
+    func testCanvasAndSourceRoundTripUnderAZoom() throws {
+        var zoomed = project()
+        zoomed.zooms = [ZoomSegment(start: 0, end: 10, level: 2,
+                                    anchor: .fixed(CGPoint(x: 0.5, y: 0.5)))]
+        let (_, imageRect) = StudioRenderer.layout(for: zoomed)
+        let geometry = StudioRenderer.screenGeometry(project: zoomed, sourceTime: 5,
+                                                     events: EventLog(), imageRect: imageRect)
+        XCTAssertGreaterThan(geometry.transform.scale, 1, "the zoom did not take")
+
+        let source = CGRect(x: 340, y: 210, width: 120, height: 80)
+        let onCanvas = try XCTUnwrap(StudioRenderer.canvasRect(
+            source, project: zoomed, transform: geometry.transform,
+            imageRect: geometry.screenRect))
+        let back = try XCTUnwrap(StudioRenderer.sourceRect(
+            onCanvas, project: zoomed, transform: geometry.transform,
+            imageRect: geometry.screenRect))
+
+        XCTAssertEqual(back.minX, source.minX, accuracy: 0.01)
+        XCTAssertEqual(back.minY, source.minY, accuracy: 0.01)
+        XCTAssertEqual(back.width, source.width, accuracy: 0.01)
+        XCTAssertEqual(back.height, source.height, accuracy: 0.01)
+    }
+}

--- a/Tests/SarvkritTests/StudioMaskGeometryTests.swift
+++ b/Tests/SarvkritTests/StudioMaskGeometryTests.swift
@@ -110,6 +110,39 @@ final class StudioMaskGeometryTests: XCTestCase {
         XCTAssertEqual(project, before)
     }
 
+    // MARK: - A resize has to remember where it started
+
+    /// **`resize` is a function of the rect the handle was grabbed on, not of the rect as it is
+    /// now.** Feed it its own output and it is still correct while the drag stays on one side of
+    /// the anchor; the moment the pointer crosses the opposite corner the rect flips, and every
+    /// event after that measures from the flipped edge — so the width becomes the distance the
+    /// mouse moved since the last event instead of the distance from the anchor, and the box
+    /// collapses to nothing under a hand that is still dragging outwards.
+    func testResizingFromTheMovingRectCollapsesPastTheOppositeCorner() {
+        let start = CGRect(x: 100, y: 100, width: 200, height: 100)
+        // Three events dragging the top-left corner rightwards, through maxX at 300 and beyond.
+        var moving = start
+        for x in [350.0, 360.0, 370.0] {
+            moving = SelectionHandles.resize(moving, handle: .topLeft,
+                                             to: CGPoint(x: x, y: 100),
+                                             constrainAspect: false, minimumSide: 1)
+        }
+        XCTAssertLessThan(moving.width, 30, "the premise of this test has gone")
+    }
+
+    /// From the anchor, the same three events grow the box as the hand expects.
+    func testResizingFromTheGrabbedRectSurvivesTheFlip() {
+        let start = CGRect(x: 100, y: 100, width: 200, height: 100)
+        var resized = start
+        for x in [350.0, 360.0, 370.0] {
+            resized = SelectionHandles.resize(start, handle: .topLeft,
+                                              to: CGPoint(x: x, y: 100),
+                                              constrainAspect: false, minimumSide: 1)
+        }
+        XCTAssertEqual(resized.minX, 300, accuracy: 0.01)
+        XCTAssertEqual(resized.maxX, 370, accuracy: 0.01)
+    }
+
     // MARK: - Canvas and source are inverses
 
     /// **The property the drag depends on.** A resize reads a canvas rect out of `maskBoxes`,

--- a/Tests/SarvkritTests/StudioPlaybackAudioTests.swift
+++ b/Tests/SarvkritTests/StudioPlaybackAudioTests.swift
@@ -1,0 +1,276 @@
+import AVFoundation
+import XCTest
+@testable import Sarvkrit
+
+/// Hearing the recording while you edit it.
+///
+/// **`player.isMuted = true` was unconditional, and `microphone.m4a` was never opened at all.** So
+/// narration was not merely quiet in the editor — it had never been loaded, and neither had the
+/// system audio riding on the screen's own track. Every clip carries `volume`,
+/// `systemAudioVolume` and `isMuted`, and the inspector offers all three, so the editor shipped
+/// controls for a soundtrack you could only hear by exporting and opening the file.
+///
+/// The same shape as the silent-export bug: the recorder captured it, the model stored settings for
+/// it, and one layer in the middle never asked for it.
+final class StudioPlaybackAudioTests: XCTestCase {
+
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("playback-audio-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: directory)
+        super.tearDown()
+    }
+
+    /// A silent asset is enough: these tests are about whether the transport drives a soundtrack,
+    /// not about what it sounds like. `StudioExportTests` owns the "is there signal" question.
+    private func silentTrack(seconds: Double) throws -> AVAsset {
+        let url = directory.appendingPathComponent("track-\(UUID().uuidString).m4a")
+        let writer = try AVAssetWriter(outputURL: url, fileType: .m4a)
+        let input = AVAssetWriterInput(mediaType: .audio, outputSettings: [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: 44_100,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderBitRateKey: 64_000,
+        ])
+        input.expectsMediaDataInRealTime = false
+        writer.add(input)
+        XCTAssertTrue(writer.startWriting())
+        writer.startSession(atSourceTime: .zero)
+
+        let rate = 44_100.0
+        let frames = 1024
+        var format = AudioStreamBasicDescription(
+            mSampleRate: rate, mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 2, mFramesPerPacket: 1, mBytesPerFrame: 2,
+            mChannelsPerFrame: 1, mBitsPerChannel: 16, mReserved: 0)
+        var description: CMAudioFormatDescription?
+        CMAudioFormatDescriptionCreate(allocator: nil, asbd: &format, layoutSize: 0, layout: nil,
+                                       magicCookieSize: 0, magicCookie: nil, extensions: nil,
+                                       formatDescriptionOut: &description)
+        let audioFormat = try XCTUnwrap(description)
+
+        var index = 0
+        while Double(index * frames) / rate < seconds {
+            var samples = [Int16](repeating: 0, count: frames)
+            var block: CMBlockBuffer?
+            samples.withUnsafeMutableBytes { raw in
+                CMBlockBufferCreateWithMemoryBlock(
+                    allocator: nil, memoryBlock: nil, blockLength: raw.count,
+                    blockAllocator: nil, customBlockSource: nil, offsetToData: 0,
+                    dataLength: raw.count, flags: 0, blockBufferOut: &block)
+                if let block { CMBlockBufferReplaceDataBytes(with: raw.baseAddress!, blockBuffer: block,
+                                                             offsetIntoDestination: 0,
+                                                             dataLength: raw.count) }
+            }
+            guard let block else { break }
+            var buffer: CMSampleBuffer?
+            var timing = CMSampleTimingInfo(
+                duration: CMTime(value: 1, timescale: CMTimeScale(rate)),
+                presentationTimeStamp: CMTime(value: CMTimeValue(index * frames),
+                                              timescale: CMTimeScale(rate)),
+                decodeTimeStamp: .invalid)
+            CMSampleBufferCreateReady(allocator: nil, dataBuffer: block,
+                                      formatDescription: audioFormat,
+                                      sampleCount: frames, sampleTimingEntryCount: 1,
+                                      sampleTimingArray: &timing, sampleSizeEntryCount: 0,
+                                      sampleSizeArray: nil, sampleBufferOut: &buffer)
+            if let buffer, input.isReadyForMoreMediaData { input.append(buffer) }
+            index += 1
+        }
+        input.markAsFinished()
+        let done = expectation(description: "audio written")
+        writer.finishWriting { done.fulfill() }
+        wait(for: [done], timeout: 20)
+        return AVURLAsset(url: url)
+    }
+
+    private func screenOnly(seconds: Double) throws -> URL {
+        let url = directory.appendingPathComponent("screen-\(UUID().uuidString).mov")
+        let size = CGSize(width: 160, height: 120)
+        let writer = try RecordingWriter(url: url, size: size, fps: 60)
+        for index in 0..<Int(seconds * 60) {
+            writer.append(try pixels(at: Double(index) / 60, size: size))
+        }
+        let done = expectation(description: "video written")
+        Task { await writer.finish(); done.fulfill() }
+        wait(for: [done], timeout: 20)
+        return url
+    }
+
+    private func pixels(at t: Double, size: CGSize) throws -> CMSampleBuffer {
+        var pixelBuffer: CVPixelBuffer?
+        CVPixelBufferCreate(nil, Int(size.width), Int(size.height),
+                            kCVPixelFormatType_32BGRA, nil, &pixelBuffer)
+        let buffer = try XCTUnwrap(pixelBuffer)
+        CVPixelBufferLockBaseAddress(buffer, [])
+        if let base = CVPixelBufferGetBaseAddress(buffer) {
+            memset(base, Int32(40 + Int(t * 60) % 180),
+                   CVPixelBufferGetBytesPerRow(buffer) * Int(size.height))
+        }
+        CVPixelBufferUnlockBaseAddress(buffer, [])
+
+        var format: CMFormatDescription?
+        CMVideoFormatDescriptionCreateForImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                     formatDescriptionOut: &format)
+        var timing = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: 60),
+            presentationTimeStamp: CMTime(seconds: t, preferredTimescale: 600),
+            decodeTimeStamp: .invalid)
+        var sample: CMSampleBuffer?
+        CMSampleBufferCreateReadyWithImageBuffer(allocator: nil, imageBuffer: buffer,
+                                                 formatDescription: try XCTUnwrap(format),
+                                                 sampleTiming: &timing, sampleBufferOut: &sample)
+        return try XCTUnwrap(sample)
+    }
+
+    @MainActor
+    private func player(seconds: Double = 2) throws -> StudioPlayer {
+        let made = StudioPlayer(url: try screenOnly(seconds: seconds))
+        made.duration = seconds
+        return made
+    }
+
+    // MARK: - There is something to play
+
+    /// A screen-only take gains no soundtrack, so nothing is loaded and nothing is decoded for a
+    /// recording that has no sound at all.
+    @MainActor
+    func testARecordingWithNoSoundGetsNoSoundtrack() throws {
+        XCTAssertFalse(try player().hasSoundtrack)
+    }
+
+    @MainActor
+    func testASoundtrackCanBeGiven() throws {
+        let player = try player()
+        player.setSoundtrack(asset: try silentTrack(seconds: 2), mix: nil as AVAudioMix?)
+        XCTAssertTrue(player.hasSoundtrack)
+    }
+
+    // MARK: - The transport drives it
+
+    @MainActor
+    func testPlayingStartsTheSoundtrack() throws {
+        let player = try player()
+        player.setSoundtrack(asset: try silentTrack(seconds: 2), mix: nil as AVAudioMix?)
+        player.play()
+        XCTAssertEqual(player.soundtrackRate, 1)
+    }
+
+    @MainActor
+    func testPausingStopsTheSoundtrack() throws {
+        let player = try player()
+        player.setSoundtrack(asset: try silentTrack(seconds: 2), mix: nil as AVAudioMix?)
+        player.play()
+        player.pause()
+        XCTAssertEqual(player.soundtrackRate, 0)
+    }
+
+    /// **Running backwards is silent, not garbled.** `AVPlayer` will not play audio at a negative
+    /// rate, and J on the shuttle is for finding a frame rather than for listening.
+    @MainActor
+    func testShuttlingBackwardsSilencesTheSoundtrack() throws {
+        let player = try player()
+        player.setSoundtrack(asset: try silentTrack(seconds: 2), mix: nil as AVAudioMix?)
+        player.shuttle(-1)
+        XCTAssertEqual(player.soundtrackRate, 0)
+    }
+
+    @MainActor
+    func testShuttlingForwardsPlaysItFaster() throws {
+        let player = try player()
+        player.setSoundtrack(asset: try silentTrack(seconds: 2), mix: nil as AVAudioMix?)
+        player.shuttle(2)
+        XCTAssertEqual(player.soundtrackRate, 2)
+    }
+
+    /// **The soundtrack is in output time, and the picture is in source time.** `StudioAudio`
+    /// builds the composition already cut to the timeline, so a trim that makes the two diverge is
+    /// the case that would put every word in the wrong place if the audio were seeked like the
+    /// video is.
+    @MainActor
+    func testScrubbingMovesTheSoundtrackInOutputTime() throws {
+        let player = try player(seconds: 4)
+        // A trim: output 0 is source 2, so seeking the audio like the video would be 2s out.
+        player.sourceTime = { $0 + 2 }
+        player.setSoundtrack(asset: try silentTrack(seconds: 4), mix: nil as AVAudioMix?)
+
+        player.scrub(to: 1)
+
+        let settled = expectation(description: "the soundtrack followed the playhead")
+        var seen: TimeInterval = -1
+        let poll = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { timer in
+            MainActor.assumeIsolated {
+                seen = player.soundtrackTime ?? -1
+                if abs(seen - 1) < 0.1 { timer.invalidate(); settled.fulfill() }
+            }
+        }
+        RunLoop.main.add(poll, forMode: .common)
+        wait(for: [settled], timeout: 5)
+        poll.invalidate()
+        XCTAssertEqual(seen, 1, accuracy: 0.1,
+                       "the soundtrack was seeked to source time rather than output time")
+    }
+    // MARK: - The model supplies it
+
+    /// **The seam, not a re-implementation.** Asserting that the player ends up with a soundtrack
+    /// after the model prepares one is the whole property: the editor is silent exactly when this
+    /// handover does not happen, and it never happened at all.
+    @MainActor
+    func testTheModelGivesThePlayerTheProjectsSoundtrack() async throws {
+        let bundle = try RecordingBundle.create(
+            at: directory.appendingPathComponent("with-sound.sarvrec"))
+        try FileManager.default.copyItem(at: try screenOnly(seconds: 2), to: bundle.screenURL)
+        try await writeSilence(to: bundle.microphoneURL, seconds: 2)
+
+        var manifest = RecordingManifest(source: .display,
+                                         pixelSize: CGSize(width: 160, height: 120),
+                                         pointPixelScale: 1, fps: 60)
+        manifest.state = .complete
+        manifest.duration = 2
+        manifest.hasMicrophone = true
+        try bundle.write(manifest)
+        try bundle.writeEvents(EventLog())
+
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        XCTAssertFalse(model.player.hasSoundtrack, "nothing should be loaded before it is asked for")
+
+        await model.prepareSoundtrack()
+        XCTAssertTrue(model.player.hasSoundtrack,
+                      "the editor had no soundtrack, so playback is silent")
+    }
+
+    /// A screen-only take stays silent and pays for nothing — `StudioAudio.composition` returns nil
+    /// and that is an ordinary answer, not a failure.
+    @MainActor
+    func testAScreenOnlyProjectPreparesNoSoundtrack() async throws {
+        let bundle = try RecordingBundle.create(
+            at: directory.appendingPathComponent("silent.sarvrec"))
+        try FileManager.default.copyItem(at: try screenOnly(seconds: 2), to: bundle.screenURL)
+
+        var manifest = RecordingManifest(source: .display,
+                                         pixelSize: CGSize(width: 160, height: 120),
+                                         pointPixelScale: 1, fps: 60)
+        manifest.state = .complete
+        manifest.duration = 2
+        try bundle.write(manifest)
+        try bundle.writeEvents(EventLog())
+
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        await model.prepareSoundtrack()
+        XCTAssertFalse(model.player.hasSoundtrack)
+    }
+
+    private func writeSilence(to url: URL, seconds: Double) async throws {
+        let source = try silentTrack(seconds: seconds)
+        guard let asset = source as? AVURLAsset else { return }
+        try FileManager.default.copyItem(at: asset.url, to: url)
+    }
+}

--- a/Tests/SarvkritTests/StudioProjectTests.swift
+++ b/Tests/SarvkritTests/StudioProjectTests.swift
@@ -1,0 +1,123 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// The project document.
+///
+/// **A project written by a newer build must open, not error.** That contract is already in force
+/// for `AnnotationDocument` and `CaptureBackground.Fill`, and it matters more here: a recording is
+/// hundreds of megabytes of somebody's work, and refusing to open it because a later version added
+/// a field would be the worst possible way to fail.
+final class StudioProjectTests: XCTestCase {
+
+    private func project() -> StudioProject {
+        var project = StudioProject(
+            canvasSize: CGSize(width: 2560, height: 1440),
+            timeline: Timeline(clips: [Clip(sourceStart: 0, sourceEnd: 12)]))
+        project.zooms = [ZoomSegment(start: 2, end: 5, level: 2.2, anchor: .followCursor)]
+        project.cursor.size = 2.1
+        project.cursor.smoothing = .heavy
+        project.speakerNotes = "remember to mention the shortcut"
+        return project
+    }
+
+    private func roundTrip(_ project: StudioProject) throws -> StudioProject {
+        let data = try JSONEncoder().encode(project)
+        return try JSONDecoder().decode(StudioProject.self, from: data)
+    }
+
+    /// One instance, compared with itself after a trip through JSON. Comparing two calls to
+    /// `project()` would compare two different objects: every clip and segment mints a fresh UUID,
+    /// so that assertion could only ever fail.
+    func testAProjectSurvivesARoundTrip() throws {
+        let original = project()
+        XCTAssertEqual(try roundTrip(original), original)
+    }
+
+    func testTheZoomAnchorSurvivesARoundTrip() throws {
+        var original = project()
+        original.zooms = [ZoomSegment(start: 1, end: 2, level: 2,
+                                      anchor: .fixed(CGPoint(x: 0.25, y: 0.75)))]
+        guard case .fixed(let point) = try roundTrip(original).zooms.first?.anchor else {
+            return XCTFail("the anchor changed kind")
+        }
+        XCTAssertEqual(point.x, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(point.y, 0.75, accuracy: 0.0001)
+    }
+
+    /// A settings file written before a field existed must load cleanly rather than resetting
+    /// everything — the rule `ClipboardSettings` already follows.
+    func testAProjectMissingMostKeysDecodesToDefaults() throws {
+        let json = """
+        {"canvasSize":{"width":1920,"height":1080},"timeline":{"clips":[]}}
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(StudioProject.self, from: json)
+        XCTAssertEqual(decoded.canvasSize.width, 1920)
+        XCTAssertEqual(decoded.cursor.smoothing, CursorSettings().smoothing)
+        XCTAssertEqual(decoded.aspect, AspectRatio.original)
+        XCTAssertTrue(decoded.zooms.isEmpty)
+    }
+
+    /// **The forward-compatibility contract.** A field this build has never heard of is held
+    /// verbatim and written back untouched, so opening a project in an older build and saving it
+    /// does not quietly delete work done in a newer one.
+    func testAnUnknownFieldIsCarriedThroughUnchanged() throws {
+        let json = """
+        {"canvasSize":{"width":1920,"height":1080},"timeline":{"clips":[]},\
+        "somethingFromTheFuture":{"enabled":true,"count":3}}
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(StudioProject.self, from: json)
+        let reEncoded = try JSONEncoder().encode(decoded)
+        let asDictionary = try JSONSerialization.jsonObject(with: reEncoded) as? [String: Any]
+        XCTAssertNotNil(asDictionary?["somethingFromTheFuture"],
+                        "a field from a newer build was dropped on save")
+    }
+
+    func testAnUnknownFieldSurvivesTwoRoundTrips() throws {
+        let json = """
+        {"canvasSize":{"width":100,"height":100},"timeline":{"clips":[]},"future":[1,2,3]}
+        """.data(using: .utf8)!
+        let once = try JSONDecoder().decode(StudioProject.self, from: json)
+        let twice = try roundTrip(once)
+        XCTAssertEqual(once.unrecognised, twice.unrecognised)
+        XCTAssertFalse(twice.unrecognised.isEmpty)
+    }
+
+    func testANewerFormatVersionStillOpens() throws {
+        let json = """
+        {"formatVersion":99,"canvasSize":{"width":100,"height":100},"timeline":{"clips":[]}}
+        """.data(using: .utf8)!
+        XCTAssertEqual(try JSONDecoder().decode(StudioProject.self, from: json).formatVersion, 99)
+    }
+
+    /// Nothing this app writes should ever fail to reopen.
+    func testAFreshProjectIsAlwaysReadable() throws {
+        let fresh = StudioProject(canvasSize: CGSize(width: 800, height: 600),
+                                  timeline: Timeline(clips: []))
+        XCTAssertNoThrow(try roundTrip(fresh))
+    }
+
+    // MARK: - Derived
+
+    func testTheProjectReportsItsOwnDuration() {
+        XCTAssertEqual(project().duration, 12, accuracy: 0.0001)
+    }
+
+    /// A zoom whose moment was cut out has nowhere to be drawn, and asking the renderer to work
+    /// that out per frame would be the same question asked sixty times a second.
+    func testZoomsWhoseMomentWasCutAreDroppedFromTheEdit() {
+        var edited = project()
+        edited.timeline = Timeline(clips: [Clip(sourceStart: 8, sourceEnd: 12)])
+        XCTAssertTrue(edited.visibleZooms.isEmpty)
+    }
+
+    func testZoomsInsideTheEditAreKept() {
+        XCTAssertEqual(project().visibleZooms.count, 1)
+    }
+
+    func testADisabledZoomIsNotVisible() {
+        var edited = project()
+        edited.zooms[0].isDisabled = true
+        XCTAssertTrue(edited.visibleZooms.isEmpty)
+    }
+}

--- a/Tests/SarvkritTests/StudioProjectTests.swift
+++ b/Tests/SarvkritTests/StudioProjectTests.swift
@@ -120,4 +120,36 @@ final class StudioProjectTests: XCTestCase {
         edited.zooms[0].isDisabled = true
         XCTAssertTrue(edited.visibleZooms.isEmpty)
     }
+
+    /// **The decoder is hand-written and the encoder is not, so they drift.** A new field reaches
+    /// disk for free and is silently dropped on the way back — which already cost this feature the
+    /// camera offset once, and would quietly discard every hand-placed click here.
+    func testClickEditsSurviveARoundTrip() throws {
+        var project = StudioProject(canvasSize: CGSize(width: 100, height: 100),
+                                    timeline: Timeline(clips: [Clip(sourceStart: 0, sourceEnd: 5)]))
+        project.clickEdits.added = [ManualClick(t: 2, point: CGPoint(x: 7, y: 9))]
+        project.clickEdits.suppressed = [4.25]
+
+        let data = try JSONEncoder().encode(project)
+        let decoded = try JSONDecoder().decode(StudioProject.self, from: data)
+
+        XCTAssertEqual(decoded.clickEdits.added.count, 1)
+        XCTAssertEqual(decoded.clickEdits.added.first?.point, CGPoint(x: 7, y: 9))
+        XCTAssertEqual(decoded.clickEdits.suppressed, [4.25])
+    }
+
+    func testPointerHighlightsSurviveARoundTrip() throws {
+        var project = StudioProject(canvasSize: CGSize(width: 100, height: 100),
+                                    timeline: Timeline(clips: [Clip(sourceStart: 0, sourceEnd: 5)]))
+        project.pointerHighlights = [PointerHighlight(start: 1, end: 2.5, radiusFraction: 0.2,
+                                                      dimming: 0.7)]
+
+        let data = try JSONEncoder().encode(project)
+        let decoded = try JSONDecoder().decode(StudioProject.self, from: data)
+
+        XCTAssertEqual(decoded.pointerHighlights.count, 1)
+        XCTAssertEqual(decoded.pointerHighlights.first?.radiusFraction, 0.2)
+        XCTAssertEqual(decoded.pointerHighlights.first?.dimming, 0.7)
+        XCTAssertEqual(decoded.pointerHighlights.first?.end, 2.5)
+    }
 }

--- a/Tests/SarvkritTests/StudioProjectTests.swift
+++ b/Tests/SarvkritTests/StudioProjectTests.swift
@@ -152,4 +152,35 @@ final class StudioProjectTests: XCTestCase {
         XCTAssertEqual(decoded.pointerHighlights.first?.dimming, 0.7)
         XCTAssertEqual(decoded.pointerHighlights.first?.end, 2.5)
     }
+
+    /// ⌘⌫ was routed to `break`. "Undo every edit" has to genuinely return the project to how it
+    /// opened, and has to be undoable itself — losing an hour's work to a mis-typed shortcut with
+    /// no way back would be the worst thing in this editor.
+    @MainActor
+    func testResettingEditsReturnsTheProjectAndStaysUndoable() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("reset-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let bundle = try RecordingBundle.create(at: directory.appendingPathComponent("r.sarvrec"))
+        var manifest = RecordingManifest(source: .display, pixelSize: CGSize(width: 100, height: 80),
+                                         pointPixelScale: 1, fps: 60)
+        manifest.state = .complete
+        manifest.duration = 10
+        try bundle.write(manifest)
+        try bundle.writeEvents(EventLog())
+
+        let model = StudioDocumentModel(bundle: bundle, manifest: manifest, events: EventLog())
+        let opened = model.project
+
+        model.addPointerHighlightAtPlayhead()
+        XCTAssertNotEqual(model.project, opened)
+
+        model.resetEdits()
+        XCTAssertEqual(model.project, opened, "reset did not return the project")
+
+        model.undo()
+        XCTAssertNotEqual(model.project, opened, "reset was not undoable")
+    }
 }

--- a/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
+++ b/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
@@ -272,4 +272,52 @@ final class StudioRenderSnapshotTests: XCTestCase {
         XCTAssertEqual(one.g, other.g, accuracy: 0.002, "green leaked structure")
         XCTAssertEqual(one.b, other.b, accuracy: 0.002, "blue leaked structure")
     }
+
+    // MARK: - Editing by hand
+
+    /// **The seam, not the layer.** The camera test above hands `drawCamera` an image directly and
+    /// therefore proved nothing about whether anything supplied one — which is exactly how the
+    /// webcam went missing from every recording. These two go the other way: they change only the
+    /// *project* and require the finished frame to differ, so the wiring is what is under test.
+    func testAPointerHighlightDimsTheSurroundings() throws {
+        var spotlit = project()
+        spotlit.pointerHighlights = [PointerHighlight(start: 0, end: 10)]
+
+        let plain = try render(project(), at: 3)
+        let dimmed = try render(spotlit, at: 3)
+
+        XCTAssertNotEqual(png(plain), png(dimmed), "no spotlight was drawn")
+        try write(dimmed, named: "studio-pointer-highlight")
+    }
+
+    /// And it must genuinely end, rather than dimming the rest of the video.
+    func testAPointerHighlightLeavesLaterFramesAlone() throws {
+        var spotlit = project()
+        spotlit.pointerHighlights = [PointerHighlight(start: 0, end: 2)]
+
+        XCTAssertEqual(png(try render(project(), at: 6)), png(try render(spotlit, at: 6)))
+    }
+
+    /// A click placed by hand draws the same effect a recorded one does.
+    func testAHandPlacedClickIsDrawn() throws {
+        var edited = project()
+        edited.clickEdits.added = [ManualClick(t: 6, point: CGPoint(x: 400, y: 250))]
+
+        let plain = try render(project(), at: 6.05)
+        let clicked = try render(edited, at: 6.05)
+
+        XCTAssertNotEqual(png(plain), png(clicked), "the hand-placed click was not drawn")
+    }
+
+    /// And suppressing a recorded one takes it out of the picture. `events()` records a click at 2.
+    func testASuppressedClickIsNotDrawn() throws {
+        var edited = project()
+        edited.clickEdits.suppressed = [2]
+
+        let withClick = try render(project(), at: 2.05)
+        let without = try render(edited, at: 2.05)
+
+        XCTAssertNotEqual(png(withClick), png(without),
+                          "the suppressed click is still in the picture")
+    }
 }

--- a/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
+++ b/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
@@ -1,0 +1,165 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// The compositor, asserted differentially.
+///
+/// **Why this is a test and not a scratch harness.** Four real bugs in the screenshot toolbar were
+/// invisible to every unit test and obvious in a picture, which is what `EditorChromeSnapshotTests`
+/// exists to catch. The same is true here and more so: a cursor drawn a few pixels off, a zoom
+/// applied to the wrong axis, or a caption clipped by its own box are all things assertions do not
+/// see. So each layer is switched on and off and the frames are required to differ — the cheapest
+/// possible guard against a layer silently doing nothing — and `make preview` writes the PNGs so a
+/// person can look.
+final class StudioRenderSnapshotTests: XCTestCase {
+
+    private let canvas = CGSize(width: 800, height: 500)
+
+    /// A recognisable screen: quarters in four colours, so a zoom or a flip is visible at a glance.
+    private func screen() throws -> CGImage {
+        let context = try XCTUnwrap(CGContext(
+            data: nil, width: 800, height: 500, bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+        let colours = [CGColor(red: 0.9, green: 0.3, blue: 0.3, alpha: 1),
+                       CGColor(red: 0.3, green: 0.7, blue: 0.4, alpha: 1),
+                       CGColor(red: 0.3, green: 0.5, blue: 0.9, alpha: 1),
+                       CGColor(red: 0.95, green: 0.8, blue: 0.3, alpha: 1)]
+        for (index, colour) in colours.enumerated() {
+            context.setFillColor(colour)
+            context.fill(CGRect(x: index % 2 == 0 ? 0 : 400, y: index < 2 ? 0 : 250,
+                                width: 400, height: 250))
+        }
+        return try XCTUnwrap(context.makeImage())
+    }
+
+    private func project() -> StudioProject {
+        StudioProject(canvasSize: canvas,
+                      timeline: Timeline(clips: [Clip(sourceStart: 0, sourceEnd: 10)]))
+    }
+
+    private func events() -> EventLog {
+        let cursor = (0..<200).map {
+            CursorSample(t: Double($0) * 0.05,
+                         point: CGPoint(x: 100 + Double($0) * 3, y: 250), kind: .arrow)
+        }
+        let clicks = [ClickEvent(t: 2, point: CGPoint(x: 400, y: 250),
+                                 button: .left, isDown: true)]
+        return EventLog(cursor: cursor, clicks: clicks)
+    }
+
+    private func render(_ project: StudioProject, at t: TimeInterval,
+                        events log: EventLog? = nil) throws -> CGImage {
+        try XCTUnwrap(StudioRenderer.frame(of: project, atSource: t,
+                                           events: log ?? events(),
+                                           sources: FrameSources(screen: try screen())))
+    }
+
+    private func png(_ image: CGImage) -> Data? { CaptureWriter.pngData(from: image) }
+
+    private func write(_ image: CGImage, named name: String) throws {
+        guard let directory = PreviewDirectory.path else { return }
+        try XCTUnwrap(png(image))
+            .write(to: URL(fileURLWithPath: directory).appendingPathComponent("\(name).png"))
+    }
+
+    // MARK: - It draws at all
+
+    func testAFrameIsProduced() throws {
+        let frame = try render(project(), at: 1)
+        XCTAssertGreaterThan(frame.width, 0)
+        XCTAssertGreaterThan(frame.height, 0)
+        try write(frame, named: "studio-plain")
+    }
+
+    /// The canvas is bigger than the recording, because padding grows it. If these were equal the
+    /// background would be invisible and the whole surround would be doing nothing.
+    func testTheCanvasIsLargerThanTheRecording() throws {
+        let frame = try render(project(), at: 1)
+        XCTAssertGreaterThan(frame.width, Int(canvas.width))
+    }
+
+    // MARK: - Layers
+
+    func testAZoomChangesTheFrame() throws {
+        var zoomed = project()
+        zoomed.zooms = [ZoomSegment(start: 0, end: 8, level: 2.4,
+                                    anchor: .fixed(CGPoint(x: 0.3, y: 0.3)))]
+        let plain = try render(project(), at: 3)
+        let close = try render(zoomed, at: 3)
+        XCTAssertNotEqual(png(plain), png(close), "the zoom did nothing")
+        try write(close, named: "studio-zoomed")
+    }
+
+    func testHidingTheCursorChangesTheFrame() throws {
+        var hidden = project()
+        hidden.cursor.isHidden = true
+        XCTAssertNotEqual(png(try render(project(), at: 3)), png(try render(hidden, at: 3)),
+                          "the cursor was not being drawn")
+    }
+
+    func testTheClickEffectChangesTheFrame() throws {
+        var none = project()
+        none.cursor.clickEffect = .none
+        // Just after the click, while the ripple is at its most visible.
+        XCTAssertNotEqual(png(try render(project(), at: 2.05)),
+                          png(try render(none, at: 2.05)),
+                          "the click effect did nothing")
+        try write(try render(project(), at: 2.05), named: "studio-click")
+    }
+
+    func testChangingTheBackgroundChangesTheFrame() throws {
+        var other = project()
+        other.background.fill = .builtIn(id: "ember")
+        XCTAssertNotEqual(png(try render(project(), at: 1)), png(try render(other, at: 1)))
+    }
+
+    func testRemovingThePaddingChangesTheFrame() throws {
+        var tight = project()
+        tight.background.padding = 0
+        XCTAssertNotEqual(png(try render(project(), at: 1)), png(try render(tight, at: 1)))
+    }
+
+    func testACaptionChangesTheFrame() throws {
+        var captioned = project()
+        captioned.captions = [Caption(words: [
+            TranscriptWord(text: "you", start: 0.5, duration: 0.3),
+            TranscriptWord(text: "press", start: 0.8, duration: 0.3),
+            TranscriptWord(text: "command", start: 1.1, duration: 0.5),
+        ])]
+        let with = try render(captioned, at: 1.0)
+        XCTAssertNotEqual(png(try render(project(), at: 1.0)), png(with), "no caption was drawn")
+        try write(with, named: "studio-caption")
+    }
+
+    /// Karaoke highlighting: the same line at two moments must look different, because a different
+    /// number of words has been spoken.
+    func testACaptionHighlightsAsItIsSpoken() throws {
+        var captioned = project()
+        captioned.captions = [Caption(words: [
+            TranscriptWord(text: "you", start: 0.5, duration: 0.3),
+            TranscriptWord(text: "press", start: 1.5, duration: 0.3),
+            TranscriptWord(text: "command", start: 2.5, duration: 0.5),
+        ])]
+        XCTAssertNotEqual(png(try render(captioned, at: 0.6)),
+                          png(try render(captioned, at: 2.6)),
+                          "the caption did not highlight word by word")
+    }
+
+    // MARK: - Consistency
+
+    /// Preview and export call the same function, so the same project at the same time must give
+    /// the same bytes. This is the test that keeps that promise honest.
+    func testTheSameMomentRendersIdentically() throws {
+        XCTAssertEqual(png(try render(project(), at: 4)), png(try render(project(), at: 4)))
+    }
+
+    /// Past the end of the recording there is no frame to show. The surround should still be drawn
+    /// rather than the whole thing coming back black or nil.
+    func testAMissingScreenFrameStillDrawsTheSurround() throws {
+        let frame = try XCTUnwrap(StudioRenderer.frame(of: project(), atSource: 99,
+                                                       events: events(),
+                                                       sources: FrameSources(screen: nil)))
+        XCTAssertGreaterThan(frame.width, 0)
+    }
+}

--- a/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
+++ b/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
@@ -281,6 +281,16 @@ final class StudioRenderSnapshotTests: XCTestCase {
 
         let bubble = try XCTUnwrap(CameraLayoutResolver.state(
             at: 3, segments: [], settings: blurred.camera, canvas: canvas, zoom: 1))
+
+        // First, that this region is actually the camera. A crop aimed at the wrong corner
+        // compares two patches of background and reports success whatever the blur did.
+        let cameraless = try XCTUnwrap(StudioRenderer.frame(
+            of: project(), atSource: 3, events: events(),
+            sources: FrameSources(screen: try screen())))
+        XCTAssertNotEqual(png(try crop(plain, canvasRect: bubble.rect)),
+                          png(try crop(cameraless, canvasRect: bubble.rect)),
+                          "the crop is not looking at the camera")
+
         XCTAssertEqual(png(try crop(plain, canvasRect: bubble.rect)),
                        png(try crop(withMask, canvasRect: bubble.rect)),
                        "the blur changed the camera bubble")
@@ -347,17 +357,17 @@ final class StudioRenderSnapshotTests: XCTestCase {
 
     /// One region of a rendered frame, addressed in canvas points.
     ///
-    /// `cropping(to:)` measures from the top-left and the canvas from the bottom-left, so the flip
-    /// is here rather than at each call — getting it wrong would compare two bands of background
-    /// and pass no matter what happened to the camera.
+    /// **No flip.** `StudioRenderer.frame` sets up document space — top-left origin, as its own
+    /// comment says — and `cropping(to:)` measures from the top-left too, so the two already
+    /// agree. Flipping here anyway compared two bands of background and passed no matter what
+    /// happened to the camera, which is why the caller checks that this crop can see the camera
+    /// at all before trusting it to notice a change.
     private func crop(_ image: CGImage, canvasRect rect: CGRect) throws -> CGImage {
         let scaleX = CGFloat(image.width) / canvas.width
         let scaleY = CGFloat(image.height) / canvas.height
-        let flipped = CGRect(x: rect.minX * scaleX,
-                             y: (canvas.height - rect.maxY) * scaleY,
-                             width: rect.width * scaleX,
-                             height: rect.height * scaleY)
-        return try XCTUnwrap(image.cropping(to: flipped.integral))
+        let scaled = CGRect(x: rect.minX * scaleX, y: rect.minY * scaleY,
+                            width: rect.width * scaleX, height: rect.height * scaleY)
+        return try XCTUnwrap(image.cropping(to: scaled.integral))
     }
 
     /// **The security property, measured where it lives.**

--- a/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
+++ b/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
@@ -252,6 +252,114 @@ final class StudioRenderSnapshotTests: XCTestCase {
         XCTAssertEqual(png(try render(hidden, at: 3)), png(frame))
     }
 
+    /// **"When I do secure blur ... it also removes the webcam video."**
+    ///
+    /// Reading the code did not explain this: every `saveGState` in the mask path is balanced in
+    /// its own function, `drawCamera` runs after the screen clip is restored, and the renderer's
+    /// cache holds only a background image the camera never touches. So it is measured instead —
+    /// the camera bubble is cropped out of both frames and required to be pixel-identical with and
+    /// without a blur elsewhere on the screen. Reasoning about a symptom is not the same as
+    /// pinning it.
+    func testABlurLeavesTheCameraExactlyWhereItWas() throws {
+        let cameraImage = try cameraFrame()
+
+        var blurred = project()
+        // Deliberately far from the bubble, which defaults to the bottom-leading corner.
+        blurred.masks = [StudioMask(mode: .secureBlur,
+                                    rects: [CGRect(x: 500, y: 300, width: 250, height: 150)],
+                                    start: 0, end: 10)]
+
+        let plain = try XCTUnwrap(StudioRenderer.frame(
+            of: project(), atSource: 3, events: events(),
+            sources: FrameSources(screen: try screen(), camera: cameraImage)))
+        let withMask = try XCTUnwrap(StudioRenderer.frame(
+            of: blurred, atSource: 3, events: events(),
+            sources: FrameSources(screen: try screen(), camera: cameraImage)))
+
+        // The blur has to have done something, or this passes by drawing nothing at all.
+        XCTAssertNotEqual(png(plain), png(withMask), "no blur was drawn")
+
+        let bubble = try XCTUnwrap(CameraLayoutResolver.state(
+            at: 3, segments: [], settings: blurred.camera, canvas: canvas, zoom: 1))
+        XCTAssertEqual(png(try crop(plain, canvasRect: bubble.rect)),
+                       png(try crop(withMask, canvasRect: bubble.rect)),
+                       "the blur changed the camera bubble")
+        try write(withMask, named: "studio-blur-and-camera")
+    }
+
+    /// And the frame the editor opens on. A trimmed take starts at the capture offset, which is
+    /// where the camera's own fade began — so this is the frame that was blank.
+    func testTheFirstFrameOfATrimmedTakeHasACamera() throws {
+        let cameraImage = try cameraFrame()
+        var trimmed = project()
+        trimmed.timeline = Timeline(clips: [Clip(sourceStart: 3.2, sourceEnd: 10)])
+
+        let frame = try XCTUnwrap(StudioRenderer.frame(
+            of: trimmed, atSource: 3.2, events: events(),
+            sources: FrameSources(screen: try screen(), camera: cameraImage),
+            clipSource: 3.2..<10, cameraStart: 3.2))
+        let withoutCamera = try XCTUnwrap(StudioRenderer.frame(
+            of: trimmed, atSource: 3.2, events: events(),
+            sources: FrameSources(screen: try screen()),
+            clipSource: 3.2..<10, cameraStart: 3.2))
+
+        XCTAssertNotEqual(png(frame), png(withoutCamera),
+                          "the first frame the editor opens on had no camera on it")
+    }
+
+    /// **A camera that is not there yet must draw nothing at all — not even its shadow.**
+    ///
+    /// `drawCamera` fills the bubble's path in black to cast the shadow, and did so *before*
+    /// applying the camera's own opacity. So through the whole fade-in, and at opacity zero
+    /// outright, there was an opaque black squircle sitting where the webcam belonged. That is a
+    /// far better match for "it removes the webcam video" than an absent camera, and it is why the
+    /// trimmed-first-frame test above passed even with the fade bug still in: the frames differed
+    /// by a black blob rather than by a camera.
+    func testACameraAtZeroOpacityDrawsNothing() throws {
+        var fading = project()
+        fading.camera.fadeSeconds = 0.4
+
+        // Untrimmed material, sampled at the instant the camera track begins: the first frame of
+        // its own fade, so opacity is exactly zero.
+        let withCamera = try XCTUnwrap(StudioRenderer.frame(
+            of: fading, atSource: 2.4, events: events(),
+            sources: FrameSources(screen: try screen(), camera: try cameraFrame()),
+            clipSource: 0..<10, cameraStart: 2.4))
+        let withoutCamera = try XCTUnwrap(StudioRenderer.frame(
+            of: fading, atSource: 2.4, events: events(),
+            sources: FrameSources(screen: try screen()),
+            clipSource: 0..<10, cameraStart: 2.4))
+
+        XCTAssertEqual(png(withCamera), png(withoutCamera),
+                       "something was drawn where the camera was not yet")
+    }
+
+    /// A flat teal square, big enough to fill any bubble it is asked to.
+    private func cameraFrame() throws -> CGImage {
+        let camera = try XCTUnwrap(CGContext(
+            data: nil, width: 400, height: 400, bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+        camera.setFillColor(CGColor(red: 0.2, green: 0.6, blue: 0.75, alpha: 1))
+        camera.fill(CGRect(x: 0, y: 0, width: 400, height: 400))
+        return try XCTUnwrap(camera.makeImage())
+    }
+
+    /// One region of a rendered frame, addressed in canvas points.
+    ///
+    /// `cropping(to:)` measures from the top-left and the canvas from the bottom-left, so the flip
+    /// is here rather than at each call — getting it wrong would compare two bands of background
+    /// and pass no matter what happened to the camera.
+    private func crop(_ image: CGImage, canvasRect rect: CGRect) throws -> CGImage {
+        let scaleX = CGFloat(image.width) / canvas.width
+        let scaleY = CGFloat(image.height) / canvas.height
+        let flipped = CGRect(x: rect.minX * scaleX,
+                             y: (canvas.height - rect.maxY) * scaleY,
+                             width: rect.width * scaleX,
+                             height: rect.height * scaleY)
+        return try XCTUnwrap(image.cropping(to: flipped.integral))
+    }
+
     /// **The security property, measured where it lives.**
     ///
     /// `secureBlur` deliberately keeps the region's mean colour — that is what makes a redaction

--- a/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
+++ b/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
@@ -320,4 +320,33 @@ final class StudioRenderSnapshotTests: XCTestCase {
         XCTAssertNotEqual(png(withClick), png(without),
                           "the suppressed click is still in the picture")
     }
+
+    /// Hand-placed text reaches the finished frame — the seam, not the layer.
+    func testATextOverlayIsDrawn() throws {
+        var titled = project()
+        titled.textOverlays = [TextOverlay(start: 0, end: 10, text: "Look at this")]
+
+        let plain = try render(project(), at: 3)
+        let withText = try render(titled, at: 3)
+
+        XCTAssertNotEqual(png(plain), png(withText), "the text was not drawn")
+        try write(withText, named: "studio-text-overlay")
+    }
+
+    /// And it is gone once its range ends, rather than staying for the rest of the video.
+    func testATextOverlayLeavesLaterFramesAlone() throws {
+        var titled = project()
+        titled.textOverlays = [TextOverlay(start: 0, end: 2, text: "Intro")]
+
+        XCTAssertEqual(png(try render(project(), at: 6)), png(try render(titled, at: 6)))
+    }
+
+    /// Empty text draws nothing at all, so a freshly added line does not put a bare box on screen
+    /// before anything has been typed into it.
+    func testEmptyTextDrawsNothing() throws {
+        var titled = project()
+        titled.textOverlays = [TextOverlay(start: 0, end: 10, text: "")]
+
+        XCTAssertEqual(png(try render(project(), at: 3)), png(try render(titled, at: 3)))
+    }
 }

--- a/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
+++ b/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
@@ -349,4 +349,47 @@ final class StudioRenderSnapshotTests: XCTestCase {
 
         XCTAssertEqual(png(try render(project(), at: 3)), png(try render(titled, at: 3)))
     }
+
+    // MARK: - Fades
+
+    /// **The wash reaches the frame, and only where it should.** A fade that darkened the middle
+    /// of the video, or one that never reached the picture at all, would both pass a test that
+    /// only checked the arithmetic.
+    func testAFadeDarkensTheFirstFrameAndNotTheMiddle() throws {
+        var faded = project()
+        faded.fadeIn = 1
+
+        let opening = try XCTUnwrap(StudioRenderer.frame(
+            of: faded, atSource: 0, events: events(),
+            sources: FrameSources(screen: try screen()), outputTime: 0))
+        let plainOpening = try XCTUnwrap(StudioRenderer.frame(
+            of: project(), atSource: 0, events: events(),
+            sources: FrameSources(screen: try screen()), outputTime: 0))
+        XCTAssertNotEqual(png(opening), png(plainOpening), "the fade never reached the picture")
+
+        let middle = try XCTUnwrap(StudioRenderer.frame(
+            of: faded, atSource: 5, events: events(),
+            sources: FrameSources(screen: try screen()), outputTime: 5))
+        let plainMiddle = try XCTUnwrap(StudioRenderer.frame(
+            of: project(), atSource: 5, events: events(),
+            sources: FrameSources(screen: try screen()), outputTime: 5))
+        XCTAssertEqual(png(middle), png(plainMiddle), "the fade darkened the middle of the video")
+
+        try write(opening, named: "studio-fade-in")
+    }
+
+    /// A frame rendered with no output time — a still, a thumbnail — carries no wash rather than
+    /// guessing at one.
+    func testWithoutAnOutputTimeThereIsNoWash() throws {
+        var faded = project()
+        faded.fadeIn = 1
+
+        let unwashed = try XCTUnwrap(StudioRenderer.frame(
+            of: faded, atSource: 0, events: events(),
+            sources: FrameSources(screen: try screen())))
+        let plain = try XCTUnwrap(StudioRenderer.frame(
+            of: project(), atSource: 0, events: events(),
+            sources: FrameSources(screen: try screen())))
+        XCTAssertEqual(png(unwashed), png(plain))
+    }
 }

--- a/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
+++ b/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
@@ -392,4 +392,47 @@ final class StudioRenderSnapshotTests: XCTestCase {
             sources: FrameSources(screen: try screen())))
         XCTAssertEqual(png(unwashed), png(plain))
     }
+
+    // MARK: - Pictures
+
+    /// A brought-in picture reaches the finished frame — the seam, not the layer.
+    func testAMediaOverlayIsDrawn() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("media-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let file = directory.appendingPathComponent("logo.png")
+        let picture = try XCTUnwrap(CGContext(
+            data: nil, width: 120, height: 120, bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+        picture.setFillColor(CGColor(red: 0.1, green: 0.9, blue: 0.4, alpha: 1))
+        picture.fill(CGRect(x: 0, y: 0, width: 120, height: 120))
+        let image = try XCTUnwrap(picture.makeImage())
+        try XCTUnwrap(CaptureWriter.pngData(from: image)).write(to: file)
+
+        var withPicture = project()
+        withPicture.mediaOverlays = [MediaOverlay(start: 0, end: 10, asset: "logo.png")]
+        let loaded = try XCTUnwrap(MediaStore.shared.image(at: file))
+
+        let plain = try XCTUnwrap(StudioRenderer.frame(
+            of: project(), atSource: 3, events: events(),
+            sources: FrameSources(screen: try screen())))
+        let composited = try XCTUnwrap(StudioRenderer.frame(
+            of: withPicture, atSource: 3, events: events(),
+            sources: FrameSources(screen: try screen(), media: ["logo.png": loaded])))
+
+        XCTAssertNotEqual(png(plain), png(composited), "the picture was not drawn")
+        try write(composited, named: "studio-media-overlay")
+    }
+
+    /// An overlay whose file is missing draws nothing rather than a black box — a project moved
+    /// between Macs with a half-copied bundle should degrade, not break.
+    func testAMissingPictureDrawsNothing() throws {
+        var withPicture = project()
+        withPicture.mediaOverlays = [MediaOverlay(start: 0, end: 10, asset: "gone.png")]
+
+        XCTAssertEqual(png(try render(project(), at: 3)), png(try render(withPicture, at: 3)))
+    }
 }

--- a/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
+++ b/Tests/SarvkritTests/StudioRenderSnapshotTests.swift
@@ -162,4 +162,114 @@ final class StudioRenderSnapshotTests: XCTestCase {
                                                        sources: FrameSources(screen: nil)))
         XCTAssertGreaterThan(frame.width, 0)
     }
+
+    // MARK: - The later layers
+
+    /// A mask must actually obscure. This is the layer where "it drew something" is not enough:
+    /// the region has to stop showing what was underneath it.
+    func testAMaskObscuresWhatIsUnderIt() throws {
+        var masked = project()
+        masked.masks = [StudioMask(mode: .secureBlur,
+                                   rects: [CGRect(x: 100, y: 100, width: 300, height: 150)],
+                                   start: 0, end: 10)]
+        let hidden = try render(masked, at: 3)
+        XCTAssertNotEqual(png(try render(project(), at: 3)), png(hidden), "the mask drew nothing")
+        try write(hidden, named: "studio-mask")
+    }
+
+    /// The same four colours in the opposite corners: the mean is identical, the picture is not.
+    private func scrambledScreen() throws -> CGImage {
+        let context = try XCTUnwrap(CGContext(
+            data: nil, width: 800, height: 500, bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+        let colours = [CGColor(red: 0.95, green: 0.8, blue: 0.3, alpha: 1),
+                       CGColor(red: 0.3, green: 0.5, blue: 0.9, alpha: 1),
+                       CGColor(red: 0.3, green: 0.7, blue: 0.4, alpha: 1),
+                       CGColor(red: 0.9, green: 0.3, blue: 0.3, alpha: 1)]
+        for (index, colour) in colours.enumerated() {
+            context.setFillColor(colour)
+            context.fill(CGRect(x: index % 2 == 0 ? 0 : 400, y: index < 2 ? 0 : 250,
+                                width: 400, height: 250))
+        }
+        return try XCTUnwrap(context.makeImage())
+    }
+
+    /// The inverse mode: everything outside is dimmed, so the frame changes outside the region
+    /// rather than inside it.
+    func testAHighlightDimsEverythingElse() throws {
+        var lit = project()
+        lit.masks = [StudioMask(mode: .highlight,
+                                rects: [CGRect(x: 300, y: 200, width: 200, height: 100)],
+                                start: 0, end: 10)]
+        let frame = try render(lit, at: 3)
+        XCTAssertNotEqual(png(try render(project(), at: 3)), png(frame))
+        try write(frame, named: "studio-highlight")
+    }
+
+    func testKeystrokePillsAreDrawn() throws {
+        var typed = project()
+        typed.keystrokes.isEnabled = true
+        let log = EventLog(cursor: events().cursor,
+                           keys: [KeyEvent(t: 2.9, label: "⌘⇧R", isModifierCombination: true)])
+        let frame = try render(typed, at: 3, events: log)
+        XCTAssertNotEqual(png(try render(project(), at: 3, events: log)), png(frame),
+                          "no keystroke pill was drawn")
+        try write(frame, named: "studio-keystrokes")
+    }
+
+    func testTheCameraIsDrawn() throws {
+        let camera = try XCTUnwrap(CGContext(
+            data: nil, width: 400, height: 400, bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+        camera.setFillColor(CGColor(red: 0.2, green: 0.6, blue: 0.75, alpha: 1))
+        camera.fill(CGRect(x: 0, y: 0, width: 400, height: 400))
+
+        let frame = try XCTUnwrap(StudioRenderer.frame(
+            of: project(), atSource: 3, events: events(),
+            sources: FrameSources(screen: try screen(),
+                                  camera: try XCTUnwrap(camera.makeImage()))))
+        XCTAssertNotEqual(png(try render(project(), at: 3)), png(frame), "no camera was drawn")
+        try write(frame, named: "studio-camera")
+    }
+
+    /// A camera hidden for a stretch must genuinely disappear, not merely fade.
+    func testAHiddenCameraSegmentDrawsNoCamera() throws {
+        var hidden = project()
+        hidden.cameraSegments = [CameraSegment(start: 0, end: 10, layout: .hidden)]
+        let camera = try XCTUnwrap(CGContext(
+            data: nil, width: 400, height: 400, bitsPerComponent: 8, bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue))
+        camera.setFillColor(CGColor(red: 0.2, green: 0.6, blue: 0.75, alpha: 1))
+        camera.fill(CGRect(x: 0, y: 0, width: 400, height: 400))
+
+        let frame = try XCTUnwrap(StudioRenderer.frame(
+            of: hidden, atSource: 3, events: events(),
+            sources: FrameSources(screen: try screen(),
+                                  camera: try XCTUnwrap(camera.makeImage()))))
+        XCTAssertEqual(png(try render(hidden, at: 3)), png(frame))
+    }
+
+    /// **The security property, measured where it lives.**
+    ///
+    /// `secureBlur` deliberately keeps the region's mean colour — that is what makes a redaction
+    /// sit in its surroundings rather than look like a sticker pasted on. What must never survive
+    /// is *structure*. So the second screen holds exactly the same pixels rearranged: identical
+    /// mean by construction, completely different picture.
+    ///
+    /// Asserted on the mean itself rather than on a whole rendered frame, deliberately. A frame
+    /// comparison also captures the shadow, the corners and the cursor, so a failure would name
+    /// the frame rather than the redaction — and a security property is the last thing to test
+    /// through a confound.
+    func testASecureBlurCarriesNoStructureFromThePixelsUnderIt() throws {
+        let region = CGRect(x: 0, y: 0, width: 800, height: 500)
+        let one = try XCTUnwrap(StudioRenderer.averageColour(of: try screen(), in: region))
+        let other = try XCTUnwrap(StudioRenderer.averageColour(of: try scrambledScreen(),
+                                                               in: region))
+        XCTAssertEqual(one.r, other.r, accuracy: 0.002, "red leaked structure")
+        XCTAssertEqual(one.g, other.g, accuracy: 0.002, "green leaked structure")
+        XCTAssertEqual(one.b, other.b, accuracy: 0.002, "blue leaked structure")
+    }
 }

--- a/Tests/SarvkritTests/StudioShortcutsTests.swift
+++ b/Tests/SarvkritTests/StudioShortcutsTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import Sarvkrit
+
+/// The list the editor shows when you press ⌘/.
+///
+/// **⌘/ was routed to `break`.** It was recognised, deliberately silent, and therefore the one
+/// discoverability hatch the editor had was nailed shut — which is why "add a zoom by hand", which
+/// has worked all along behind an unlabelled glyph and the `Z` key, was reported as missing.
+///
+/// This list is a plain value so it can be checked against the router rather than drifting from it.
+final class StudioShortcutsTests: XCTestCase {
+
+    /// **Every shortcut listed must actually do something.** A list that promises a key the router
+    /// ignores is worse than no list.
+    func testEveryListedShortcutIsRouted() {
+        for entry in StudioShortcuts.all where !entry.isUnavailable {
+            XCTAssertNotNil(
+                StudioKeyRouting.action(forCharacters: entry.characters,
+                                        modifiers: entry.modifiers,
+                                        isEditingText: false),
+                "\(entry.title) is listed as \(entry.keyLabel) but the router ignores it")
+        }
+    }
+
+    /// And the two that are honestly not built say so, rather than being quietly left out.
+    func testTheUnbuiltCommandsAreListedAsUnavailable() {
+        let unavailable = StudioShortcuts.all.filter(\.isUnavailable).map(\.title)
+        XCTAssertTrue(unavailable.contains { $0.contains("In") })
+        XCTAssertTrue(unavailable.contains { $0.contains("Out") })
+    }
+
+    /// The things people could not find are in there.
+    func testTheHardToFindActionsAreListed() {
+        let titles = StudioShortcuts.all.map(\.title)
+        XCTAssertTrue(titles.contains { $0.localizedCaseInsensitiveContains("zoom") })
+        XCTAssertTrue(titles.contains { $0.localizedCaseInsensitiveContains("play") })
+        XCTAssertTrue(titles.contains { $0.localizedCaseInsensitiveContains("split") })
+    }
+
+    func testEntriesAreGrouped() {
+        XCTAssertFalse(StudioShortcuts.groups.isEmpty)
+        XCTAssertEqual(StudioShortcuts.groups.flatMap(\.entries).count, StudioShortcuts.all.count)
+    }
+}

--- a/Tests/SarvkritTests/TextOverlayTests.swift
+++ b/Tests/SarvkritTests/TextOverlayTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import Sarvkrit
+
+/// Text put on the video by hand.
+///
+/// **Its own type, because captions cannot express this.** `Caption` has no text field and no time
+/// range of its own — both derive from `words: [TranscriptWord]`, each needing a speech-recognition
+/// timestamp — and `CaptionStyle` is stored once per project with a position that is one of three
+/// canned values rather than a point. Faking a caption would mean inventing word timings to carry a
+/// string, then fighting the karaoke highlighting the type exists for.
+final class TextOverlayTests: XCTestCase {
+
+    func testItCoversOnlyItsOwnRange() {
+        let overlay = TextOverlay(start: 2, end: 5)
+        XCTAssertFalse(overlay.covers(1.9))
+        XCTAssertTrue(overlay.covers(2))
+        XCTAssertTrue(overlay.covers(4.9))
+        XCTAssertFalse(overlay.covers(5), "the range is half-open, like every other track's")
+    }
+
+    /// It fades rather than snapping: text appearing between two frames reads as a flash.
+    func testItFadesInAndOut() {
+        var overlay = TextOverlay(start: 0, end: 4)
+        overlay.fadeSeconds = 0.5
+
+        XCTAssertEqual(overlay.opacity(at: 2), 1, accuracy: 0.001)
+        XCTAssertLessThan(overlay.opacity(at: 0.1), 1)
+        XCTAssertLessThan(overlay.opacity(at: 3.9), 1)
+        XCTAssertEqual(overlay.opacity(at: 9), 0)
+    }
+
+    /// A line shorter than twice its fade still reaches full opacity rather than never arriving.
+    func testAShortLineStillBecomesVisible() {
+        var overlay = TextOverlay(start: 0, end: 0.5)
+        overlay.fadeSeconds = 2
+        XCTAssertGreaterThan(overlay.opacity(at: 0.25), 0.9)
+    }
+
+    /// Measurements are fractions of the canvas, so a title keeps its framing at any export size.
+    func testTheFontScalesWithTheCanvas() {
+        var overlay = TextOverlay(start: 0, end: 1)
+        overlay.sizeFraction = 0.05
+        XCTAssertEqual(overlay.font(forCanvasHeight: 1000).pointSize, 50, accuracy: 0.001)
+        XCTAssertEqual(overlay.font(forCanvasHeight: 2000).pointSize, 100, accuracy: 0.001)
+    }
+
+    /// The trap that has now bitten this feature twice: a hand-written decoder so a field added
+    /// later cannot make an older project unreadable — which the model treats as *no* project, and
+    /// therefore silently discards edits.
+    func testAnOlderOverlayWithMissingFieldsStillDecodes() throws {
+        let json = #"{"start":1,"end":4,"text":"Hello"}"#
+        let overlay = try JSONDecoder().decode(TextOverlay.self, from: Data(json.utf8))
+
+        XCTAssertEqual(overlay.text, "Hello")
+        XCTAssertEqual(overlay.end, 4, accuracy: 1e-9)
+        XCTAssertEqual(overlay.sizeFraction, 0.055, accuracy: 1e-9)
+        XCTAssertNotNil(overlay.background)
+    }
+
+    func testItSurvivesARoundTrip() throws {
+        var overlay = TextOverlay(start: 1, end: 3, text: "Look here")
+        overlay.origin = CGPoint(x: 0.2, y: 0.8)
+        overlay.haloColour = RGBAColour(r: 0, g: 0, b: 0, a: 1)
+        overlay.background = nil
+
+        let decoded = try JSONDecoder().decode(
+            TextOverlay.self, from: try JSONEncoder().encode(overlay))
+
+        XCTAssertEqual(decoded.text, "Look here")
+        XCTAssertEqual(decoded.origin, CGPoint(x: 0.2, y: 0.8))
+        XCTAssertNotNil(decoded.haloColour)
+        XCTAssertNil(decoded.background, "a nil background must stay nil, not revert to a default")
+    }
+}

--- a/Tests/SarvkritTests/TimelineLayoutTests.swift
+++ b/Tests/SarvkritTests/TimelineLayoutTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import Sarvkrit
+
+/// What the timeline shows, and where.
+///
+/// **The view used to hardcode two tracks.** `clipTrack` and `zoomTrack` were hand-placed rects,
+/// `preferredHeight` was a closed-form sum of exactly those two, and each had its own bespoke hit
+/// test. Five of the project's own collections therefore had no representation at all — masks,
+/// camera segments, captions, pointer highlights, and text once it existed. "There are no layers"
+/// was a fair description of a timeline that could only show two.
+///
+/// None of that geometry was testable while it lived inside `draw(_:)`. This is why it moved.
+final class TimelineLayoutTests: XCTestCase {
+
+    private func project(seconds: Double = 10) -> StudioProject {
+        StudioProject(canvasSize: CGSize(width: 100, height: 100),
+                      timeline: Timeline(clips: [Clip(sourceStart: 0, sourceEnd: seconds)]))
+    }
+
+    private func rows(_ project: StudioProject,
+                      selection: TimelineLayout.Selection = .init()) -> [TimelineLayout.Row] {
+        TimelineLayout.rows(project: project, events: EventLog(), selection: selection)
+    }
+
+    // MARK: - Which rows appear
+
+    /// A bare project shows the two rows that are always meaningful and nothing else, so the
+    /// timeline is not a wall of empty tracks.
+    func testABareProjectShowsOnlyVideoAndZoom() {
+        XCTAssertEqual(rows(project()).map(\.kind), [.video, .zoom])
+    }
+
+    /// And a row appears when you add the first of something, which is how you learn it exists.
+    func testARowAppearsWithItsFirstItem() {
+        var edited = project()
+        edited.textOverlays = [TextOverlay(start: 1, end: 3, text: "Hi")]
+        edited.pointerHighlights = [PointerHighlight(start: 4, end: 5)]
+
+        let kinds = rows(edited).map(\.kind)
+        XCTAssertTrue(kinds.contains(.text))
+        XCTAssertTrue(kinds.contains(.pointer))
+        XCTAssertFalse(kinds.contains(.camera), "an empty row is noise")
+    }
+
+    /// The order never changes, so the timeline does not rearrange itself as you work.
+    func testRowOrderIsStable() {
+        var edited = project()
+        edited.pointerHighlights = [PointerHighlight(start: 1, end: 2)]
+        edited.textOverlays = [TextOverlay(start: 1, end: 2)]
+        edited.cameraSegments = [CameraSegment(start: 1, end: 2, layout: .hidden)]
+
+        XCTAssertEqual(rows(edited).map(\.kind), [.video, .text, .camera, .zoom, .pointer])
+    }
+
+    // MARK: - Where items land
+
+    func testAClipSpansItsOutputRange() throws {
+        let row = try XCTUnwrap(rows(project(seconds: 8)).first { $0.kind == .video })
+        let item = try XCTUnwrap(row.items.first)
+        XCTAssertEqual(item.start, 0, accuracy: 1e-9)
+        XCTAssertEqual(item.end, 8, accuracy: 1e-9)
+    }
+
+    /// Source-time tracks are placed by where their material ended up, which is the whole point of
+    /// storing them in source time — a trim moves the picture and the zoom together.
+    func testASegmentIsPlacedWhereItsMaterialEndedUp() throws {
+        var trimmed = project()
+        trimmed.timeline = Timeline(clips: [Clip(sourceStart: 4, sourceEnd: 10)])
+        trimmed.textOverlays = [TextOverlay(start: 6, end: 8, text: "Hi")]
+
+        let row = try XCTUnwrap(rows(trimmed).first { $0.kind == .text })
+        let item = try XCTUnwrap(row.items.first)
+        XCTAssertEqual(item.start, 2, accuracy: 1e-9, "source 6 is output 2 after trimming to 4")
+        XCTAssertEqual(item.end, 4, accuracy: 0.01)
+    }
+
+    /// Something the edit cut out entirely is not drawn at all, rather than piled at zero.
+    func testAnItemWhoseMaterialWasCutIsDropped() throws {
+        var trimmed = project()
+        trimmed.timeline = Timeline(clips: [Clip(sourceStart: 0, sourceEnd: 2)])
+        trimmed.textOverlays = [TextOverlay(start: 7, end: 9, text: "Gone")]
+
+        XCTAssertFalse(rows(trimmed).contains { $0.kind == .text })
+    }
+
+    func testSelectionMarksExactlyOneItem() throws {
+        var edited = project()
+        let first = TextOverlay(start: 1, end: 2, text: "A")
+        let second = TextOverlay(start: 3, end: 4, text: "B")
+        edited.textOverlays = [first, second]
+
+        let row = try XCTUnwrap(
+            rows(edited, selection: .init(text: second.id)).first { $0.kind == .text })
+        XCTAssertEqual(row.items.filter(\.isSelected).map(\.id), [second.id])
+    }
+
+    /// A disabled zoom is shown dimmed rather than hidden: it is still part of the edit.
+    func testADisabledZoomIsMutedNotMissing() throws {
+        var edited = project()
+        var zoom = ZoomSegment(start: 1, end: 4, level: 2, anchor: .fixed(.zero))
+        zoom.isDisabled = true
+        edited.zooms = [zoom]
+
+        let row = try XCTUnwrap(rows(edited).first { $0.kind == .zoom })
+        XCTAssertEqual(row.items.count, 1)
+        XCTAssertTrue(try XCTUnwrap(row.items.first).isMuted)
+    }
+
+    // MARK: - Geometry
+
+    func testTheViewGrowsWithItsRows() {
+        let two = TimelineLayout.preferredHeight(rowCount: 2)
+        let five = TimelineLayout.preferredHeight(rowCount: 5)
+        XCTAssertGreaterThan(five, two)
+    }
+
+    func testRowsStackWithoutOverlapping() {
+        let bounds = CGRect(x: 0, y: 0, width: 400, height: 300)
+        let first = TimelineLayout.rect(ofRow: 0, in: bounds)
+        let second = TimelineLayout.rect(ofRow: 1, in: bounds)
+
+        XCTAssertLessThanOrEqual(first.maxY, second.minY)
+        XCTAssertEqual(first.height, second.height, accuracy: 0.001)
+    }
+
+    /// Every row fits inside the height the view asked for, or the last one is clipped.
+    func testEveryRowFitsInsideThePreferredHeight() {
+        let count = 6
+        let height = TimelineLayout.preferredHeight(rowCount: count)
+        let bounds = CGRect(x: 0, y: 0, width: 400, height: height)
+        for index in 0..<count {
+            XCTAssertLessThanOrEqual(TimelineLayout.rect(ofRow: index, in: bounds).maxY, height)
+        }
+    }
+}

--- a/Tests/SarvkritTests/TimelineTests.swift
+++ b/Tests/SarvkritTests/TimelineTests.swift
@@ -1,0 +1,241 @@
+import XCTest
+@testable import Sarvkrit
+
+/// The mapping between the edit and the recording it was made from.
+///
+/// **Every desynchronisation bug in the studio lives in one function.** The cursor, the zooms, the
+/// captions and the keystrokes are all stored in *source* time and looked up through
+/// `sourceTime(forOutput:)`; the video frame is fetched through the same call. If that mapping is
+/// wrong by a frame, everything but the video moves together and the recording looks like it was
+/// dubbed. So the arithmetic is a pure struct and this suite is exhaustive about it.
+final class TimelineTests: XCTestCase {
+
+    private func clip(_ start: TimeInterval, _ end: TimeInterval,
+                      speed: Double = 1) -> Clip {
+        Clip(sourceStart: start, sourceEnd: end, speed: speed)
+    }
+
+    // MARK: - Duration
+
+    func testAnUntouchedTimelineIsAsLongAsItsClip() {
+        let timeline = Timeline(clips: [clip(0, 10)])
+        XCTAssertEqual(timeline.duration, 10, accuracy: 0.0001)
+    }
+
+    func testDurationIsTheSumOfTheClips() {
+        let timeline = Timeline(clips: [clip(0, 4), clip(6, 10)])
+        XCTAssertEqual(timeline.duration, 8, accuracy: 0.0001)
+    }
+
+    /// Double speed halves the time a clip occupies in the finished video.
+    func testSpeedShortensAClipsContributionToTheDuration() {
+        let timeline = Timeline(clips: [clip(0, 10, speed: 2)])
+        XCTAssertEqual(timeline.duration, 5, accuracy: 0.0001)
+    }
+
+    func testHalfSpeedLengthensIt() {
+        let timeline = Timeline(clips: [clip(0, 10, speed: 0.5)])
+        XCTAssertEqual(timeline.duration, 20, accuracy: 0.0001)
+    }
+
+    func testAnEmptyTimelineHasNoDuration() {
+        XCTAssertEqual(Timeline(clips: []).duration, 0)
+    }
+
+    // MARK: - Output to source
+
+    func testOutputTimeMapsStraightThroughAtNormalSpeed() {
+        let timeline = Timeline(clips: [clip(0, 10)])
+        let found = timeline.sourceTime(forOutput: 3)
+        XCTAssertEqual(found?.sourceTime ?? -1, 3, accuracy: 0.0001)
+    }
+
+    /// The whole point of `sourceStart`: a trimmed clip's output zero is not the recording's zero.
+    func testATrimmedClipOffsetsTheLookup() {
+        let timeline = Timeline(clips: [clip(5, 15)])
+        let found = timeline.sourceTime(forOutput: 2)
+        XCTAssertEqual(found?.sourceTime ?? -1, 7, accuracy: 0.0001)
+    }
+
+    func testASpedUpClipConsumesSourceFaster() {
+        let timeline = Timeline(clips: [clip(0, 10, speed: 2)])
+        let found = timeline.sourceTime(forOutput: 2)
+        XCTAssertEqual(found?.sourceTime ?? -1, 4, accuracy: 0.0001)
+    }
+
+    /// A cut in the middle: output 5 lands in the second clip, which starts at source 20.
+    func testTheLookupCrossesIntoTheSecondClip() {
+        let timeline = Timeline(clips: [clip(0, 4), clip(20, 30)])
+        let found = timeline.sourceTime(forOutput: 5)
+        XCTAssertEqual(found?.sourceTime ?? -1, 21, accuracy: 0.0001)
+        XCTAssertEqual(found?.clip.sourceStart, 20)
+    }
+
+    func testTheLookupIsNilPastTheEnd() {
+        let timeline = Timeline(clips: [clip(0, 4)])
+        XCTAssertNil(timeline.sourceTime(forOutput: 9))
+    }
+
+    func testTheLookupIsNilBeforeTheStart() {
+        let timeline = Timeline(clips: [clip(0, 4)])
+        XCTAssertNil(timeline.sourceTime(forOutput: -1))
+    }
+
+    /// The boundary belongs to the clip that starts there, not the one that ended.
+    func testAnExactBoundaryLandsInTheFollowingClip() {
+        let timeline = Timeline(clips: [clip(0, 4), clip(20, 30)])
+        let found = timeline.sourceTime(forOutput: 4)
+        XCTAssertEqual(found?.clip.sourceStart, 20)
+        XCTAssertEqual(found?.sourceTime ?? -1, 20, accuracy: 0.0001)
+    }
+
+    /// Asked for exactly the end, there is no frame to show — the video is over.
+    func testTheLookupIsNilAtExactlyTheDuration() {
+        let timeline = Timeline(clips: [clip(0, 4)])
+        XCTAssertNil(timeline.sourceTime(forOutput: 4))
+    }
+
+    // MARK: - Split
+
+    func testSplittingMakesTwoClipsOutOfOne() {
+        let timeline = Timeline(clips: [clip(0, 10)]).split(at: 4)
+        XCTAssertEqual(timeline.clips.count, 2)
+        XCTAssertEqual(timeline.clips[0].sourceEnd, 4, accuracy: 0.0001)
+        XCTAssertEqual(timeline.clips[1].sourceStart, 4, accuracy: 0.0001)
+    }
+
+    func testSplittingPreservesTheTotalDuration() {
+        let timeline = Timeline(clips: [clip(0, 10)]).split(at: 4)
+        XCTAssertEqual(timeline.duration, 10, accuracy: 0.0001)
+    }
+
+    /// The split point is given in output time, so a sped-up clip splits at the source time the
+    /// user is actually looking at — not at the same number.
+    func testSplittingASpedUpClipCutsAtTheRightSourceTime() {
+        let timeline = Timeline(clips: [clip(0, 10, speed: 2)]).split(at: 2)
+        XCTAssertEqual(timeline.clips[0].sourceEnd, 4, accuracy: 0.0001)
+    }
+
+    func testSplittingCarriesTheSpeedToBothHalves() {
+        let timeline = Timeline(clips: [clip(0, 10, speed: 2)]).split(at: 2)
+        XCTAssertEqual(timeline.clips[0].speed, 2)
+        XCTAssertEqual(timeline.clips[1].speed, 2)
+    }
+
+    func testTheTwoHalvesGetDifferentIdentities() {
+        let timeline = Timeline(clips: [clip(0, 10)]).split(at: 4)
+        XCTAssertNotEqual(timeline.clips[0].id, timeline.clips[1].id)
+    }
+
+    /// A split that would leave a sliver nobody can grab is refused rather than performed.
+    func testSplittingTooCloseToTheStartIsRefused() {
+        let original = Timeline(clips: [clip(0, 10)])
+        XCTAssertEqual(original.split(at: 0.02).clips.count, 1)
+    }
+
+    func testSplittingTooCloseToTheEndIsRefused() {
+        let original = Timeline(clips: [clip(0, 10)])
+        XCTAssertEqual(original.split(at: 9.98).clips.count, 1)
+    }
+
+    func testSplittingPastTheEndDoesNothing() {
+        XCTAssertEqual(Timeline(clips: [clip(0, 10)]).split(at: 40).clips.count, 1)
+    }
+
+    // MARK: - Delete
+
+    func testDeletingRemovesTheClipAndClosesTheGap() {
+        let first = clip(0, 4), second = clip(20, 30)
+        let timeline = Timeline(clips: [first, second]).delete(id: first.id)
+        XCTAssertEqual(timeline.clips.count, 1)
+        XCTAssertEqual(timeline.duration, 10, accuracy: 0.0001)
+        XCTAssertEqual(timeline.sourceTime(forOutput: 0)?.sourceTime ?? -1, 20, accuracy: 0.0001)
+    }
+
+    /// Deleting the last clip would leave a timeline that cannot be edited back into existence.
+    func testTheLastClipCannotBeDeleted() {
+        let only = clip(0, 10)
+        let timeline = Timeline(clips: [only]).delete(id: only.id)
+        XCTAssertEqual(timeline.clips.count, 1)
+    }
+
+    func testDeletingAnUnknownIdChangesNothing() {
+        let timeline = Timeline(clips: [clip(0, 4), clip(6, 8)])
+        XCTAssertEqual(timeline.delete(id: UUID()).clips.count, 2)
+    }
+
+    // MARK: - Trim
+
+    func testTrimmingTheStartMovesSourceStart() {
+        let only = clip(0, 10)
+        let timeline = Timeline(clips: [only]).trim(id: only.id, start: 3, end: nil)
+        XCTAssertEqual(timeline.clips[0].sourceStart, 3, accuracy: 0.0001)
+        XCTAssertEqual(timeline.duration, 7, accuracy: 0.0001)
+    }
+
+    func testTrimmingTheEndMovesSourceEnd() {
+        let only = clip(0, 10)
+        let timeline = Timeline(clips: [only]).trim(id: only.id, start: nil, end: 6)
+        XCTAssertEqual(timeline.clips[0].sourceEnd, 6, accuracy: 0.0001)
+    }
+
+    /// Trim is a view onto the recording, so it is reversible — that is what lets the trim badge
+    /// honestly say how much is hidden, and what makes clicking it put the material back.
+    func testTrimmingBackOutRestoresTheMaterial() {
+        let only = clip(0, 10)
+        let trimmed = Timeline(clips: [only]).trim(id: only.id, start: 3, end: nil)
+        let restored = trimmed.trim(id: only.id, start: 0, end: nil)
+        XCTAssertEqual(restored.duration, 10, accuracy: 0.0001)
+    }
+
+    func testTrimmingPastTheOtherEdgeIsRefused() {
+        let only = clip(0, 10)
+        let timeline = Timeline(clips: [only]).trim(id: only.id, start: 9.99, end: nil)
+        XCTAssertEqual(timeline.clips[0].sourceStart, 0, accuracy: 0.0001)
+    }
+
+    // MARK: - Speed
+
+    func testSettingSpeedChangesTheDuration() {
+        let only = clip(0, 10)
+        let timeline = Timeline(clips: [only]).setSpeed(id: only.id, 4)
+        XCTAssertEqual(timeline.duration, 2.5, accuracy: 0.0001)
+    }
+
+    func testSpeedIsClampedToTheSupportedRange() {
+        let only = clip(0, 10)
+        XCTAssertEqual(Timeline(clips: [only]).setSpeed(id: only.id, 99).clips[0].speed,
+                       Clip.speedRange.upperBound)
+        XCTAssertEqual(Timeline(clips: [only]).setSpeed(id: only.id, 0).clips[0].speed,
+                       Clip.speedRange.lowerBound)
+    }
+
+    // MARK: - Source to output
+
+    /// The inverse mapping, which is what puts a zoom segment stored in source time onto the
+    /// timeline in the right place.
+    func testSourceTimeMapsBackToOutputTime() {
+        let timeline = Timeline(clips: [clip(0, 4), clip(20, 30)])
+        XCTAssertEqual(timeline.outputTime(forSource: 22) ?? -1, 6, accuracy: 0.0001)
+    }
+
+    /// Source that was cut out has no place in the output at all, and saying so is what lets the
+    /// renderer skip a zoom whose moment was deleted.
+    func testSourceInsideACutHasNoOutputTime() {
+        let timeline = Timeline(clips: [clip(0, 4), clip(20, 30)])
+        XCTAssertNil(timeline.outputTime(forSource: 10))
+    }
+
+    func testTheTwoMappingsAreInverses() {
+        let timeline = Timeline(clips: [clip(2, 6, speed: 2), clip(20, 30, speed: 0.5)])
+        for output in stride(from: 0.0, to: timeline.duration - 0.01, by: 0.37) {
+            guard let source = timeline.sourceTime(forOutput: output) else {
+                return XCTFail("no source for output \(output)")
+            }
+            guard let back = timeline.outputTime(forSource: source.sourceTime) else {
+                return XCTFail("no output for source \(source.sourceTime)")
+            }
+            XCTAssertEqual(back, output, accuracy: 0.001)
+        }
+    }
+}

--- a/Tests/SarvkritTests/TimelineTests.swift
+++ b/Tests/SarvkritTests/TimelineTests.swift
@@ -238,4 +238,170 @@ final class TimelineTests: XCTestCase {
             XCTAssertEqual(back, output, accuracy: 0.001)
         }
     }
+
+    // MARK: - Order
+
+    /// **Reordering is a move on an array, and that is not a coincidence.**
+    ///
+    /// `sourceTime(forOutput:)` walks the clips in array order, and every other track — zooms,
+    /// masks, camera layouts, captions — is stored in *source* time and resolved through that
+    /// mapping. So a clip carries its material with it, and whatever was attached to that material
+    /// arrives with it. There was simply no method to do it: split, delete, trim and setSpeed, and
+    /// nothing that changed order.
+    func testMovingAClipChangesTheOrder() {
+        let a = Clip(sourceStart: 0, sourceEnd: 2)
+        let b = Clip(sourceStart: 10, sourceEnd: 13)
+        let timeline = Timeline(clips: [a, b]).move(from: 0, to: 1)
+
+        XCTAssertEqual(timeline.clips.map(\.id), [b.id, a.id])
+    }
+
+    func testMovingAClipKeepsTheTotalDuration() {
+        let timeline = Timeline(clips: [Clip(sourceStart: 0, sourceEnd: 2),
+                                        Clip(sourceStart: 10, sourceEnd: 13)])
+        XCTAssertEqual(timeline.move(from: 1, to: 0).duration, timeline.duration, accuracy: 1e-9)
+    }
+
+    /// The material moves with the clip: after the swap, the second half of the finished video
+    /// shows what used to be the first.
+    func testAMovedClipTakesItsMaterialWithIt() throws {
+        let timeline = Timeline(clips: [Clip(sourceStart: 0, sourceEnd: 2),
+                                        Clip(sourceStart: 10, sourceEnd: 13)]).move(from: 0, to: 1)
+
+        XCTAssertEqual(try XCTUnwrap(timeline.sourceTime(forOutput: 0.5)).sourceTime, 10.5,
+                       accuracy: 1e-9)
+        XCTAssertEqual(try XCTUnwrap(timeline.sourceTime(forOutput: 3.5)).sourceTime, 0.5,
+                       accuracy: 1e-9)
+    }
+
+    /// A move that changes nothing is refused, so it costs no undo step.
+    func testAMoveToTheSamePlaceIsRefused() {
+        let timeline = Timeline(clips: [Clip(sourceStart: 0, sourceEnd: 2),
+                                        Clip(sourceStart: 10, sourceEnd: 13)])
+        XCTAssertEqual(timeline.move(from: 0, to: 0), timeline)
+    }
+
+    func testAMoveOutOfBoundsIsRefused() {
+        let timeline = Timeline(clips: [Clip(sourceStart: 0, sourceEnd: 2)])
+        XCTAssertEqual(timeline.move(from: 0, to: 7), timeline)
+        XCTAssertEqual(timeline.move(from: 4, to: 0), timeline)
+    }
+
+    // MARK: - Duplicate
+
+    func testDuplicatingAClipAddsItAfterTheOriginal() {
+        let a = Clip(sourceStart: 0, sourceEnd: 2)
+        let b = Clip(sourceStart: 10, sourceEnd: 13)
+        let timeline = Timeline(clips: [a, b]).duplicate(id: a.id)
+
+        XCTAssertEqual(timeline.clips.count, 3)
+        XCTAssertEqual(timeline.clips[0].id, a.id)
+        XCTAssertEqual(timeline.clips[2].id, b.id)
+    }
+
+    /// A new identity, or selection and every per-clip edit would address both at once.
+    func testADuplicateGetsItsOwnIdentity() {
+        let a = Clip(sourceStart: 0, sourceEnd: 2)
+        let timeline = Timeline(clips: [a]).duplicate(id: a.id)
+        XCTAssertNotEqual(timeline.clips[0].id, timeline.clips[1].id)
+    }
+
+    func testADuplicateShowsTheSameMaterialTwice() throws {
+        let a = Clip(sourceStart: 4, sourceEnd: 6)
+        let timeline = Timeline(clips: [a]).duplicate(id: a.id)
+
+        XCTAssertEqual(timeline.duration, 4, accuracy: 1e-9)
+        XCTAssertEqual(try XCTUnwrap(timeline.sourceTime(forOutput: 0.5)).sourceTime, 4.5,
+                       accuracy: 1e-9)
+        XCTAssertEqual(try XCTUnwrap(timeline.sourceTime(forOutput: 2.5)).sourceTime, 4.5,
+                       accuracy: 1e-9)
+    }
+
+    // MARK: - Rolling a cut
+
+    /// Dragging the seam between two clips moves material from one to the other without changing
+    /// where the cut sits in the finished video — the thing a cut is usually adjusted *for*.
+    func testRollingACutTradesMaterialBetweenNeighbours() {
+        let a = Clip(sourceStart: 0, sourceEnd: 5)
+        let b = Clip(sourceStart: 5, sourceEnd: 10)
+        let rolled = Timeline(clips: [a, b]).roll(after: a.id, by: 1)
+
+        XCTAssertEqual(rolled.clips[0].sourceEnd, 6, accuracy: 1e-9)
+        XCTAssertEqual(rolled.clips[1].sourceStart, 6, accuracy: 1e-9)
+        XCTAssertEqual(rolled.duration, 10, accuracy: 1e-9)
+    }
+
+    /// A roll that would leave either side too small to grab is refused rather than performed.
+    func testARollThatWouldLeaveASliverIsRefused() {
+        let a = Clip(sourceStart: 0, sourceEnd: 5)
+        let b = Clip(sourceStart: 5, sourceEnd: 10)
+        let timeline = Timeline(clips: [a, b])
+        XCTAssertEqual(timeline.roll(after: a.id, by: 5), timeline)
+        XCTAssertEqual(timeline.roll(after: a.id, by: -5), timeline)
+    }
+
+    // MARK: - Freeze frame
+
+    /// **A held frame is a clip that keeps showing its last moment.** One field rather than a new
+    /// type, so it composes with speed and trimming instead of sitting beside them.
+    func testAHoldLengthensTheClipWithoutConsumingMoreSource() {
+        var clip = Clip(sourceStart: 0, sourceEnd: 4)
+        clip.hold = 3
+        let timeline = Timeline(clips: [clip])
+
+        XCTAssertEqual(timeline.duration, 7, accuracy: 1e-9)
+    }
+
+    func testDuringTheHoldTheSourceTimeStopsAtTheEnd() throws {
+        var clip = Clip(sourceStart: 0, sourceEnd: 4)
+        clip.hold = 3
+        let timeline = Timeline(clips: [clip])
+
+        let moving = try XCTUnwrap(timeline.sourceTime(forOutput: 2)).sourceTime
+        let held = try XCTUnwrap(timeline.sourceTime(forOutput: 5.5)).sourceTime
+        let later = try XCTUnwrap(timeline.sourceTime(forOutput: 6.5)).sourceTime
+
+        XCTAssertEqual(moving, 2, accuracy: 1e-9)
+        XCTAssertEqual(held, 4, accuracy: 0.001, "the hold should show the clip's last frame")
+        XCTAssertEqual(later, held, accuracy: 1e-9, "the held frame must not drift")
+    }
+
+    /// It composes with speed: the moving part is shortened, the hold is not.
+    func testAHoldIsNotAffectedBySpeed() {
+        var clip = Clip(sourceStart: 0, sourceEnd: 4)
+        clip.speed = 2
+        clip.hold = 3
+        XCTAssertEqual(Timeline(clips: [clip]).duration, 5, accuracy: 1e-9)
+    }
+
+    /// And the clip after a hold still starts where it should.
+    func testAClipAfterAHoldStartsAfterIt() throws {
+        var first = Clip(sourceStart: 0, sourceEnd: 2)
+        first.hold = 2
+        let second = Clip(sourceStart: 20, sourceEnd: 22)
+        let timeline = Timeline(clips: [first, second])
+
+        XCTAssertEqual(try XCTUnwrap(timeline.sourceTime(forOutput: 4.5)).sourceTime, 20.5,
+                       accuracy: 1e-9)
+    }
+
+    // MARK: - Older projects
+
+    /// **A project saved before a field existed must still open.**
+    ///
+    /// `Clip` uses synthesized `Codable`, and a synthesized decoder throws on a missing key even
+    /// when the property has a default — a default is not the same as optional. So every field
+    /// added here is a chance to make every saved project unreadable, and
+    /// `StudioDocumentModel` treats an unreadable project as "no project", which would silently
+    /// discard somebody's edits.
+    func testAClipSavedBeforeHoldExistedStillDecodes() throws {
+        let json = """
+        {"id":"\(UUID().uuidString)","sourceStart":0,"sourceEnd":5,"speed":1,
+         "volume":1,"systemAudioVolume":1,"isMuted":false,"hidesCursor":false,
+         "disablesCursorSmoothing":false}
+        """
+        let clip = try JSONDecoder().decode(Clip.self, from: Data(json.utf8))
+        XCTAssertEqual(clip.hold, 0)
+        XCTAssertEqual(clip.sourceEnd, 5, accuracy: 1e-9)
+    }
 }

--- a/Tests/SarvkritTests/ZoomEaseTests.swift
+++ b/Tests/SarvkritTests/ZoomEaseTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Sarvkrit
+
+/// The curve a zoom travels along.
+///
+/// **Endpoint exactness is the whole point of this suite.** An ease that returns 0.998 instead of 1
+/// leaves the frame a fraction short of its target, and the jolt when the next segment takes over
+/// from a different value is visible on every zoom in the video. It is also exactly the kind of
+/// error that looks like a rendering bug and gets hunted for in the compositor.
+final class ZoomEaseTests: XCTestCase {
+
+    func testEveryCurveStartsExactlyAtZero() {
+        for ease in ZoomEase.allCases {
+            XCTAssertEqual(ease.value(0), 0, accuracy: 1e-12, "\(ease.rawValue)")
+        }
+    }
+
+    func testEveryCurveEndsExactlyAtOne() {
+        for ease in ZoomEase.allCases {
+            XCTAssertEqual(ease.value(1), 1, accuracy: 1e-12, "\(ease.rawValue)")
+        }
+    }
+
+    func testEveryCurveIsMonotonic() {
+        for ease in ZoomEase.allCases {
+            var previous = -1.0
+            for step in 0...100 {
+                let value = ease.value(Double(step) / 100)
+                XCTAssertGreaterThanOrEqual(value, previous, "\(ease.rawValue) went backwards")
+                previous = value
+            }
+        }
+    }
+
+    /// Nothing may overshoot. A zoom that sails past its level and settles back reads as a bounce,
+    /// which is charming once and seasickening over a five-minute demo.
+    func testNoCurveLeavesTheUnitRange() {
+        for ease in ZoomEase.allCases {
+            for step in 0...100 {
+                let value = ease.value(Double(step) / 100)
+                XCTAssertGreaterThanOrEqual(value, 0, "\(ease.rawValue)")
+                XCTAssertLessThanOrEqual(value, 1, "\(ease.rawValue)")
+            }
+        }
+    }
+
+    func testProgressIsClampedOutsideTheUnitRange() {
+        XCTAssertEqual(ZoomEase.smooth.value(-3), 0, accuracy: 1e-12)
+        XCTAssertEqual(ZoomEase.smooth.value(4), 1, accuracy: 1e-12)
+    }
+
+    func testLinearIsItsOwnProgress() {
+        XCTAssertEqual(ZoomEase.linear.value(0.37), 0.37, accuracy: 1e-12)
+    }
+
+    /// A damped spring covers most of the distance early and eases into the target, so it is ahead
+    /// of linear in the first half. That is what makes it read as motion with weight.
+    func testSmoothLeadsLinearEarlyOn() {
+        XCTAssertGreaterThan(ZoomEase.smooth.value(0.25), ZoomEase.linear.value(0.25))
+    }
+
+    /// Instant exists for cuts: the frame is at its target from the first frame, not a moment after.
+    func testInstantArrivesImmediately() {
+        XCTAssertEqual(ZoomEase.instant.value(0.0001), 1, accuracy: 1e-12)
+    }
+
+    // MARK: - Interpolating a level
+
+    func testInterpolatingLandsOnBothEnds() {
+        XCTAssertEqual(ZoomEase.smooth.interpolate(from: 1, to: 2.5, progress: 0), 1, accuracy: 1e-12)
+        XCTAssertEqual(ZoomEase.smooth.interpolate(from: 1, to: 2.5, progress: 1), 2.5, accuracy: 1e-12)
+    }
+
+    func testInterpolatingRunsBackwardsToo() {
+        XCTAssertEqual(ZoomEase.linear.interpolate(from: 2, to: 1, progress: 0.5), 1.5, accuracy: 1e-12)
+    }
+}

--- a/Tests/SarvkritTests/ZoomJoinTests.swift
+++ b/Tests/SarvkritTests/ZoomJoinTests.swift
@@ -1,0 +1,187 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// What happens between two zooms that follow each other closely.
+///
+/// **"The zoom first goes to 2.5x then 1x and then to 1.4x, creating a weird animation."** It did,
+/// by construction: `transform` found the one segment containing the moment and computed
+/// `interpolate(from: 1, to: segment.level, …)` — `from:` being the literal 1. The resolver saw one
+/// segment at a time, held no state, and had no idea a neighbour existed, so every ramp was
+/// measured against identity at both ends. Two abutting segments therefore spent the first's
+/// ease-out falling to 1× and the second's ease-in climbing back.
+///
+/// Nothing caught it because **every existing resolver test passes a single-element array**, and
+/// the planner test that checks spacing explicitly permits `a.end == b.start`. So every test here
+/// passes more than one segment.
+final class ZoomJoinTests: XCTestCase {
+
+    private let frame = CGSize(width: 1000, height: 800)
+
+    private func segment(_ start: TimeInterval, _ end: TimeInterval, level: Double,
+                         at anchor: CGPoint = CGPoint(x: 0.5, y: 0.5)) -> ZoomSegment {
+        ZoomSegment(start: start, end: end, level: level, anchor: .fixed(anchor))
+    }
+
+    private func scale(_ segments: [ZoomSegment], at t: TimeInterval) -> Double {
+        ZoomResolver.transform(at: t, segments: segments, cursor: nil, frameSize: frame).scale
+    }
+
+    private func centre(_ segments: [ZoomSegment], at t: TimeInterval) -> CGPoint {
+        ZoomResolver.transform(at: t, segments: segments, cursor: nil, frameSize: frame).center
+    }
+
+    /// Every 20 ms across a window, which is finer than a frame at 60 fps.
+    private func samples(_ segments: [ZoomSegment],
+                         from: TimeInterval, to: TimeInterval) -> [(t: TimeInterval, scale: Double)] {
+        stride(from: from, through: to, by: 0.02).map { ($0, scale(segments, at: $0)) }
+    }
+
+    // MARK: - The reported bug
+
+    /// The exact pair out of the user's own recording: `27.63 → 33.65 at 1.38×` following
+    /// `21.57 → 27.63 at 2.50×`, abutting to the frame.
+    func testTwoAbuttingZoomsNeverPassThroughOneTimes() {
+        let segments = [segment(21.57, 27.63, level: 2.50),
+                        segment(27.63, 33.65, level: 1.38)]
+
+        let across = samples(segments, from: 26.5, to: 29.0)
+        let lowest = across.min { $0.scale < $1.scale }!
+        XCTAssertGreaterThan(lowest.scale, 1.30,
+                             "the frame dropped to \(lowest.scale)× at \(lowest.t)s, "
+                             + "between a 2.5× zoom and a 1.38× one")
+    }
+
+    /// And it gets there in one movement rather than two: sampled across the join, the scale only
+    /// ever descends.
+    func testTheJoinIsOneContinuousMove() {
+        let segments = [segment(21.57, 27.63, level: 2.50),
+                        segment(27.63, 33.65, level: 1.38)]
+
+        let across = samples(segments, from: 26.5, to: 29.0).map(\.scale)
+        for (earlier, later) in zip(across, across.dropFirst()) {
+            XCTAssertLessThanOrEqual(later, earlier + 0.001,
+                                     "the scale went back up, so the frame changed direction")
+        }
+        XCTAssertEqual(across.first ?? 0, 2.50, accuracy: 0.01)
+        XCTAssertEqual(across.last ?? 0, 1.38, accuracy: 0.01)
+    }
+
+    /// Upwards too — the other pair in the same recording is `1.69×` followed by `2.50×`.
+    func testAJoinThatZoomsFurtherInIsAlsoOneMove() {
+        let segments = [segment(11.02, 17.46, level: 1.69),
+                        segment(17.46, 19.66, level: 2.50)]
+
+        let across = samples(segments, from: 16.5, to: 18.5).map(\.scale)
+        for (earlier, later) in zip(across, across.dropFirst()) {
+            XCTAssertGreaterThanOrEqual(later, earlier - 0.001, "the scale dipped on the way up")
+        }
+        XCTAssertEqual(across.first ?? 0, 1.69, accuracy: 0.01)
+        XCTAssertEqual(across.last ?? 0, 2.50, accuracy: 0.01)
+    }
+
+    /// A short gap is still a join. The user's recording has a 0.40 s one, and during it the frame
+    /// should hold rather than resolve to identity because no segment covers the moment.
+    func testAShortGapHoldsRatherThanZoomingOut() {
+        let segments = [segment(5.0, 10.0, level: 2.5),
+                        segment(10.4, 15.0, level: 1.4)]
+
+        XCTAssertEqual(scale(segments, at: 10.2), 2.5, accuracy: 0.01,
+                       "the frame zoomed out during a 0.4s gap between two zooms")
+        let lowest = samples(segments, from: 9.0, to: 12.0).min { $0.scale < $1.scale }!
+        XCTAssertGreaterThan(lowest.scale, 1.35)
+    }
+
+    /// **A real pause is still a zoom out.** Holding a 2.5× close-up across three seconds of
+    /// nothing happening would be worse than the dip — the shot has to breathe.
+    func testALongGapStillReturnsToOneTimes() {
+        let segments = [segment(5.0, 10.0, level: 2.5),
+                        segment(13.0, 18.0, level: 1.4)]
+
+        XCTAssertEqual(scale(segments, at: 11.5), 1.0, accuracy: 0.01)
+    }
+
+    // MARK: - The ends of a run are unchanged
+
+    func testTheFirstZoomOfARunStillEasesInFromOneTimes() {
+        let segments = [segment(5.0, 10.0, level: 2.5),
+                        segment(10.0, 15.0, level: 1.4)]
+        XCTAssertEqual(scale(segments, at: 5.0), 1.0, accuracy: 0.01)
+        XCTAssertGreaterThan(scale(segments, at: 5.3), 1.0)
+    }
+
+    func testTheLastZoomOfARunStillEasesOutToOneTimes() {
+        let segments = [segment(5.0, 10.0, level: 2.5),
+                        segment(10.0, 15.0, level: 1.4)]
+        XCTAssertEqual(scale(segments, at: 15.0 - 0.001), 1.0, accuracy: 0.05)
+        XCTAssertEqual(scale(segments, at: 16.0), 1.0, accuracy: 0.001)
+    }
+
+    // MARK: - The frame moves once, not twice
+
+    /// **The centre travels with the scale.** `clamp` collapses the centre to the middle at 1×, so
+    /// the old dip also panned the picture to the centre of the screen and back out again. With no
+    /// dip the scale is continuous, and the anchor must be too — otherwise the join is a smooth
+    /// zoom with an instant jump sideways inside it.
+    func testTheCentreDoesNotJumpAtAJoin() {
+        let segments = [segment(5.0, 10.0, level: 2.0, at: CGPoint(x: 0.3, y: 0.3)),
+                        segment(10.0, 15.0, level: 2.0, at: CGPoint(x: 0.7, y: 0.7))]
+
+        let before = centre(segments, at: 9.98)
+        let after = centre(segments, at: 10.02)
+        XCTAssertEqual(before.x, after.x, accuracy: 0.02, "the frame jumped sideways at the join")
+        XCTAssertEqual(before.y, after.y, accuracy: 0.02)
+    }
+
+    /// And it arrives, rather than easing towards the old anchor forever.
+    func testTheCentreReachesTheNewAnchor() {
+        let segments = [segment(5.0, 10.0, level: 2.0, at: CGPoint(x: 0.3, y: 0.3)),
+                        segment(10.0, 15.0, level: 2.0, at: CGPoint(x: 0.7, y: 0.7))]
+
+        let settled = centre(segments, at: 12.0)
+        XCTAssertEqual(settled.x, 0.7, accuracy: 0.01)
+        XCTAssertEqual(settled.y, 0.7, accuracy: 0.01)
+    }
+
+    /// A held shot is not a moving one, so the renderer has nothing to blur across a gap where the
+    /// frame is standing still.
+    func testAHeldGapIsNotMoving() {
+        let segments = [segment(5.0, 10.0, level: 2.5),
+                        segment(10.4, 15.0, level: 1.4)]
+        XCTAssertFalse(ZoomResolver.transform(at: 10.2, segments: segments, cursor: nil,
+                                              frameSize: frame).isMoving)
+    }
+
+    // MARK: - A cut still wins
+
+    /// **A clip boundary must still make a zoom ease out.** Suppressing the ease-out at a join must
+    /// not suppress it at a cut, where the picture is about to jump to different material — that is
+    /// the pop the previous round fixed, and it would come straight back.
+    func testAZoomStillEasesOutAtACutEvenWithANeighbourAfterIt() {
+        let segments = [segment(5.0, 10.0, level: 2.5),
+                        segment(10.0, 15.0, level: 1.4)]
+
+        // The clip ends at 8.0, partway through the first segment.
+        let atTheCut = ZoomResolver.transform(at: 7.99, segments: segments, cursor: nil,
+                                              frameSize: frame, clipSource: 5.0..<8.0)
+        XCTAssertEqual(atTheCut.scale, 1.0, accuracy: 0.1,
+                       "the zoom did not ease out at the cut")
+    }
+
+    // MARK: - Order and disabling
+
+    /// Segments arriving out of order must not change which one is the neighbour.
+    func testTheNeighbourIsFoundRegardlessOfArrayOrder() {
+        let ordered = [segment(5.0, 10.0, level: 2.5), segment(10.0, 15.0, level: 1.4)]
+        let shuffled = [ordered[1], ordered[0]]
+        XCTAssertEqual(scale(shuffled, at: 10.2), scale(ordered, at: 10.2), accuracy: 0.001)
+    }
+
+    /// A disabled neighbour is not a neighbour — the frame has nothing to hold at, so it zooms out.
+    func testADisabledNeighbourDoesNotJoin() {
+        var disabled = segment(5.0, 10.0, level: 2.5)
+        disabled.isDisabled = true
+        let segments = [disabled, segment(10.4, 15.0, level: 1.4)]
+        XCTAssertEqual(scale(segments, at: 10.2), 1.0, accuracy: 0.01)
+    }
+}

--- a/Tests/SarvkritTests/ZoomLevelTests.swift
+++ b/Tests/SarvkritTests/ZoomLevelTests.swift
@@ -1,0 +1,182 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// How close the automatic zoom decides to go.
+///
+/// **"It only focuses on the cursor, it does not take into account where the cursor is."** Both
+/// halves were true and for a reason worth writing down. The level *was* derived from the
+/// activity's extent — zoom until it fills `targetCoverage` of the frame — but the extent was the
+/// bounding box of **click points only**, and a single click has no extent at all. Guarded by
+/// `max(box.width, 1)`, the arithmetic asked for a 600× zoom and took the ceiling. Typing was the
+/// same: a typing run carried exactly one cursor sample. So every isolated click and every typing
+/// burst landed on 2.5×, and a real recording read `2.50, 2.50, 2.50, 1.69, 1.38`.
+///
+/// The cursor was the one signal the planner never used. It does now — but only where the pointer
+/// *rested*, not where it travelled. Where somebody moved the mouse from is not what they are
+/// showing you.
+final class ZoomLevelTests: XCTestCase {
+
+    private let frame = CGSize(width: 1000, height: 1000)
+
+    private func click(_ t: TimeInterval, _ x: CGFloat, _ y: CGFloat) -> ClickEvent {
+        ClickEvent(t: t, point: CGPoint(x: x, y: y), button: .left, isDown: true, isInside: true)
+    }
+
+    /// A cursor track from `from` to `to` across `over` seconds, sampled at 20 Hz. The speed is
+    /// what decides whether these points count, so it is the parameter that matters.
+    private func track(from: CGPoint, to: CGPoint,
+                       start: TimeInterval, over: TimeInterval) -> [CursorSample] {
+        let steps = max(1, Int(over * 20))
+        return (0...steps).map { step in
+            let fraction = CGFloat(step) / CGFloat(steps)
+            return CursorSample(t: start + over * Double(step) / Double(steps),
+                                point: CGPoint(x: from.x + (to.x - from.x) * fraction,
+                                               y: from.y + (to.y - from.y) * fraction),
+                                kind: .arrow)
+        }
+    }
+
+    private func parked(at point: CGPoint, from: TimeInterval,
+                        over: TimeInterval) -> [CursorSample] {
+        track(from: point, to: point, start: from, over: over)
+    }
+
+    /// The recorder sets `isInside: false` whenever the pointer leaves the recorded region, which
+    /// happens constantly in area and window modes.
+    private func outside(_ samples: [CursorSample]) -> [CursorSample] {
+        samples.map {
+            CursorSample(t: $0.t, point: $0.point, kind: $0.kind, isInside: false)
+        }
+    }
+
+    private func level(_ log: EventLog) -> Double? {
+        ZoomPlanner.plan(events: log, frameSize: frame, duration: 60).first?.level
+    }
+
+    // MARK: - The pointer's own extent counts
+
+    /// A click with the pointer parked on it is a tight target, and still gets the closest zoom.
+    func testAClickWithTheCursorParkedOnItZoomsAllTheWay() {
+        let log = EventLog(cursor: parked(at: CGPoint(x: 500, y: 500), from: 3, over: 4),
+                           clicks: [click(5, 500, 500)])
+        XCTAssertEqual(level(log) ?? 0, ZoomPlanner.Tuning().levelRange.upperBound,
+                       accuracy: 0.001)
+    }
+
+    /// **The assertion that fails today.** The same click, but the pointer spent the surrounding
+    /// couple of seconds working slowly across a region — so the region is the subject, not the
+    /// click, and zooming to 2.5× would crop most of what was being shown.
+    func testAPointerWorkingAcrossARegionZoomsLessThanAClickAlone() {
+        let working = EventLog(
+            cursor: track(from: CGPoint(x: 300, y: 500), to: CGPoint(x: 700, y: 500),
+                          start: 3.8, over: 2),
+            clicks: [click(5, 500, 500)])
+        let still = EventLog(cursor: parked(at: CGPoint(x: 500, y: 500), from: 3, over: 4),
+                             clicks: [click(5, 500, 500)])
+
+        let spread = try? XCTUnwrap(level(working))
+        let tight = try? XCTUnwrap(level(still))
+        XCTAssertNotNil(spread)
+        XCTAssertLessThan(spread ?? 9, (tight ?? 0) - 0.2,
+                          "the pointer's own extent did not change the level")
+    }
+
+    /// And it lands where the arithmetic says: a 400pt-wide region in a 1000pt frame at 60%
+    /// coverage is 1.5×.
+    func testTheLevelFollowsTheRegionTheCursorCovered() {
+        let log = EventLog(
+            cursor: track(from: CGPoint(x: 300, y: 500), to: CGPoint(x: 700, y: 500),
+                          start: 3.8, over: 2),
+            clicks: [click(5, 500, 500)])
+        XCTAssertEqual(level(log) ?? 0, 1.5, accuracy: 0.15)
+    }
+
+    // MARK: - Travelling is not attending
+
+    /// **Where somebody moved the mouse from is not what they are showing you.** A fling across
+    /// the screen to reach a button says nothing about the subject, and counting it would drag the
+    /// box out to the full width and cancel the zoom on almost every click.
+    func testAFastSweepToTheTargetIsIgnored() {
+        let flung = EventLog(
+            cursor: track(from: CGPoint(x: 60, y: 500), to: CGPoint(x: 940, y: 500),
+                          start: 4.6, over: 0.25)
+                + parked(at: CGPoint(x: 940, y: 500), from: 4.85, over: 1),
+            clicks: [click(5, 940, 500)])
+
+        XCTAssertEqual(level(flung) ?? 0, ZoomPlanner.Tuning().levelRange.upperBound,
+                       accuracy: 0.001,
+                       "a fast sweep was counted as part of the subject")
+    }
+
+    /// The distinction is speed and nothing else, so the same two endpoints crossed slowly do
+    /// count. Without this the test above would pass by ignoring the cursor entirely.
+    func testTheSameTravelDoneSlowlyDoesCount() {
+        let slow = EventLog(
+            cursor: track(from: CGPoint(x: 300, y: 500), to: CGPoint(x: 700, y: 500),
+                          start: 3.8, over: 2),
+            clicks: [click(5, 500, 500)])
+        let fast = EventLog(
+            cursor: track(from: CGPoint(x: 300, y: 500), to: CGPoint(x: 700, y: 500),
+                          start: 4.9, over: 0.15)
+                + parked(at: CGPoint(x: 700, y: 500), from: 5.05, over: 1),
+            clicks: [click(5, 500, 500)])
+
+        XCTAssertLessThan(level(slow) ?? 9, level(fast) ?? 0)
+    }
+
+    /// A pointer outside the recorded region is not evidence about anything on screen — the same
+    /// rule the click path already applies with its own `isInside` flag.
+    func testCursorSamplesOutsideTheRecordingAreIgnored() {
+        let log = EventLog(
+            cursor: outside(parked(at: CGPoint(x: -400, y: 500), from: 3.8, over: 2))
+                + parked(at: CGPoint(x: 500, y: 500), from: 4.9, over: 0.2),
+            clicks: [click(5, 500, 500)])
+        XCTAssertEqual(level(log) ?? 0, ZoomPlanner.Tuning().levelRange.upperBound,
+                       accuracy: 0.001)
+    }
+
+    // MARK: - Typing gets the same treatment
+
+    /// A typing run used to carry exactly one cursor sample, so it always landed on the ceiling
+    /// regardless of what the pointer was doing around it.
+    func testATypingRunReadsTheCursorTooRatherThanOneSample() {
+        let keys = (0..<8).map {
+            KeyEvent(t: 5 + Double($0) * 0.2, label: "a", isModifierCombination: false)
+        }
+        // A 400pt spread: wide enough that the coverage rule asks for 1.5× rather than the
+        // ceiling, and narrow enough that it is not floored back up to still-a-zoom. Both bounds
+        // matter, and a spread outside them would make this test pass or fail for the wrong reason.
+        let spread = EventLog(
+            cursor: track(from: CGPoint(x: 300, y: 500), to: CGPoint(x: 700, y: 500),
+                          start: 4, over: 3),
+            keys: keys)
+        let still = EventLog(cursor: parked(at: CGPoint(x: 500, y: 500), from: 4, over: 3),
+                             keys: keys)
+
+        XCTAssertLessThan(level(spread) ?? 9, (level(still) ?? 0) - 0.2)
+    }
+
+    // MARK: - Nothing regressed
+
+    /// With no cursor track at all the planner falls back to the clicks, which is what every
+    /// existing planner test relies on and what a log from a build that recorded no cursor has.
+    func testWithNoCursorTrackTheClicksStillDecide() {
+        XCTAssertEqual(level(EventLog(clicks: [click(5, 500, 500)])) ?? 0,
+                       ZoomPlanner.Tuning().levelRange.upperBound, accuracy: 0.001)
+    }
+
+    func testEveryLevelStaysInsideTheAllowedRange() {
+        let clicks = (0..<20).map { click(Double($0) * 2, CGFloat($0 * 47 % 1000), 500) }
+        let cursor: [CursorSample] = (0..<400).map { step in
+            let x = CGFloat((step * 13) % 1000)
+            let y = CGFloat((step * 7) % 1000)
+            return CursorSample(t: Double(step) * 0.1, point: CGPoint(x: x, y: y), kind: .arrow)
+        }
+        let tuning = ZoomPlanner.Tuning()
+        for segment in ZoomPlanner.plan(events: EventLog(cursor: cursor, clicks: clicks),
+                                        frameSize: frame, duration: 60) {
+            XCTAssertTrue(tuning.levelRange.contains(segment.level), "\(segment.level)")
+        }
+    }
+}

--- a/Tests/SarvkritTests/ZoomPlannerTests.swift
+++ b/Tests/SarvkritTests/ZoomPlannerTests.swift
@@ -236,9 +236,15 @@ final class ZoomPlannerTests: XCTestCase {
     }
 
     /// The case that must keep working: a tight cluster still earns a real close-up.
+    /// Asserted against the top of the range rather than against a number.
+    ///
+    /// **It used to say `> 2`, which stopped being true when the ceiling came down to 2.0** — and
+    /// the ceiling coming down was the point of that change, not a regression. What "properly"
+    /// means here is "as close as the planner is allowed to go", so that is what it now says.
     func testATightClusterStillZoomsProperly() {
         let tight = (0..<4).map { click(5 + Double($0) * 0.3, 500, 500) }
         let segment = plan(EventLog(clicks: tight)).first
-        XCTAssertGreaterThan(segment?.level ?? 0, 2)
+        XCTAssertEqual(segment?.level ?? 0, ZoomPlanner.Tuning().levelRange.upperBound,
+                       accuracy: 0.001)
     }
 }

--- a/Tests/SarvkritTests/ZoomPlannerTests.swift
+++ b/Tests/SarvkritTests/ZoomPlannerTests.swift
@@ -1,0 +1,181 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// Deciding where and when to zoom, from the event log alone.
+///
+/// This is the taste, and taste needs to be adjustable without touching anything that draws — so
+/// it is a pure function over clicks and keystrokes with every threshold named in one struct, the
+/// same shape `AutoBalance` and `RuleMatcher` already use. No video, no AV types, no main actor.
+final class ZoomPlannerTests: XCTestCase {
+
+    private let frame = CGSize(width: 1000, height: 1000)
+
+    private func click(_ t: TimeInterval, _ x: CGFloat, _ y: CGFloat,
+                       inside: Bool = true) -> ClickEvent {
+        ClickEvent(t: t, point: CGPoint(x: x, y: y), button: .left, isDown: true, isInside: inside)
+    }
+
+    private func plan(_ log: EventLog, duration: TimeInterval = 60) -> [ZoomSegment] {
+        ZoomPlanner.plan(events: log, frameSize: frame, duration: duration)
+    }
+
+    // MARK: - Nothing to do
+
+    func testAnEmptyLogPlansNoZooms() {
+        XCTAssertTrue(plan(EventLog()).isEmpty)
+    }
+
+    /// A recording of someone reading has clicks nowhere. Inventing zooms for it would be worse
+    /// than leaving it alone.
+    func testALogWithNoClicksOrKeysPlansNoZooms() {
+        let cursor = (0..<50).map {
+            CursorSample(t: Double($0) * 0.1, point: CGPoint(x: 500, y: 500))
+        }
+        XCTAssertTrue(plan(EventLog(cursor: cursor)).isEmpty)
+    }
+
+    /// Clicks that landed outside the recorded region aim at nothing, which is what a multi-display
+    /// recording produces constantly.
+    func testClicksOutsideTheRecordedRegionAreIgnored() {
+        XCTAssertTrue(plan(EventLog(clicks: [click(5, 10, 10, inside: false)])).isEmpty)
+    }
+
+    // MARK: - Clustering
+
+    func testASingleClickPlansOneZoom() {
+        XCTAssertEqual(plan(EventLog(clicks: [click(5, 500, 500)])).count, 1)
+    }
+
+    /// Clicking twice on the same button is one action, not two, and zooming out and back in
+    /// between them is the single most nauseating thing this feature could do.
+    func testTwoClicksCloseInTimeAndSpaceAreOneZoom() {
+        let log = EventLog(clicks: [click(5, 500, 500), click(5.4, 540, 520)])
+        XCTAssertEqual(plan(log).count, 1)
+    }
+
+    func testTwoClicksFarApartInTimeAreTwoZooms() {
+        let log = EventLog(clicks: [click(5, 500, 500), click(35, 520, 510)])
+        XCTAssertEqual(plan(log).count, 2)
+    }
+
+    // MARK: - Level
+
+    /// A single click has no extent, so it gets as close as the planner is allowed to go.
+    func testATightActivityZoomsAsFarAsAllowed() {
+        let segment = plan(EventLog(clicks: [click(5, 500, 500)])).first
+        XCTAssertEqual(segment?.level ?? 0, ZoomPlanner.Tuning().levelRange.upperBound,
+                       accuracy: 0.0001)
+    }
+
+    /// A drag across most of the screen cannot be zoomed into without hiding half of itself.
+    func testAWideActivityBarelyZoomsAtAll() {
+        let clicks = stride(from: CGFloat(100), through: 820, by: 180).enumerated().map {
+            click(5 + Double($0.offset) * 0.3, $0.element, 500)
+        }
+        let segment = plan(EventLog(clicks: clicks)).first
+        XCTAssertEqual(segment?.level ?? 0, ZoomPlanner.Tuning().levelRange.lowerBound,
+                       accuracy: 0.0001)
+    }
+
+    func testEveryPlannedLevelStaysInsideTheAllowedRange() {
+        let clicks = (0..<30).map { click(Double($0) * 2, CGFloat($0 * 31 % 1000), 500) }
+        let tuning = ZoomPlanner.Tuning()
+        for segment in plan(EventLog(clicks: clicks)) {
+            XCTAssertTrue(tuning.levelRange.contains(segment.level), "\(segment.level)")
+        }
+    }
+
+    // MARK: - Anchor
+
+    /// Following a pointer that barely moves reads as drift, so a still activity is pinned.
+    func testAStillActivityIsAnchoredInPlace() {
+        guard case .fixed = plan(EventLog(clicks: [click(5, 500, 500)])).first?.anchor else {
+            return XCTFail("a single click should be anchored, not followed")
+        }
+    }
+
+    func testAMovingActivityFollowsTheCursor() {
+        let clicks = stride(from: CGFloat(100), through: 820, by: 180).enumerated().map {
+            click(5 + Double($0.offset) * 0.3, $0.element, 500)
+        }
+        guard case .followCursor = plan(EventLog(clicks: clicks)).first?.anchor else {
+            return XCTFail("a wide drag should follow the cursor")
+        }
+    }
+
+    /// Anchors are normalised so they survive a change of export resolution.
+    func testAFixedAnchorIsNormalisedToTheFrame() {
+        guard case .fixed(let point) = plan(EventLog(clicks: [click(5, 250, 750)])).first?.anchor
+        else { return XCTFail("expected a fixed anchor") }
+        XCTAssertEqual(point.x, 0.25, accuracy: 0.01)
+        XCTAssertEqual(point.y, 0.75, accuracy: 0.01)
+    }
+
+    // MARK: - Structure
+
+    func testSegmentsComeBackSortedByStart() {
+        let clicks = [click(30, 100, 100), click(5, 500, 500), click(50, 900, 900)]
+        let starts = plan(EventLog(clicks: clicks)).map(\.start)
+        XCTAssertEqual(starts, starts.sorted())
+    }
+
+    /// Overlapping segments have no defined transform, so the renderer would pick one arbitrarily
+    /// and the zoom would flicker between them.
+    func testSegmentsNeverOverlap() {
+        let clicks = (0..<40).map { click(Double($0) * 0.7, CGFloat($0 * 47 % 1000), 500) }
+        let segments = plan(EventLog(clicks: clicks))
+        for (a, b) in zip(segments, segments.dropFirst()) {
+            XCTAssertLessThanOrEqual(a.end, b.start, "segments overlap")
+        }
+    }
+
+    func testSegmentsStayInsideTheRecording() {
+        let clicks = [click(0.05, 500, 500), click(29.9, 500, 500)]
+        for segment in plan(EventLog(clicks: clicks), duration: 30) {
+            XCTAssertGreaterThanOrEqual(segment.start, 0)
+            XCTAssertLessThanOrEqual(segment.end, 30)
+        }
+    }
+
+    /// `isAutomatic` is what lets "Re-detect zooms" replace generated segments while leaving
+    /// hand-made ones alone. Without it the button cannot be pressed twice without losing work.
+    func testEveryPlannedSegmentIsMarkedAutomatic() {
+        let clicks = (0..<10).map { click(Double($0) * 4, 500, 500) }
+        XCTAssertTrue(plan(EventLog(clicks: clicks)).allSatisfy(\.isAutomatic))
+    }
+
+    /// A zoom shorter than the eye takes to arrive is worse than no zoom. This is the rule that
+    /// stops a click-heavy demo feeling frantic.
+    func testNoPlannedSegmentIsShorterThanTheMinimum() {
+        let clicks = (0..<20).map { click(Double($0) * 1.1, CGFloat($0 * 91 % 1000), 500) }
+        let tuning = ZoomPlanner.Tuning()
+        for segment in plan(EventLog(clicks: clicks)) {
+            XCTAssertGreaterThanOrEqual(segment.end - segment.start, tuning.minimumActivity)
+        }
+    }
+
+    /// A click storm must not become a zoom storm.
+    func testAClickStormIsCappedInDensity() {
+        let clicks = (0..<60).map { click(Double($0) * 0.5, CGFloat($0 * 37 % 1000), 500) }
+        let segments = plan(EventLog(clicks: clicks), duration: 30)
+        XCTAssertLessThanOrEqual(segments.count, Int(30 / ZoomPlanner.Tuning().minimumSpacing) + 1)
+    }
+
+    // MARK: - Typing
+
+    /// The most common thing in a software demo is filling something in, and it produces no clicks
+    /// at all. A planner that only watches the mouse ignores it entirely.
+    func testATypingBurstPlansAZoom() {
+        let keys = (0..<8).map {
+            KeyEvent(t: 10 + Double($0) * 0.15, label: "A", isModifierCombination: false)
+        }
+        let cursor = [CursorSample(t: 10, point: CGPoint(x: 400, y: 400))]
+        XCTAssertEqual(plan(EventLog(cursor: cursor, keys: keys)).count, 1)
+    }
+
+    func testAStrayKeypressDoesNotPlanAZoom() {
+        let keys = [KeyEvent(t: 10, label: "A", isModifierCombination: false)]
+        XCTAssertTrue(plan(EventLog(keys: keys)).isEmpty)
+    }
+}

--- a/Tests/SarvkritTests/ZoomPlannerTests.swift
+++ b/Tests/SarvkritTests/ZoomPlannerTests.swift
@@ -68,14 +68,18 @@ final class ZoomPlannerTests: XCTestCase {
                        accuracy: 0.0001)
     }
 
-    /// A drag across most of the screen cannot be zoomed into without hiding half of itself.
-    func testAWideActivityBarelyZoomsAtAll() {
+    /// A drag across most of the screen cannot be zoomed into without hiding half of itself — so
+    /// it gets no zoom at all rather than a token one.
+    ///
+    /// **This used to assert the level clamped to the floor.** That was the implementation
+    /// showing through: a 1.2× zoom held over a wide drag is not a close-up, it is a slow drift
+    /// the viewer has to follow for nothing. A real recording produced exactly that and it was
+    /// the worst thing about the output.
+    func testAWideActivityGetsNoZoomAtAll() {
         let clicks = stride(from: CGFloat(100), through: 820, by: 180).enumerated().map {
             click(5 + Double($0.offset) * 0.3, $0.element, 500)
         }
-        let segment = plan(EventLog(clicks: clicks)).first
-        XCTAssertEqual(segment?.level ?? 0, ZoomPlanner.Tuning().levelRange.lowerBound,
-                       accuracy: 0.0001)
+        XCTAssertTrue(plan(EventLog(clicks: clicks)).isEmpty)
     }
 
     func testEveryPlannedLevelStaysInsideTheAllowedRange() {
@@ -95,12 +99,14 @@ final class ZoomPlannerTests: XCTestCase {
         }
     }
 
+    /// Moves enough to be worth following — a quarter of the frame — but stays tight enough to
+    /// earn a real zoom. Anything wider than that now produces no segment to have an anchor.
     func testAMovingActivityFollowsTheCursor() {
-        let clicks = stride(from: CGFloat(100), through: 820, by: 180).enumerated().map {
+        let clicks = stride(from: CGFloat(300), through: 540, by: 80).enumerated().map {
             click(5 + Double($0.offset) * 0.3, $0.element, 500)
         }
         guard case .followCursor = plan(EventLog(clicks: clicks)).first?.anchor else {
-            return XCTFail("a wide drag should follow the cursor")
+            return XCTFail("a moving activity should follow the cursor")
         }
     }
 
@@ -177,5 +183,62 @@ final class ZoomPlannerTests: XCTestCase {
     func testAStrayKeypressDoesNotPlanAZoom() {
         let keys = [KeyEvent(t: 10, label: "A", isModifierCombination: false)]
         XCTAssertTrue(plan(EventLog(keys: keys)).isEmpty)
+    }
+
+    // MARK: - Zooms that would be worse than nothing
+
+    /// **From a real recording.** Twenty-eight clicks spread across a twelve-second demo produced
+    /// one eleven-second segment at 1.2× — the floor — because every activity touched its
+    /// neighbour and the merged bounding box covered most of the screen. A zoom that barely zooms,
+    /// held for the whole video, is visual noise: it is not a close-up, it is a slow drift.
+    func testClicksAllOverTheScreenPlanNoZoomRatherThanOneUselessOne() {
+        let scattered = (0..<28).map { index -> ClickEvent in
+            let t: TimeInterval = 0.2 + Double(index) * 0.42
+            let x: CGFloat = CGFloat(80 + (index * 137) % 840)
+            let y: CGFloat = CGFloat(60 + (index * 211) % 880)
+            return click(t, x, y)
+        }
+        let planned = plan(EventLog(clicks: scattered), duration: 12.4)
+        for segment in planned {
+            XCTAssertGreaterThan(segment.level, ZoomPlanner.Tuning().levelRange.lowerBound + 0.01,
+                                 "a zoom was planned that barely zooms")
+        }
+    }
+
+    /// One segment covering nearly the whole recording is not a zoom, it is a crop — and it is
+    /// what the merge rules produced before they were capped.
+    func testNoSegmentSwallowsTheWholeRecording() {
+        let busy = (0..<28).map { index -> ClickEvent in
+            let t: TimeInterval = 0.2 + Double(index) * 0.42
+            let x: CGFloat = CGFloat(80 + (index * 137) % 840)
+            return click(t, x, 500)
+        }
+        for segment in plan(EventLog(clicks: busy), duration: 12.4) {
+            XCTAssertLessThan(segment.duration, 12.4 * 0.8,
+                              "one segment covered almost the entire recording")
+        }
+    }
+
+    /// Activity that genuinely continues should still be capped, so a five-minute demo of steady
+    /// clicking does not become one five-minute zoom.
+    func testAContinuousStreamOfClicksIsBrokenIntoSeveralZooms() {
+        let steady = (0..<80).map { index -> ClickEvent in
+            let t: TimeInterval = 1 + Double(index) * 0.5
+            let x: CGFloat = 500 + CGFloat((index % 3) * 20)
+            return click(t, x, 500)
+        }
+        let planned = plan(EventLog(clicks: steady), duration: 45)
+        XCTAssertGreaterThan(planned.count, 1, "continuous clicking became one endless zoom")
+        for segment in planned {
+            XCTAssertLessThanOrEqual(segment.duration,
+                                     ZoomPlanner.Tuning().maximumActivity + 0.01)
+        }
+    }
+
+    /// The case that must keep working: a tight cluster still earns a real close-up.
+    func testATightClusterStillZoomsProperly() {
+        let tight = (0..<4).map { click(5 + Double($0) * 0.3, 500, 500) }
+        let segment = plan(EventLog(clicks: tight)).first
+        XCTAssertGreaterThan(segment?.level ?? 0, 2)
     }
 }

--- a/Tests/SarvkritTests/ZoomResolverTests.swift
+++ b/Tests/SarvkritTests/ZoomResolverTests.swift
@@ -1,0 +1,158 @@
+import CoreGraphics
+import XCTest
+@testable import Sarvkrit
+
+/// Turning a list of zoom segments into the one transform a frame is drawn with.
+///
+/// **The clamp is the part that must not be got wrong.** A zoomed frame whose centre drifts past
+/// the edge of the recording shows background through the middle of the picture — which looks like
+/// a rendering fault, not a framing choice — so the centre is always pulled back inside.
+final class ZoomResolverTests: XCTestCase {
+
+    private let frame = CGSize(width: 1000, height: 1000)
+
+    private func resolve(_ segments: [ZoomSegment], at t: TimeInterval,
+                         cursor: CGPoint? = nil) -> ZoomTransform {
+        ZoomResolver.transform(at: t, segments: segments, cursor: cursor, frameSize: frame)
+    }
+
+    private func segment(_ start: TimeInterval, _ end: TimeInterval, level: Double = 2,
+                         anchor: ZoomSegment.Anchor = .fixed(CGPoint(x: 0.5, y: 0.5)))
+        -> ZoomSegment {
+        ZoomSegment(start: start, end: end, level: level, anchor: anchor)
+    }
+
+    // MARK: - Nothing to do
+
+    func testWithNoZoomsTheFrameIsUntouched() {
+        let transform = resolve([], at: 5)
+        XCTAssertEqual(transform.scale, 1, accuracy: 0.0001)
+        XCTAssertEqual(transform.center.x, 0.5, accuracy: 0.0001)
+    }
+
+    func testBeforeAnySegmentTheFrameIsUntouched() {
+        XCTAssertEqual(resolve([segment(10, 20)], at: 0).scale, 1, accuracy: 0.0001)
+    }
+
+    func testAfterEverySegmentTheFrameIsBack() {
+        XCTAssertEqual(resolve([segment(1, 2)], at: 30).scale, 1, accuracy: 0.0001)
+    }
+
+    // MARK: - Easing
+
+    func testAtTheStartOfASegmentTheZoomHasNotBegun() {
+        XCTAssertEqual(resolve([segment(5, 10)], at: 5).scale, 1, accuracy: 0.001)
+    }
+
+    func testTheZoomIsFullyInAfterItsEase() {
+        let one = segment(5, 10)
+        XCTAssertEqual(resolve([one], at: 5 + one.easeIn + 0.01).scale, 2, accuracy: 0.01)
+    }
+
+    func testTheZoomIsPartlyInDuringItsEase() {
+        let one = segment(5, 10)
+        let scale = resolve([one], at: 5 + one.easeIn / 2).scale
+        XCTAssertGreaterThan(scale, 1)
+        XCTAssertLessThan(scale, 2)
+    }
+
+    func testTheZoomIsBackOutByTheEnd() {
+        XCTAssertEqual(resolve([segment(5, 10)], at: 10).scale, 1, accuracy: 0.01)
+    }
+
+    /// A zoom that begins on frame zero opens already zoomed. Nobody wants their video to start by
+    /// moving; if the first thing to show is a close-up, it should simply be there.
+    func testAZoomStartingAtZeroOpensAlreadyZoomed() {
+        XCTAssertEqual(resolve([segment(0, 10)], at: 0).scale, 2, accuracy: 0.01)
+    }
+
+    func testADisabledSegmentDoesNothing() {
+        var one = segment(5, 10)
+        one.isDisabled = true
+        XCTAssertEqual(resolve([one], at: 7).scale, 1, accuracy: 0.0001)
+    }
+
+    func testAnInstantSegmentIsAtFullLevelImmediately() {
+        var one = segment(5, 10)
+        one.ease = .instant
+        XCTAssertEqual(resolve([one], at: 5.001).scale, 2, accuracy: 0.01)
+    }
+
+    // MARK: - Clamping
+
+    /// At 1x the whole frame is visible, so there is only one legal centre.
+    func testAtNoZoomTheCentreIsTheCentre() {
+        let one = segment(5, 10, level: 1, anchor: .fixed(CGPoint(x: 0, y: 0)))
+        let transform = resolve([one], at: 7)
+        XCTAssertEqual(transform.center.x, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(transform.center.y, 0.5, accuracy: 0.0001)
+    }
+
+    /// An anchor in the corner would show background through the frame. It is pulled in to the
+    /// nearest legal position instead.
+    func testAnAnchorInTheCornerIsPulledInside() {
+        let one = segment(0, 10, level: 2, anchor: .fixed(CGPoint(x: 0, y: 0)))
+        let transform = resolve([one], at: 5)
+        XCTAssertEqual(transform.center.x, 0.25, accuracy: 0.001)
+        XCTAssertEqual(transform.center.y, 0.25, accuracy: 0.001)
+    }
+
+    func testAnAnchorAtTheFarCornerIsPulledInsideToo() {
+        let one = segment(0, 10, level: 2, anchor: .fixed(CGPoint(x: 1, y: 1)))
+        let transform = resolve([one], at: 5)
+        XCTAssertEqual(transform.center.x, 0.75, accuracy: 0.001)
+    }
+
+    func testACentredAnchorIsLeftAlone() {
+        let one = segment(0, 10, level: 4, anchor: .fixed(CGPoint(x: 0.5, y: 0.5)))
+        XCTAssertEqual(resolve([one], at: 5).center.x, 0.5, accuracy: 0.001)
+    }
+
+    /// The invariant, over every level and every anchor: the visible rectangle stays inside the
+    /// recording. This is the one that catches a clamp written for the wrong axis.
+    func testTheVisibleRectangleNeverLeavesTheRecording() {
+        for level in stride(from: 1.0, through: 4.0, by: 0.25) {
+            for x in stride(from: -0.5, through: 1.5, by: 0.1) {
+                let one = segment(0, 10, level: level,
+                                  anchor: .fixed(CGPoint(x: x, y: x)))
+                let transform = resolve([one], at: 5)
+                let half = 0.5 / transform.scale
+                XCTAssertGreaterThanOrEqual(transform.center.x - half, -0.0001, "\(level) \(x)")
+                XCTAssertLessThanOrEqual(transform.center.x + half, 1.0001, "\(level) \(x)")
+            }
+        }
+    }
+
+    // MARK: - Following
+
+    func testAFollowingSegmentUsesTheCursor() {
+        let one = segment(0, 10, level: 2, anchor: .followCursor)
+        let transform = resolve([one], at: 5, cursor: CGPoint(x: 700, y: 700))
+        XCTAssertGreaterThan(transform.center.x, 0.5)
+    }
+
+    /// With no cursor there is nothing to follow, and the middle is the only honest answer.
+    func testAFollowingSegmentWithNoCursorCentresItself() {
+        let one = segment(0, 10, level: 2, anchor: .followCursor)
+        XCTAssertEqual(resolve([one], at: 5, cursor: nil).center.x, 0.5, accuracy: 0.001)
+    }
+
+    /// Inside the dead zone the frame is still. Tracking a pointer that has barely moved reads as
+    /// drift, and drift over a whole demo is what makes people feel seasick.
+    func testASmallCursorMovementDoesNotMoveTheFrame() {
+        let one = segment(0, 10, level: 2, anchor: .followCursor)
+        let centre = resolve([one], at: 5, cursor: CGPoint(x: 500, y: 500)).center
+        let nudged = resolve([one], at: 5, cursor: CGPoint(x: 540, y: 500)).center
+        XCTAssertEqual(centre.x, nudged.x, accuracy: 0.001)
+    }
+
+    // MARK: - Motion
+
+    /// The renderer blurs the frame only while the transform is actually travelling, so a static
+    /// zoomed shot costs nothing.
+    func testTheTransformSaysWhenItIsMoving() {
+        let one = segment(5, 10)
+        XCTAssertTrue(resolve([one], at: 5 + one.easeIn / 2).isMoving)
+        XCTAssertFalse(resolve([one], at: 7.5).isMoving)
+    }
+}

--- a/Tests/SarvkritTests/ZoomResolverTests.swift
+++ b/Tests/SarvkritTests/ZoomResolverTests.swift
@@ -155,4 +155,44 @@ final class ZoomResolverTests: XCTestCase {
         XCTAssertTrue(resolve([one], at: 5 + one.easeIn / 2).isMoving)
         XCTAssertFalse(resolve([one], at: 7.5).isMoving)
     }
+
+    // MARK: - Cuts
+
+    /// **A zoom that straddles a cut must ease out at the cut, not snap.**
+    ///
+    /// Source time is not monotonic in output time once the edit has a cut in it: the frame after a
+    /// boundary can come from anywhere in the recording. A ramp measured from the segment's own end
+    /// is therefore still mid-flight when the picture jumps, and the zoom pops.
+    ///
+    /// This is a defect today rather than one reordering introduces — any ripple-delete already
+    /// creates that discontinuity — but reordering makes it happen at every cut instead of
+    /// occasionally, so it is fixed here.
+    func testAZoomEasesOutAtACutRatherThanSnapping() {
+        // A zoom running 8…12, on a clip whose material stops at 10.
+        let zoomed = ZoomResolver.transform(at: 9, segments: [segment(8, 12)], cursor: nil,
+                                            frameSize: frame, clipSource: 0..<10)
+        let atTheCut = ZoomResolver.transform(at: 9.99, segments: [segment(8, 12)], cursor: nil,
+                                              frameSize: frame, clipSource: 0..<10)
+
+        XCTAssertGreaterThan(zoomed.scale, 1.5, "the zoom should be in by the middle of the clip")
+        XCTAssertEqual(atTheCut.scale, 1, accuracy: 0.05,
+                       "the zoom was still mid-ramp at the cut, so it snaps")
+    }
+
+    /// And a clip that begins inside a zoom opens already zoomed, rather than ramping in from
+    /// nothing just after a cut — which would read as a mistake. Same reasoning as a zoom that
+    /// begins on frame zero.
+    func testAClipThatBeginsInsideAZoomOpensAlreadyZoomed() {
+        let transform = ZoomResolver.transform(at: 9.05, segments: [segment(8, 12)], cursor: nil,
+                                               frameSize: frame, clipSource: 9..<12)
+        XCTAssertEqual(transform.scale, 2, accuracy: 0.0001)
+    }
+
+    /// With no clip range the arithmetic is exactly what it always was, so nothing that does not
+    /// cut is affected.
+    func testWithoutAClipRangeNothingChanges() {
+        let withRange = ZoomResolver.transform(at: 9, segments: [segment(8, 12)], cursor: nil,
+                                               frameSize: frame, clipSource: nil)
+        XCTAssertEqual(withRange.scale, resolve([segment(8, 12)], at: 9).scale, accuracy: 0.0001)
+    }
 }

--- a/docs/superpowers/specs/2026-09-05-screen-recording-studio-design.md
+++ b/docs/superpowers/specs/2026-09-05-screen-recording-studio-design.md
@@ -1,0 +1,1998 @@
+# Screen Studio in Sarvkrit — implementation plan
+
+*Working title for the feature: **Screen Recording** (Capture category). Codenamed `Studio` in
+source paths. This document is the approved design; the implementation plan it describes is carried
+out one phase per branch, one branch per pull request.*
+
+---
+
+## Context
+
+Sarvkrit already does the hard half of this. `Features/Screenshots` has ScreenCaptureKit behind a
+testable protocol, a frozen-screen selection overlay, a window picker, a countdown, and — the part
+that matters most — a complete **"put the capture on a beautiful background"** compositor:
+`CaptureBackground` (mesh/gradient/solid/image/blurred fills, padding, corner radius, two-layer
+shadow, inset, alignment, aspect targets), `BackgroundLayout` (pure layout maths),
+`BackgroundCompositor` (the drawing), `MeshRenderer` (dithered mesh gradients), `AutoBalance`
+(pick a background from the shot's own colours).
+
+Screen Studio is, structurally, that same compositor **with a time axis** — plus a recorder that
+captures not just pixels but *what the user did*, so the editor can re-render the cursor, invent
+zooms and draw captions after the fact.
+
+What is missing is: a video recorder, an event log, a project document, a time-varying renderer, an
+export pipeline, and an editor window with a timeline. This plan covers all of it.
+
+The goal is parity with Screen Studio on the things that make it feel magic — automatic zoom,
+re-rendered cursor with motion blur, karaoke captions, one-click gorgeous backgrounds — held to
+Sarvkrit's existing standards: pure testable decision logic, no network, per-feature permissions,
+and prose in the codebase that explains *why*.
+
+> **Companion document.** A full feature inventory of Screen Studio 3.7.5 — primary sources, its
+> reverse-engineered project schema, its version history and its explicit absences — is at
+> `2026-09-05-screen-studio-feature-inventory.md` beside this file. Every claim about "the
+> reference" below traces to it. Read it before implementing any feature whose details matter.
+
+---
+
+## Where the work happens
+
+**A dedicated worktree, not this checkout.** This session sits on `feature/update-check`, and
+`origin/main` is already 4 commits ahead of it *and* contains it — so `origin/main` is the base.
+
+```sh
+git worktree add /Users/apple/Documents/Dev/sarvkrit_wt/studio -b feature/studio origin/main
+cd /Users/apple/Documents/Dev/sarvkrit_wt/studio
+xcodegen generate          # Sarvkrit.xcodeproj is gitignored; nothing builds without this
+```
+
+Directory name is the branch's last path component, matching every existing worktree
+(`tray-panel-resize`, `panel-overhaul`, `screenshots`, …). Outside the repo, so no `.gitignore`
+entry is needed.
+
+Three things that bite in a fresh Sarvkrit worktree, all of which look like build failures and are
+not:
+
+1. **Re-run `xcodegen generate` every time a source file is added.** This plan adds roughly forty.
+   Skipping it fails with "cannot find X in scope", which reads as a typo.
+2. **Quit `/Applications/Sarvkrit.app` before `make test`.** `LSMultipleInstancesProhibited` makes
+   LaunchServices refuse the test host with a bare "Could not launch SarvkritTests". The `test`
+   target already `pkill`s for this reason.
+3. **Check *which* Sarvkrit is running before believing what the app shows you.** With a dozen
+   worktrees around, a dev build left running from another one holds the single-instance slot and
+   a freshly launched copy exits silently. `pgrep -lf "Sarvkrit.app/Contents/MacOS/Sarvkrit"`
+   prints the full path.
+
+### Branch and PR strategy
+
+`main` takes no direct pushes — server-enforced — and the owner merges every PR. Seven phases in one
+pull request would be unreviewable, so:
+
+| Branch | Base | Contents |
+|---|---|---|
+| `feature/studio` | `origin/main` | The integration branch. Never merged as a whole. |
+| `feature/studio-recording` | `origin/main` | Phase 1. First PR. |
+| `feature/studio-cursor` | `origin/main` | Phase 2, once Phase 1 has merged. |
+| `feature/studio-zoom` | … | Phase 3. |
+| … | | one branch, one worktree, one PR per phase |
+
+Each phase branch gets its own worktree under `sarvkrit_wt/` and is rebased on `origin/main` before
+its PR. Each PR must pass `make test` locally, fill in the template's *What changed / Why / How it
+was verified*, and carry its own tests — the phases are ordered so every one of them is
+independently shippable.
+
+The design document is committed on the first branch, at
+`docs/superpowers/specs/2026-09-05-screen-recording-studio-design.md`.
+
+---
+
+## The one idea everything else follows from
+
+**A Sarvkrit recording is not a video. It is a bundle.**
+
+```
+Meeting demo.sarvrec/            ← the recording (immutable, written once)
+  screen.mov                     ← HEVC, showsCursor = false, no zoom, no background
+  camera.mov                     ← optional, separate file, its own clock offset
+  mic.m4a                        ← optional
+  system.m4a                     ← optional
+  events.json                    ← the whole point (see below)
+  manifest.json                  ← displays, scale, source rect, clock epoch, versions
+```
+
+`events.json` is a timestamped log recorded *alongside* the video:
+
+| Event | Fields | Used by |
+|---|---|---|
+| `cursorMoved` | `t`, `point` (global pt), `cursorType` | cursor layer, auto-zoom |
+| `mouseDown` / `mouseUp` | `t`, `point`, `button` | click effect, auto-zoom, auto-cut |
+| `scrolled` | `t`, `point`, `delta` | auto-zoom damping |
+| `keyDown` | `t`, `keyLabel`, `modifiers` | keystroke layer |
+| `appActivated` | `t`, `bundleID`, `name` | chapter markers |
+| `windowMoved` | `t`, `windowID`, `frame` | window-follow crop |
+| `displayChanged` | `t`, `displayID`, `frame` | multi-display safety |
+
+Because the cursor is **not baked into the video**, the editor can draw it at any size, smooth it,
+give it motion blur, swap the glyph, and — critically — keep it sharp when the frame is zoomed 2×.
+This is the single difference between "a screen recording with a filter" and Screen Studio.
+
+**The editor is a non-destructive compositor.** One pure function:
+
+```swift
+StudioRenderer.frame(of project: StudioProject, at t: CMTime, sources: FrameSources) -> CGImage
+```
+
+Preview and export call the same function. If they can diverge, they will, and every "the export
+doesn't match what I saw" bug lives in that gap. There is no separate preview path.
+
+### Clock alignment is the make-or-break detail
+
+Every event timestamp and every video PTS must be expressed on **one clock**. The recorder takes
+the `CMSampleBuffer` presentation timestamp of the first screen frame as `t = 0`, and converts
+`NSEvent`-derived `mach_absolute_time` stamps into the same timebase. Camera and audio get a
+measured offset stored in the manifest rather than an assumed zero.
+
+Get this wrong by 80 ms and the cursor visibly lags the thing it is clicking — the most damaging
+possible defect in this feature, and one that looks like "the app is slow" rather than a bug. It is
+therefore Phase 1 work with its own test, not a Phase 5 polish item.
+
+---
+
+## Reuse map — what already exists
+
+| Need | Reuse verbatim | File |
+|---|---|---|
+| Background fills, padding, radius, shadow, inset, alignment | `CaptureBackground` | `Features/Screenshots/CaptureBackground.swift` |
+| Canvas + image-rect maths | `BackgroundLayout.compute` | `Features/Screenshots/BackgroundLayout.swift` |
+| Mesh gradient painting (dithered) | `MeshRenderer` | `Features/Screenshots/MeshRenderer.swift` |
+| Shadow / fill drawing | `BackgroundCompositor.drawSurround` | `Features/Screenshots/BackgroundCompositor.swift` |
+| Background presets + palette | `BackgroundCatalogue`, `BackgroundPresetStore` | same folder |
+| Pick a background from the shot | `AutoBalance` | `Features/Screenshots/AutoBalance.swift` |
+| Aspect presets | `AspectRatio` | `Features/Screenshots/CaptureBackground.swift` |
+| SCK behind a protocol, stubbed in tests | `ScreenCapturing` / `StubScreenCaptureService` | `Features/Screenshots/ScreenCapturing.swift` |
+| Screen-recording permission + relaunch dance | `ScreenRecordingRelaunch`, `Requirement.screenRecording` | `Core/` |
+| Region selection overlay on a frozen screen | `CaptureOverlayController`, `SelectionView`, `SelectionGesture` | `UI/Screenshots/` |
+| Window picker | `WindowPicker`, `WindowPickerList`, `WindowListFilter` | `Features/Screenshots/`, `UI/Screenshots/` |
+| Countdown before capture | `CountdownView` | `UI/Screenshots/CountdownView.swift` |
+| Snapshot undo over a value type | `UndoStack<Value>` | `Features/Screenshots/UndoStack.swift` |
+| View↔document coordinate mapping | `CanvasTransform` | `Features/Screenshots/CanvasTransform.swift` |
+| Stroke smoothing (adapts to cursor smoothing) | `PencilSmoothing` | `Features/Screenshots/PencilSmoothing.swift` |
+| Editor window pattern, key routing, dirty-close | `ScreenshotEditorWindowController`, `EditorKeyRouting` | `UI/ScreenshotEditor/` |
+| Inspector UI idiom | `BackgroundInspector` (709 lines — read it before writing ours) | `UI/ScreenshotEditor/` |
+| Debounced disk writes | `CoalescingSaver` | `Core/CoalescingSaver.swift` |
+| Spacing/type/motion tokens | `Theme` | `UI/DesignSystem/Tokens.swift` |
+| Feature registration, permissions, tray panel | `Feature`, `FeatureRegistry`, `Requirement` | `Core/` |
+| Toasts | `ToastPresenter` | existing |
+
+Additional pieces the exploration turned up, all directly reusable:
+
+| Need | Reuse | File |
+|---|---|---|
+| The whole session/HUD/`isRunning` shape | `ScrollCaptureSession` — read it first; it is the template | `Features/Screenshots/ScrollCaptureSession.swift` |
+| Borderless HUD panel with correct level ordering | `FloatingPanel` (note: `isFloatingPanel` must be set *before* `level`) | `UI/Shared/FloatingPanel.swift` |
+| Positioning a HUD on the right screen | `ScreenPlacement.screenUnderPointer` | `UI/Shelf/ScreenPlacement.swift` |
+| SCK filter that excludes our own windows | `SCKScreenCaptureService.filter(for:content:options:)` | `Features/Screenshots/` |
+| SCK config with sRGB forced + `pointPixelScale` sizing | `SCKScreenCaptureService.configuration(for:options:isWindow:)` | same |
+| Pixel-grid snapping, display↔global rect maths | `CaptureGeometry` | `Core/CaptureGeometry.swift` |
+| Parking a finished `.mov` on the shelf | `ShelfItem.Kind.files([FileReference])` — bookmark-based, zero new code | `Features/Shelf/ShelfItem.swift` |
+| Filename patterns with `{date}`/`{time}`/`{n}` | `CaptureFilename` | `Features/Screenshots/` |
+| One render path for canvas *and* export | `AnnotationRenderer.Quality { interactive, export }` — the exact pattern | `Features/Screenshots/AnnotationRenderer.swift` |
+| Annotation elements over video | `AnnotationElement`, `RGBAColour`, `StrokeStyle`, `TextElement` | `Features/Screenshots/AnnotationElement.swift` |
+| An existing `CIContext` | `PixelFilters.context` | `Features/Screenshots/PixelFilters.swift` |
+| `sarvkrit://` URL commands | `CaptureURLCommand` | `Features/Screenshots/` |
+
+**Roughly 40% of this feature already exists.** The plan's job is to add a time axis to it without
+forking it.
+
+### Integration points that will break if forgotten
+
+These are the "quiet failure" list — each is something that compiles fine and is wrong:
+
+1. **`CaptureOverlayGuard.dismissEverything()`** — ⌃⇧⎋ is documented in the README as *always
+   clears the screen*. The recording HUD and the countdown must register, or the one shortcut that
+   promises to work always stops working.
+2. **`AppDelegate.capture(...)`** needs an `isRecording` guard mirroring the existing
+   `ScrollCaptureSession.shared.isRunning` check, so pressing the shortcut again stops the
+   recording rather than starting a second one.
+3. **Do not add `.recording` to `CaptureMode`.** Its raw values are persisted in the history index
+   and it drives four exhaustive switches plus `CaptureHistoryShelf.availableModes`. A recording is
+   not a screenshot mode; it gets its own `RecordingSource` enum.
+4. **`CaptureHistoryItem` cannot hold a recording** — no duration, no media discriminator, and
+   `CaptureHistoryStore.add` PNG-encodes. Recordings get their own `StudioLibraryStore`, in
+   `~/Library/Application Support/Sarvkrit/Recordings/`, following `CaptureHistoryStore`'s shape
+   (index JSON + payload files + `CoalescingSaver` + retention) but not its schema.
+5. **`QuickAccessController.show(_:)`** takes a `CaptureHistoryItem` and thumbnails via
+   `NSImage(contentsOf:)`. A recording's thumbnail needs `AVAssetImageGenerator`. Either generalise
+   it or give recordings their own post-capture affordance — the latter, because what you want
+   after a recording ("Edit", "Save", "Reveal") is not what you want after a screenshot.
+6. **`SelectionView` hides the pointer with a cursor rect, not `NSCursor.hide()`.** The recorder
+   must *not* inherit that — the pointer has to stay visible while recording, and the frozen
+   overlay is dismissed before the stream starts.
+7. **Nothing under `Features/` imports the UI layer.** The recorder reaches its HUD through nullable
+   closures set by `AppDelegate`, exactly as `ScreenshotFeature` does.
+
+---
+
+## Platform constraints — verified against the macOS 26.5 SDK
+
+The deployment target is **macOS 14.4** and `project.yml` explains why it must not move (Core Audio
+process taps for the volume mixer). Everything below was checked in the SDK headers, not assumed:
+
+| API | Availability | Consequence |
+|---|---|---|
+| `SCStream.addRecordingOutput` / `SCRecordingOutput` | **macOS 15.0** | ✗ Unusable. Write frames ourselves via `AVAssetWriter`. |
+| `SCStreamConfiguration.captureMicrophone` | **macOS 15.0** | ✗ Unusable. Mic via `AVCaptureSession`. |
+| `SCStreamConfiguration.capturesAudio` | macOS 13.0 | ✓ System audio. |
+| `excludesCurrentProcessAudio` | macOS 13.0 | ✓ Keeps our own beeps out. |
+| `showsCursor` | macOS 12.3 | ✓ Set **false** — we draw our own. |
+| `SCContentSharingPicker` | macOS 14.0 | ✓ Available, but we use our own overlay for consistency. |
+| `SCStreamFrameInfo{Status,ContentRect,ScaleFactor,DirtyRects}` | macOS 12.3 | ✓ Needed to drop idle frames. |
+| `preservesAspectRatio`, `streamName`, `ignoreGlobalClipDisplay` | macOS 14.0 | ✓ |
+| `includeChildWindows` | macOS 14.2 | ✓ Window mode with sheets/popovers. |
+| `SFSpeechRecognizer.requiresOnDeviceRecognition` | macOS 10.15 | ✓ Captions, on-device only. |
+| SwiftUI `MeshGradient` | macOS 15.0 | ✗ Already why `MeshRenderer` exists. |
+
+Losing `SCRecordingOutput` is not a hardship — it writes one muxed file, and we *want* separate
+tracks so audio can be edited independently.
+
+---
+
+## The renderer
+
+### Layer order
+
+The frame is built bottom-up, and the order is stated once here because every feature below plugs
+into a named slot:
+
+```
+1. Background fill        static per (canvas size, style) → rendered ONCE, cached
+2. Screen shadow          moves with the screen rect → per frame, from a pre-blurred sprite
+3. Screen layer           video frame, transformed by the zoom curve, clipped to rounded rect
+4. Click effect           ripples/highlights at click points, in screen-layer space
+5. Cursor                 vector glyph, screen-layer space, motion-blurred
+6. Camera                 own rect, own radius/shadow/shape, canvas space
+7. Keystrokes             canvas space, anchored
+8. Captions               canvas space, anchored
+9. Annotations            canvas space (reuses AnnotationElement from the screenshot editor)
+10. Watermark             none. We do not ship one.
+```
+
+**The background is time-invariant.** A mesh gradient at canvas resolution is far too slow to paint
+at 60 fps in `MeshRenderer`, and completely unnecessary, because it does not change between frames.
+It is rendered once when the style changes and blitted thereafter. The same applies to the shadow,
+which is rendered once into a small pre-blurred nine-slice sprite and stretched to the moving
+screen rect rather than re-blurred 60 times a second.
+
+This is the whole performance strategy: **find what does not change, and stop redrawing it.**
+(Measure the actual costs before tuning — `MeshRenderer`'s own doc comment sets the standard:
+"Measured, not assumed.")
+
+### One renderer, two backends
+
+`MeshRenderer`'s doc comment records a real finding: Core Image works in a linear space and made
+sRGB colours "markedly lighter than their surroundings". That verdict stands for *authoring* the
+gradient. It does not stand for *compositing* — a blit, a scale and an alpha blend are colour-space
+agnostic if every input is tagged.
+
+So:
+
+- Backgrounds, shadows and cursor glyphs are **authored in CoreGraphics** (unchanged, reusing
+  existing code verbatim), producing tagged sRGB `CGImage`s.
+- Per-frame compositing runs through **one `CIContext`**, with `workingColorSpace` pinned to sRGB so
+  no linearisation happens, writing straight into a `CVPixelBuffer` — no intermediate `CGImage`, no
+  CPU round-trip.
+
+There is **one** renderer, not two. The backend is a parameter:
+
+```swift
+enum RenderBackend { case gpu, software }   // software == kCIContextUseSoftwareRenderer
+```
+
+The app uses `.gpu`; tests use `.software`, which is deterministic. A second CoreGraphics
+implementation was considered and rejected: two rasterisers can never agree byte-for-byte on
+scaling and antialiasing, so "both paths produce the same bytes" would be an untestable promise,
+and maintaining two layer stacks is exactly how preview and export drift apart.
+
+*(A `CIContext` in the test host is fine, incidentally — `PixelFilters.context` is one and
+`PixelFiltersTests` runs against it today.)*
+
+The parity test therefore compares **software against GPU within a per-channel tolerance**, while
+asserting geometry — cursor centroid, screen-rect bounds, caption baseline — exactly. Geometry is
+where the bugs are; a two-LSB difference in a gradient is not.
+
+### Preview
+
+`AVPlayer` supplies the decoded frames and the clock; `StudioRenderer` composites them. The player's
+layer is never displayed — an `AVPlayerItemVideoOutput` is attached and a display link driven by
+`NSScreen.displayLink(target:selector:)` (macOS 14.0, so available at our target) pulls
+`copyPixelBuffer(forItemTime:)` each tick and hands it to the renderer.
+
+This is what the `AVPlayerItemVideoOutput` header itself describes, and it is the right call for a
+specific reason: **`AVAssetReader` cannot seek.** A reader-based preview would have to be torn down
+and rebuilt on every scrub, decoding from the nearest HEVC keyframe each time — which is precisely
+the interaction a timeline is made of. `AVPlayer` gives seeking, rate and scrubbing for free.
+
+`AVAssetReader` remains correct for the **export** path, which is strictly sequential.
+
+Preview at 4K on a busy project will not always hit 60 fps, and that is acceptable — but it must
+never *lie*. When the renderer cannot keep up it drops frames; it does not skip layers. A preview
+that silently disables motion blur to stay smooth is how you ship an export nobody expected.
+
+---
+
+## Non-goals, and why
+
+Stated up front, in the README's own register, because a plan that quietly omits things reads as an
+oversight rather than a decision:
+
+- **No cloud upload, no share links, no "export to a URL".** The README's privacy section says *the
+  app contains no network code at all*, and that sentence is worth more than a share button.
+  Exporting writes a file; what happens to the file is the user's business.
+- **No account, no licence check, no watermark.** Screen Studio watermarks its free tier. Sarvkrit
+  has no tiers.
+- **No cloud transcription.** Captions use `SFSpeechRecognizer` with
+  `requiresOnDeviceRecognition = true`, and when `supportsOnDeviceRecognition` is false the feature
+  says so plainly and offers nothing rather than quietly sending audio to Apple.
+
+  **This is a quality decision and it deserves to be visible rather than discovered in Phase 6.**
+  The reference bundles Whisper locally, in three model sizes, and gets noticeably better
+  transcripts than `SFSpeechRecognizer` does — particularly on technical vocabulary. Whisper is
+  equally private; it runs on-device either way. The only argument against it is **size**: a Core ML
+  Whisper model adds roughly 150–500 MB to an app whose entire DMG is currently a few megabytes,
+  and tripling the download of a menu-bar utility to improve one sub-feature is the wrong trade for
+  v1.
+
+  So: `SFSpeechRecognizer` now, with `contextualStrings` doing real work to close the vocabulary
+  gap, and **a bundled or separately-downloaded Whisper listed in Phase 7 as an explicit decision**
+  rather than a silent limitation. If transcript quality turns out to be the thing people complain
+  about, the answer is already scoped.
+- **No iPhone/iPad recording in v1.** It is a genuinely separate capture stack
+  (`AVCaptureDevice` over USB with the device as an external camera). Listed in Phase 7, not
+  pretended away.
+- **No background removal on the camera in v1.** `VNGeneratePersonSegmentation` is available and
+  good; it is also a per-frame cost on a feature most users will not switch on. Phase 6.
+- **No multi-track video / picture-in-picture of a second recording.** One screen, one camera.
+
+---
+
+## How it registers with the app
+
+One file, one line, per the README's own rule:
+
+```swift
+// Sources/Sarvkrit/Features/Studio/ScreenRecordingFeature.swift
+final class ScreenRecordingFeature: Feature {
+    var id: String { "screenRecording" }          // stable — this is the UserDefaults key
+    var category: FeatureCategory { .capture }
+    var title: String { "Screen Recording" }
+    var summary: String { "Record your screen; it edits itself." }
+    var symbolName: String { "record.circle" }
+    var shortcutHint: String? { "⌃⇧R" }
+    var requirements: Set<Requirement> { [.screenRecording] }
+    // Camera / microphone / speech are per-sub-feature, requested on first use — see below.
+}
+```
+
+…plus one line in `FeatureRegistry.makeAll()`, after `ScreenshotFeature()`.
+
+### New `Requirement` cases
+
+`Requirement` currently has three cases. This adds three, each with the same honest `explanation`
+prose the existing ones carry:
+
+- `.camera` — `AVCaptureDevice.requestAccess(for: .video)`. Queryable, requestable.
+- `.microphone` — `AVCaptureDevice.requestAccess(for: .audio)`. Queryable, requestable.
+- `.speechRecognition` — `SFSpeechRecognizer.requestAuthorization`. Queryable, requestable.
+
+And three `Info.plist` keys written in the app's voice, e.g.:
+
+> `NSCameraUsageDescription` — "Sarvkrit needs the camera to record you alongside your screen. The
+> video is written to your Mac and never sent anywhere."
+
+`.screenRecording` is reused unchanged, **including its relaunch quirk** — `ScreenRecordingRelaunch`
+already handles the fact that macOS will not hand a running process a new grant, and the recorder
+gets that behaviour for free by returning `noDisplays` the same way `SCKScreenCaptureService` does.
+
+### Sub-toggles that stay off until asked
+
+The README's Snap Areas precedent: a thing that changes what an ordinary action does stays off
+until requested. Two qualify here:
+
+- **Show keystrokes** — needs Accessibility, and watching the keyboard is exactly what a privacy-
+  minded user wants to opt into rather than discover. Off by default. When on, it records key
+  *labels*, never characters typed into a secure field (see the secure-field note under Files).
+- **Captions** — needs Speech Recognition and several seconds of CPU. Off by default.
+
+Mouse clicks need **no permission at all** — `NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDown)`
+is unprivileged — so the base recorder never touches the event tap. That is worth protecting: it
+means recording your screen asks for exactly one grant, the one macOS makes unavoidable.
+
+#### ⚠️ Keystrokes must NOT go in `requirements`
+
+`FeatureCategoryTests.testAccessibilityIsRequiredByTapFeaturesAndOnlyThem` asserts a hard
+invariant, not a list:
+
+```swift
+XCTAssertEqual(needsIt, feature is EventTapFeature, "\(feature.id): wrong requirement")
+```
+
+So `ScreenRecordingFeature` **cannot** declare `.accessibility` — it is not an `EventTapFeature`,
+and it should not become one for a sub-toggle most users leave off. Instead, keystroke capture
+follows the pattern `.audioCapture` already establishes: it is requested at the point of use.
+
+Turning the sub-toggle on calls `PermissionsManager.request(.accessibility)`; while the grant is
+missing the sub-toggle renders a `PermissionBanner` and records nothing. The feature as a whole is
+never gated on it. This is both the correct UX and the only shape that keeps the invariant.
+
+Note also that `Feature`'s protocol extension **defaults `requirements` to `[.accessibility]`**, so
+the override is mandatory and must carry a comment saying why, exactly as `ScreenshotFeature`,
+`ShelfFeature` and `KeepAwakeFeature` do.
+
+### House rules this module must follow
+
+Non-negotiable, taken from the existing code rather than invented here:
+
+- **`Features/` never imports `UI/`.** The recorder reaches its HUD and the editor through optional
+  closures set in `AppDelegate.wireStudio()`.
+- **Settings are computed properties over an injected `UserDefaults`**, with a same-value `guard` in
+  the setter and `objectWillChange.send()` after. Never `@Published`, never `@AppStorage` — the
+  reason is recorded in `AppState.swift`: a same-value write through a SwiftUI binding became a
+  loop that pinned a core at 100%.
+- **Feature `id` and every persisted `rawValue` are permanent.** `RecordingSource`,
+  `ZoomSegment.Anchor`, `CursorStyle`, `ExportPreset` all get stable raw values from day one.
+- **Design-system tokens only, stock controls only.** No custom `ButtonStyle`/`SliderStyle` — there
+  is not one in the whole app and there should not be a first. The timeline is the one exception,
+  and it is an `NSView`, not a styled SwiftUI control (same reasoning as `SelectionView`).
+- **`.accessibilityLabel` on every composed element**, and `.clickableCursor()` on anything
+  plain-styled that responds to a click.
+- **Write the comment that says which bug the code prevents.** This is the strongest convention in
+  the repo; a new module that does not do it will read as foreign.
+- Style: ~100 columns, 4-space indent, `// MARK: -` dividers. There is no SwiftLint config.
+
+### Tests that will break, and must be updated in the same PR
+
+The README's "one file plus one line" is true of the app and false of the suite:
+
+| Test | What to do |
+|---|---|
+| `FeatureStoreTests.testRegistryIDsAreUniqueAndStable` | Add `"screenRecording"` at the right position in the exact ordered array. |
+| `FeatureCategoryTests.testShippingFeaturesLandInTheExpectedCategories` | Add the id→`.capture` row. |
+| `FeatureCategoryTests.testOnlyFeaturesThatNeedOneSupplyACustomDetailPane` | Add the id — we do implement `makeDetailView()`. |
+| `FeatureCategoryTests.testAccessibilityIsRequiredByTapFeaturesAndOnlyThem` | Passes only if `requirements` excludes `.accessibility`. See above. |
+| `ScreenshotShortcutTests.testNoCaptureHotkeyIDCollidesWithAnExistingOne` | Grow `existing` for the new `GlobalHotkey.ID` values — **next free is 15**. |
+| `TrayPanelRenderTests.allPanels` | Automatic, but our panel must lay out with *no recordings at all*. |
+| `RequirementTests` | Covers the three new cases. |
+
+Prose carrying counts also needs updating: README's "Nineteen features", `Theme.Size.panelMaxContentHeight`'s comment, `TrayPanelStrip`'s "nine of them", `TrayPanelRenderTests`' "eighteen rows and seven headers".
+
+*(While in there: README and CONTRIBUTING both say "846 tests"; the suite is now 1,582 across 144
+files, and `Tokens.swift:153` says the deployment target is 14.0 when it is 14.4. Worth fixing,
+separately from this work.)*
+
+### Shortcuts
+
+Capture already owns the **⌃⇧ + letter** family (`ScreenshotAction`, ten actions). Recording joins
+it rather than claiming a new one:
+
+| Action | Default | `GlobalHotkey.ID` |
+|---|---|---|
+| Start/stop recording | ⌃⇧R | 15 |
+| Record area | ⌃⇧E | 16 |
+| Pause/resume | ⌃⇧U | 17 |
+
+`RecordingAction` conforms to `ShortcutOwner`, which gets it the whole `ShortcutConflict.verdict`
+policy — refusals, warnings, and the shortcut recorder UI — for free.
+
+R, E and U are verified free: `ScreenshotAction` claims ⌃⇧ + **A W F 5 S T Z H P Y**, and ⌃⇧⎋ is
+`dismissAllOverlays`.
+
+### The two in-app surfaces
+
+**Tray panel** (`trayPanels()`, id `"recording"`, symbol `record.circle`). The README's rule is that
+the menu bar is a dashboard, not a switchboard — so this panel leads with the thing you came for:
+
+- A **Record** button, plus the source/camera/mic pickers inline, so a recording can start without
+  the pre-record bar at all.
+- The **three most recent recordings** as rows: thumbnail (`AVAssetImageGenerator`), duration, age,
+  and a click to open the editor.
+- While recording: elapsed time and a Stop button, replacing the above.
+
+It must lay out with **no recordings at all** — `TrayPanelRenderTests` sweeps every contributed
+panel and the existing suites deliberately exercise the empty case.
+
+**Detail pane** (`makeDetailView()` — remember to add the id to
+`FeatureCategoryTests`' `needsOwnPane` set). A `Form`/`.formStyle(.grouped)` pane with sections for:
+quality (fps, resolution cap, HEVC/H.264 for the intermediate), defaults applied to new projects
+(background, cursor style, auto-zoom on/off), the sub-toggles (captions, keystrokes) with their
+`PermissionBanner`s, the shortcut recorders, retention and the current library size, and the export
+folder and filename pattern (reusing `CaptureFilename`).
+
+---
+
+## Files
+
+### New — Phase 1 only
+
+```
+Sources/Sarvkrit/Features/Studio/
+  ScreenRecordingFeature.swift        Feature conformance, settings, hotkeys, UI closures
+  ScreenRecording.swift               the protocol, RecordingRequest/Handle, RecordingError
+  SCKScreenRecordingService.swift     the only file importing ScreenCaptureKit for streaming
+  RecordingWriter.swift               AVAssetWriter, fragmented MP4, back-pressure, PTS rebasing
+  EventLog.swift                      the serial writer + Codable event types
+  GeometrySidecar.swift               per-frame contentRect/scaleFactor
+  RecordingBundle.swift               .sarvrec layout, manifest, recovery
+  RecordingSource.swift               display | window | area — stable raw values
+  RecordingAction.swift               ShortcutOwner conformance, GlobalHotkey.ID 15–17
+  StudioProject.swift                 the document; Codable with unknown passthrough
+  Timeline.swift                      pure: clips, split, trim, speed, sourceTime(forOutput:)
+  StudioRenderer.swift                pure: frame(of:at:sources:), the layer order
+  StudioLibraryStore.swift            index, payloads, age + size retention
+  ExportPreset.swift                  pure
+
+Sources/Sarvkrit/UI/Studio/
+  StudioEditorWindowController.swift  modelled on ScreenshotEditorWindowController
+  StudioEditorView.swift              rail, canvas, transport
+  StudioTimelineView.swift            NSView — ruler, tracks, playhead
+  StudioPreviewView.swift             AVPlayerItemVideoOutput + display link
+  PreRecordBar.swift                  FloatingPanel
+  RecordingHUD.swift                  FloatingPanel
+  StudioTrayView.swift                trayPanels()
+  ScreenRecordingDetailView.swift     makeDetailView()
+
+Tests/SarvkritTests/
+  StubScreenRecordingService.swift    + a small fixture bundle
+  TimelineTests.swift  RecordingClockTests.swift  RecordingRecoveryTests.swift
+  StudioProjectCodingTests.swift  StudioLibraryStoreTests.swift  ExportPresetTests.swift
+  StudioRenderSnapshotTests.swift  StudioChromeSnapshotTests.swift
+```
+
+Later phases add `CursorGlyph`, `CursorPath`, `ClickEffect`, `CursorSet` (2); `ZoomPlanner`,
+`ZoomEase`, `ZoomSegment` (3); `StudioKeyRouting`, `SilenceDetector`, `TypingDetector` (4);
+`CameraSegment`, `Ducker`, `LoudnessMeter`, `StudioMask` (5); `CaptionGrouper`, `CaptionStyle`,
+`Transcriber`, `KeystrokeOverlay` (6) — each with its test file.
+
+### Existing files touched
+
+| File | Change |
+|---|---|
+| `Core/Feature.swift` | three `Requirement` cases: `.camera`, `.microphone`, `.speechRecognition` |
+| `Core/FeatureRegistry.swift` | one line, after `ScreenshotFeature()` |
+| `Core/GlobalHotkey.swift` | `ID` 15–17 |
+| `Core/FocusedRoleCache.swift` | add a focused-element **secure field** check (see below) |
+| `App/AppDelegate.swift` | `wireStudio()` + one call in `applicationDidFinishLaunching` |
+| `UI/Screenshots/CaptureOverlayGuard.swift` | register the HUD and pre-record bar |
+| `Resources/Info.plist` | `NSCameraUsageDescription`, `NSMicrophoneUsageDescription`, `NSSpeechRecognitionUsageDescription` |
+| `Features/Screenshots/CaptureBackground.swift` | `AspectRatio`: append `fourFive`, `threeFour`, `custom` |
+| `Features/Screenshots/AnnotationElement.swift` | Phase 7 only: time ranges on elements |
+| `README.md` | the feature entry, the permissions section, the feature count |
+| Five test files | see the breakage table above |
+
+**On the secure-field check.** `ClipboardPrivacyFilter` is *not* the right utility — it reads
+pasteboard markers (`org.nspasteboard.ConcealedType`), which says nothing about where a keystroke
+was typed. There is no secure-field test in the codebase today. `FocusedRoleCache` already watches
+the focused AX element and exposes `isTextFieldFocused`; it gains a sibling that reports whether
+that element's role or subrole is `AXSecureTextField`. Keystrokes are dropped while it is true.
+
+---
+
+## Phase plan
+
+Each phase ends somewhere shippable. Phase 1 alone is already better than QuickTime.
+
+| Phase | Goal | Ships |
+|---|---|---|
+| **1** | Record → composite → export | Area/window/display recording, background, padding, radius, shadow, aspect, MP4 export |
+| **2** | The cursor | Re-rendered cursor, smoothing, size, click effects, cursor hiding |
+| **3** | Automatic zoom | Zoom track, auto-generation, manual editing, easing |
+| **4** | Timeline editing | Trim, split, delete, speed, playback, keyboard shortcuts |
+| **5** | Audio + camera + masks | Mic, system audio, waveforms, volume, silence trimming, camera track, masks |
+| **6** | Captions + keystrokes | On-device transcription, karaoke rendering, transcript editor, key display |
+| **7** | The long tail | Presets, annotations, GIF, ProRes, vertical templates, iPhone capture |
+
+---
+
+## Phase 1 — Record, composite, export
+
+### 1.1 The recorder
+
+`Features/Studio/Recording/`
+
+```swift
+/// Everything that streams from ScreenCaptureKit, behind one protocol.
+///
+/// Sibling of `ScreenCapturing`, and for exactly the same reason: `SarvkritTests` is hosted
+/// inside `Sarvkrit.app`, so a live SCStream in a test either prompts or hands back denied
+/// results. `StubScreenRecordingService` replays a fixture bundle instead.
+protocol ScreenRecording: AnyObject {
+    func start(_ request: RecordingRequest) async throws -> RecordingHandle
+}
+```
+
+**Configuration, and the reasoning for each choice:**
+
+| Setting | Value | Why |
+|---|---|---|
+| `showsCursor` | `false` | We draw it. This is the feature. |
+| `minimumFrameInterval` | 1/60 (user: 30/60) | 60 is the point; 30 offered for long recordings. |
+| `queueDepth` | 8 | 5 is the SCK floor for smooth 60 fps; 8 gives headroom. |
+| `pixelFormat` | `kCVPixelFormatType_32BGRA` | What CI wants; ties to the sRGB working space. |
+| `colorSpaceName` | `CGColorSpace.sRGB` | Matches `MeshRenderer`'s output exactly. One pipeline. |
+| `width`/`height` | source × backing scale | Retina, full resolution. Never downscale at capture. |
+| `capturesAudio` | user | System audio. |
+| `excludesCurrentProcessAudio` | `true` | Our own toasts must not land in the recording. |
+| `includeChildWindows` | `true` (window mode) | Otherwise a menu or sheet vanishes mid-demo. |
+| `preservesAspectRatio` | `true` | |
+| Excluded windows | `AppIdentity.bundleID` | Same one line that keeps the overlay out of screenshots. |
+| `hidesDesktopIcons` | user, default on | Already in `CaptureOptions`; the filter builder already implements it. Free. |
+
+**Writing.** `AVAssetWriter` with `AVVideoCodecType.hevc`, `AVVideoQualityKey` 0.9, and
+`kVTCompressionPropertyKey_RealTime = true`. HEVC over H.264 because a 4K/60 screen recording is
+enormous and the source is already Apple Silicon with a hardware encoder. The recording is an
+intermediate the user rarely keeps, so quality beats compatibility here — the *export* is where
+H.264 compatibility matters.
+
+**Dropping idle frames.** `SCStreamFrameInfoStatus` reports `.idle` when nothing changed. Those
+frames are not written; the next real frame carries a longer duration instead. For a recording of a
+mostly-still screen this is a large saving and nothing about playback changes — measure the actual
+ratio on a real demo before quoting one.
+
+**Back-pressure.** If the writer cannot keep up, frames are dropped at the *tail*, a counter is
+incremented, and the count is shown when recording stops ("4 frames dropped"). Silently producing
+a stuttering file is the failure mode to avoid.
+
+**Files over 4 GB.** Verify a >4 GB recording plays back. This is the class of bug that only appears
+after someone's longest and most valuable take, so it gets checked rather than assumed.
+
+### 1.1a Not losing a recording
+
+The single worst outcome this feature has is a lost take, so it gets designed for rather than hoped
+about.
+
+- **Crash recovery, via fragmented MP4.** Set `AVAssetWriter.movieFragmentInterval` to ~2 s. The
+  writer then flushes a self-contained fragment twice a second's worth, so a file whose
+  `finishWriting` never ran is still playable up to the last fragment. This is how the reference
+  does it (its bundles contain fragmented segments and playlists written live) and it is far more
+  robust than trying to repair a conventional MP4 whose `moov` atom was never written.
+
+  `manifest.json` is written *at start* with `state: "recording"`. On next launch any bundle still
+  marked `recording` is recovered: the fragmented file is remuxed to a clean MP4 and the event and
+  geometry sidecars — appended continuously, not held in memory — are truncated to the last
+  fragment's PTS. The user is told a recording was recovered and how long it is.
+
+  **This also gives pause/resume and low-disk shutdown for free**, since all three are the same
+  question: what does the file look like if we stop unexpectedly?
+- **Disk space.** Estimate bytes-per-second from the configuration and refuse to start when free
+  space is under two minutes' worth, with the number stated. Warn at ten minutes' worth. Stop
+  cleanly — finishing the file — when space runs out mid-recording, rather than failing the write
+  and losing everything.
+- **The event log is flushed periodically**, not only on stop, for the same reason.
+- **Display reconfiguration** (a monitor unplugged, resolution changed) stops the recording cleanly
+  and keeps what exists, rather than continuing with a stream whose geometry no longer matches the
+  sidecar. `CaptureOverlayController` already takes the "cancel rather than recover" line on
+  `didChangeScreenParametersNotification`; recording takes "stop and keep" instead, because there
+  is something worth keeping.
+
+### 1.2 The event log
+
+A serial-queue writer appending to a preallocated buffer, flushed to `events.json` on stop.
+
+Cursor position is **sampled at the display's refresh rate** via
+`NSScreen.displayLink(target:selector:)` (macOS 14.0; `CVDisplayLink` is deprecated from 15) rather
+than taken from move events, because move events stop arriving when the mouse is still — and a
+cursor that only has samples while moving cannot be interpolated across a pause.
+
+Every sample is stamped with **`mach_absolute_time()` directly**, not `NSEvent.timestamp`, so it
+shares a timebase with the `CMSampleBuffer` PTS with no conversion to get wrong.
+
+**Cursor identity: match a kind, and keep the bitmap when you cannot.**
+
+`NSCursor.currentSystem` hands back an *image*, not an identifier. It is compared against the known
+system cursors (`arrow`, `iBeam`, `pointingHand`, `openHand`, `closedHand`, `crosshair`,
+`resizeLeftRight`, `resizeUpDown`, `resizeDiagonal`, `notAllowed`, `contextualMenu`) by hashing the
+bitmap, giving a stable `CursorKind` for the overwhelmingly common case.
+
+When nothing matches — Figma, Photoshop, Blender, a game, any app shipping its own pointers — the
+**bitmap is stored**, deduplicated by that same hash, in `cursors/` inside the bundle. The renderer
+then draws the vector glyph when a kind matched, and the captured bitmap when it did not, with
+smoothing and motion blur applied either way.
+
+This is the correction to an obvious-sounding rule. "Never store the bitmap, always draw vectors"
+gives a beautiful pointer in Safari and **an arrow where the brush was** in every Photoshop demo,
+which is worse than a slightly soft custom cursor. A demo of a design tool is exactly the kind of
+recording this feature is for. Storing costs a handful of small PNGs, because a session uses a
+dozen distinct cursors at most and they are hashed.
+
+**Outside the recorded region.** In area and window modes the pointer spends time outside what is
+being recorded. Those samples are recorded with an `isInside: false` flag; the renderer hides the
+cursor while it is false (fading, not popping), and `ZoomPlanner` ignores clicks that land outside.
+Without this, a multi-display recording immediately shows a cursor pinned to the edge of the frame
+and zooms that aim at nothing.
+
+### 1.3 The per-frame geometry sidecar
+
+**Window mode moves.** With `SCContentFilter(desktopIndependentWindow:)` the captured frame is
+window-relative, and the window can be dragged mid-recording — so a global cursor coordinate cannot
+be mapped into frame space by a single constant.
+
+Each frame's `SCStreamFrameInfoContentRect` and `SCStreamFrameInfoScaleFactor` are therefore
+recorded into a `geometry.json` sidecar keyed by PTS, and the renderer maps cursor and click points
+through *that frame's* rect. Display and area modes write a single constant entry, so there is one
+code path rather than a special case.
+
+Window mode also captures **shadowless and on a transparent background** —
+`ignoreShadowsSingleWindow`, `backgroundColor = .clear`, `pixelFormat = 32BGRA`, which
+`SCKScreenCaptureService.configuration(for:options:isWindow:)` already sets — so the compositor's
+own rounded corners and two-layer shadow apply to it. That is what produces the reference's frame
+10: a real window floating on a gradient with a shadow that follows its corner radius.
+
+### 1.4 Pause and resume
+
+⌃⇧U pauses. Both the screen stream and the audio tracks stop together; events during the pause are
+discarded; and on resume the writer **rebases PTS** by the paused duration so the output has no gap.
+Rebasing rather than writing a gap matters because a gap means every downstream time — zoom
+segments, captions, the timeline — has to know about it, and none of them should.
+
+The HUD shows elapsed *recorded* time, not wall-clock, so a paused recording does not appear to be
+still running.
+
+### 1.5 Picking what to record
+
+Reuses the screenshot path almost entirely. `CaptureMode` gains no cases — instead a parallel
+`RecordingSource` enum (`display`, `window`, `area`) drives the same overlay:
+
+- **Area** — `CaptureOverlayController` on a frozen screen, `SelectionView` for the drag, snapped to
+  even pixels (an odd width breaks HEVC macroblock alignment and costs quality for nothing).
+  `SelectionGesture` already supports an aspect constraint and `SelectionHandles` already supports
+  resizing, so an aspect-locked area picker with typed dimensions is mostly wiring. Add rule-of-
+  thirds guides while dragging — free to draw, and framing a recording is a composition decision in
+  a way framing a screenshot is not.
+- **Window** — `WindowPickerList`, unchanged.
+- **Display** — the display under the cursor, or picked when there is more than one.
+
+The *countdown* is `CountdownView`, already written, already tested.
+
+### 1.6 The two recording surfaces
+
+Both are `FloatingPanel`s, both modelled on `ScrollCaptureSession`'s HUD, and **both must register
+with `CaptureOverlayGuard`** — ⌃⇧⎋ is documented as always clearing the screen and this feature
+must not be the exception.
+
+#### The pre-record bar
+
+Appears on ⌃⇧R, positioned by `ScreenPlacement.screenUnderPointer()`. One row, left to right:
+
+| Control | Behaviour |
+|---|---|
+| **Source** — Display · Window · Area | Segmented. Choosing Area opens the frozen overlay; Window opens the picker. The chosen source is remembered, like `CaptureModeMemory`. |
+| **Camera** ▾ | Off + every `AVCaptureDevice`. Selecting one shows a small live preview inside the bar so you can frame yourself before recording, not after. |
+| **Microphone** ▾ | Off + every input device, with a live level meter — reuses `AudioDevice`/`MixerLevels` from the Sound feature. |
+| **System audio** | Toggle. |
+| **Countdown** ▾ | None · 3 s · 5 s · 10 s. |
+| **Record** | Primary button. |
+
+The bar accepts key (Escape cancels) and is dismissed before the stream starts, so it is never in
+the recording — though `excludedBundleIDs` already guarantees that.
+
+**The camera preview is the point of this bar.** Discovering your camera was off, or pointed at the
+ceiling, after a ten-minute take is the single most costly failure this feature can have.
+
+#### The during-recording HUD
+
+Small, unobtrusive, on the display being recorded but excluded from it:
+
+- Elapsed **recorded** time (not wall-clock — see pause, above).
+- Pause/resume, Stop, **Restart** and **Discard**. "That take was rubbish, go again" is a daily
+  action and routing it through stop-then-delete-the-file is friction on the thing people do most.
+  Discard asks once, because it is not undoable.
+- A live mic level, when the mic is on. Silence here is the second-most costly failure.
+- A dropped-frame count, shown **only if non-zero**.
+
+Stop tears down the stream, flushes the event log and the geometry sidecar, and hands off to the
+post-record flow.
+
+**The camera preview**, when a camera is on, is a small floating window so you can see yourself
+while recording. It is excluded from capture like everything else of ours — but say plainly in the
+UI that it *covers* part of the screen and what is underneath is still recorded, because "why is
+there a hole in my recording" is otherwise a confusing few minutes.
+
+#### Recording flags
+
+⌃⌥⌘F during a recording drops a marker. Flags land on the editor's ruler, so "I fluffed that line"
+is one keystroke at the time instead of a hunt afterwards. Written to `flags.json` in the bundle.
+
+This is a small feature with a large effect on how a long take feels to record, and it costs
+almost nothing: a timestamp, a list, and a tick mark.
+
+### 1.7 After the recording stops
+
+This is Screen Studio's magic moment and it should be ours: **stopping opens the editor with the
+project already good.** `AutoBalance` has picked a background from the first frame, padding and
+radius are set, and the preview is playing. From Phase 3 onward `ZoomPlanner` has run too; in Phase
+1 the editor opens with the background and a trim-only timeline, which is already the useful part.
+
+Alongside it, a single **"Export with defaults"** action — 1080p H.264 to the capture folder — for
+the large fraction of recordings nobody wants to edit at all. A tool that demands an editing session
+for a thirty-second bug repro has misjudged what most recordings are for.
+
+The alternative (a Quick Access thumbnail like screenshots get) is deliberately not the default:
+what you want after a recording is to watch it, and what you want after a screenshot is to send it.
+
+### 1.8 Where recordings live
+
+`StudioLibraryStore`, in `~/Library/Application Support/Sarvkrit/Recordings/`, following
+`CaptureHistoryStore`'s shape — an index JSON, payload directories, `CoalescingSaver`, a retention
+window — but not its schema (`CaptureHistoryItem` has no duration and no media discriminator).
+
+**Retention has to be size-aware, not just age-aware.** Screenshots are kilobytes and a 30-day
+window is free; recordings are hundreds of megabytes and the same window is tens of gigabytes of
+someone's disk. So: default **7 days**, plus a total-size cap (default 10 GB) that evicts oldest
+first, and the settings pane states the current total in plain numbers. A utility that quietly eats
+a disk is worse than one that forgets something.
+
+`CaptureRetention.Window` gains no cases; recordings get their own `RecordingRetention` with both
+axes, and the two stores stay independent.
+
+### 1.9 Export
+
+`AVAssetWriter` again, driven by `StudioRenderer`. Presets:
+
+| Preset | Codec | Notes |
+|---|---|---|
+| MP4 · H.264 | `h264` | The default. Plays everywhere, including Slack previews and PowerPoint. |
+| MP4 · HEVC | `hevc` | Half the size, not universally playable. Says so in the UI. |
+| MOV · ProRes 422 | `proRes422` | For handing to a real editor. Huge, and the UI says how huge. |
+| GIF | — | Phase 7. Needs its own quantiser to not look terrible. |
+
+Resolution presets are computed from the canvas aspect: 4K, 1440p, 1080p, 720p, plus "Original".
+fps 60 or 30. Export runs off the main actor with a determinate progress sheet and a working
+Cancel — one that actually tears down the writer and deletes the partial file rather than just
+hiding the sheet.
+
+**Named export presets**, because "which of these numbers do I want" is not a question most people
+can answer:
+
+| Preset | Settings |
+|---|---|
+| **Web** | 1080p, H.264, 60 fps, ~8 Mbps. The default. |
+| **Social** | 1080p, H.264, 30 fps, 4:5 or 9:16 canvas, captions forced on. |
+| **For an editor** | Original resolution, ProRes 422, 60 fps, audio tracks kept separate. |
+| **Small** | 720p, H.264, 30 fps. For a bug report in a chat window. |
+
+Plus **Copy to clipboard** — exports to a temporary file and puts it on the pasteboard as a
+`public.file-url`, so a short recording can be pasted straight into Slack or a PR comment. This is
+the fastest path from "record" to "sent" and it is worth having as a first-class action.
+
+`CaptureFilename` supplies the naming, so `{date}`, `{time}` and `{n}` work exactly as they do for
+screenshots.
+
+### Phase 1 acceptance
+
+- Record a 30-second window capture; the `.sarvrec` bundle contains video, events and manifest.
+- Open it; the editor shows the recording on a mesh background with padding and shadow, and the
+  frame at t=10s is pixel-identical between the CI and CG render paths.
+- Export 1080p H.264; the output opens in QuickTime, is 30 s ± 1 frame, and matches the preview.
+- **The clock test:** a synthetic recording whose events place the cursor at a known point at a
+  known time renders the cursor within 1 px of that point in the exported frame at that time.
+
+---
+
+## Phase 2 — The cursor
+
+Frames 2, 3, 7 and 8 of the reference recording show four different cursor glyphs (arrow, crosshair,
+pointing hand, arrow again), all rendered large, crisp and clean, and frame 7 shows one smeared by
+motion blur during a fast move. This is the single most visible piece of craft in the product.
+
+### 2.1 Glyph assets
+
+Vector, drawn in code, not PNGs. Each cursor is a `CGPath` plus a fill and a stroke, so it is sharp
+at any size and any zoom level — the same argument `CaptureBackground`'s doc comment makes about
+gradients being data rather than image assets, for the same reason.
+
+The macOS arrow is a specific shape and getting it wrong is uncanny: a 12-point path, black fill,
+1.25 px white stroke, and a soft shadow (`blur 6, opacity 0.25, offsetY 2`). `CursorGlyph` is a pure
+enum returning `(path, hotspot)` in a 24×24 unit box, exhaustively snapshot-tested — this is
+precisely the kind of thing that regresses invisibly.
+
+**Cursor sets.** The glyph set is a `CursorSet` — a named collection covering every `CursorKind` —
+so more can be added without touching the renderer. Ship two: **macOS** (faithful, the default) and
+**Bold** (heavier stroke, higher contrast, for recordings that will be watched small). Each set is
+paths and colours in the `BackgroundCatalogue` mould, not image assets, for the same reasons.
+
+An unknown set id in a project falls back to `macOS` and the project keeps the unknown value, so a
+file written by a later build round-trips — the `.unknown` passthrough contract `CaptureBackground`
+already establishes.
+
+### 2.2 Smoothing
+
+The raw 120 Hz path has hand jitter that is invisible at 1× and obvious at 2.5× zoom.
+
+`CursorPath` reuses the algorithm `PencilSmoothing` already establishes — **RDP then Catmull-Rom**,
+in that order, for the reasons its doc comment gives — with one addition: a critically-damped
+spring (`ζ = 1.0`, ω tuned so a 500 px jump settles in ~90 ms) applied *after* interpolation.
+
+The spring is what makes the cursor feel like it has weight. It also introduces lag, which is the
+tension: too little and the cursor jitters, too much and it arrives after the click it made. So the
+spring is **suspended within 120 ms of a click event** and the cursor snaps to the true position.
+A click that lands somewhere the cursor visibly is not is worse than any amount of jitter.
+
+`Smoothing` is a user setting: Off / Light / Standard / Heavy, mapping to spring stiffness. Off is
+genuinely off — the raw path — because some recordings (drawing apps, precise dragging) are made
+worse by any smoothing at all.
+
+### 2.3 Motion blur — on three channels
+
+Frame 7 is the evidence this exists. The reference applies it independently to **cursor movement**,
+**screen zooming** and **screen panning**, and that separation is right: a blurred cursor over a
+sharp frame is correct when only the mouse moved, and a blurred *frame* is correct when the zoom
+raced somewhere. One global slider cannot express both.
+
+So: a master intensity, plus three per-channel amounts.
+
+- **Cursor** — sample the smoothed path at 4 sub-positions across the frame's duration and
+  composite the glyph at each with ¼ alpha. Degrades to a single sharp glyph when the cursor is
+  still, with no branch needed.
+- **Zooming** and **panning** — the screen layer's transform is likewise sampled across the frame
+  and accumulated. Only active while the zoom curve is actually moving, so a static zoomed frame
+  costs nothing.
+
+On by default. It is the difference between 60 fps looking smooth and looking sampled — and it is
+also what hides the fact that a 60 fps timeline is being resampled through a speed change.
+
+### 2.4 Size, and the zoom relationship
+
+Cursor size is a multiplier (0.5× – 3.0×, default 1.6×) applied in **canvas** space, not screen-layer
+space. This matters: if the cursor scaled with the zoom, a 2.5× zoom would give a comically large
+pointer. Screen Studio keeps it roughly constant on screen, and so do we — the cursor grows
+slightly with zoom (`pow(zoom, 0.25)`) so it does not look detached, but nowhere near linearly.
+
+### 2.5 Click effects
+
+Four options, defaulting to the first:
+
+- **Ripple** — an expanding ring at the click point, 320 ms, ease-out, fading. Radius scales with
+  cursor size.
+- **Highlight** — a soft filled circle that fades over 200 ms.
+- **Shrink** — the cursor itself scales to 0.85× for 90 ms and back. Subtle, and the one that
+  reads as "the mouse was pressed" rather than "an effect played".
+- **None.**
+
+Left and right clicks get different tints. A click *held* (drag) shows the effect on down and a
+faint trail until up.
+
+Optionally, a **click sound** — a soft tick mixed into the exported audio. Off by default, because a
+recording with narration does not want it and one without narration often does.
+
+### 2.5a Rotation, and two things to filter out
+
+**Rotation.** A cursor tilted a few degrees into its direction of travel while moving fast reads as
+momentum. Capped at ±12°, eased in over 80 ms, and returning to upright when the speed drops —
+uncapped rotation looks like a bug, and it is a genuinely small effect that is felt more than seen.
+
+**Shake-to-locate.** macOS enlarges the pointer when you shake it. We are not capturing the system
+cursor bitmap so the size does not leak in, but the *path* does — a violent zigzag that
+`ZoomPlanner` would read as activity and the smoother would chase. `CursorPath.removingShakes`
+detects rapid direction reversals (four or more within 350 ms within a small radius) and replaces
+the span with a straight interpolation. Pure, and easy to test with a synthetic zigzag.
+
+**An enlarged system cursor.** If the user has raised the pointer size in Accessibility settings,
+our size multiplier compounds with theirs and the result is absurd. Read
+`NSWorkspace`/`defaults` for the accessibility cursor scale at record time, store it in the
+manifest, and divide it out. When it is far above normal, say so in the pre-record bar rather than
+silently correcting — the user may have set it deliberately.
+
+### 2.6 Hiding
+
+`Hide cursor when idle` — after N seconds of no movement (default 3), fade out over 400 ms; fade
+back in on the first movement. This is what makes a recording that pauses on a diagram not have a
+pointer sitting in the middle of it.
+
+Also: hide entirely, and hide during a specified time range (a timeline-level override).
+
+### 2.7 Loop the cursor back
+
+For a recording meant to loop — a demo GIF, a landing-page hero — the cursor ending far from where
+it started makes the seam obvious. `Loop cursor` interpolates the path over the last N seconds
+(default 1.0) so it arrives back at its opening position, easing rather than sliding linearly.
+
+Purely a render-time transform on the path; the events are untouched, so it can be switched off
+again. Pure function, testable: `CursorPath.looped(_:over:)`.
+
+### Phase 2 tests
+
+- `CursorGlyph` — snapshot each glyph at 1×/2×/3×.
+- `CursorPath.smoothed` — pure over a fixture path; asserts jitter reduction, and asserts the
+  click-snap suspension puts the cursor exactly on the click point at the click time.
+- `ClickEffect.state(at:)` — pure; asserts the ripple's radius/alpha curve at sampled times.
+
+---
+
+## Phase 3 — Automatic zoom
+
+The reference recording's whole feel comes from this. Frames 1 → 4 → 7 zoom progressively into the
+cursor's region; frame 9 shows the zoom-out in flight with the shadow and rounded corners visible.
+
+### 3.1 The zoom track
+
+```swift
+struct ZoomSegment: Codable, Equatable, Identifiable {
+    var id: UUID
+    var start: TimeInterval
+    var end: TimeInterval
+    var level: Double            // 1.0 … 4.0
+    var anchor: Anchor           // .followCursor | .fixed(CGPoint) | .region(CGRect)
+    var easeIn: TimeInterval     // default 0.6
+    var easeOut: TimeInterval    // default 0.5
+    var isAutomatic: Bool        // generated, and re-generatable, until the user edits it
+}
+```
+
+Segments are non-overlapping and sorted. The renderer resolves the transform at time `t` by finding
+the covering segment and evaluating the ease.
+
+**`isAutomatic` is load-bearing.** It is what lets "Re-detect zooms" replace generated segments
+while leaving hand-made ones alone — the alternative is a button the user cannot press twice
+without losing work.
+
+### 3.2 Generation
+
+`ZoomPlanner` — pure, over the event log alone, no video, no AV types. This is the
+`RuleMatcher`/`AutoBalance` pattern: taste as a testable function.
+
+The algorithm, stated concretely because "it decides where to zoom" is not a specification:
+
+1. **Cluster clicks.** Clicks within 1.5 s and 200 px of each other form one *activity*.
+2. **Extend by dwell.** An activity's window extends to cover cursor dwell before the first click
+   (up to 1.2 s) and after the last (up to 0.8 s) — you look before you click, and you look at what
+   happened after.
+3. **Drop the too-short.** An activity spanning under 1.0 s produces no zoom. A zoom that ends
+   before the eye has arrived is worse than no zoom; this is the rule that stops the output
+   feeling frantic.
+4. **Merge the too-close.** Two activities separated by under 0.8 s merge rather than producing a
+   zoom-out-zoom-in, which is nauseating.
+5. **Choose the level** from the activity's spatial extent: the zoom is whatever makes the
+   activity's bounding box occupy ~60% of the frame, clamped to 1.2× – 2.5×. A single click in one
+   spot gets 2.5×; a drag across half the screen gets 1.3×.
+6. **Anchor.** `.followCursor` when the activity moves more than 15% of the frame, `.fixed` at the
+   centroid otherwise. Following a cursor that barely moves reads as drift.
+7. **Cap the density.** No more than one zoom per 4 s of timeline; beyond that, merge. Screen
+   Studio's own failure mode when a demo is click-heavy.
+
+Every threshold above is a named constant in one struct (`ZoomPlanner.Tuning`) with a documented
+default, so the taste can be adjusted without touching the algorithm.
+
+**Typing is activity too.** A burst of `keyDown` events with no clicks is someone filling in a form
+or writing code, and it deserves a zoom as much as a click does — anchored on the caret's last
+known position, which is the last click or, failing that, the cursor. Clusters of 5+ keystrokes
+within 2 s form a typing activity and go through steps 2–7 unchanged. Without this, the most common
+thing in a software demo produces no zoom at all.
+
+*(Keystrokes are only available when the keystroke sub-toggle was on during recording. When it was
+off, zoom planning uses clicks alone and that is a documented consequence of the privacy default,
+not a bug.)*
+
+### 3.3 Following the cursor
+
+A `.followCursor` segment does not track the cursor exactly — that produces seasickness. It tracks a
+**heavily damped** version (ω roughly 1/8 of the cursor spring) and only moves at all once the cursor
+leaves a dead-zone of 25% of the frame from centre. Inside the dead-zone the frame is still.
+
+The pan is also **clamped so the screen layer never shows past its own edge** — no black bars, no
+background bleeding through the middle of a zoom. At 1.0× the clamp is identity, which is why
+zooming out always lands exactly where the un-zoomed frame is.
+
+### 3.4 Easing
+
+`ZoomEase` is a pure curve. Screen Studio's feel is a soft, slightly overshooting ease — not
+`easeInOut`, which reads as mechanical. The default is a critically-damped spring evaluated over
+the ease duration, with an `easeOut` shorter than the `easeIn` (0.5 vs 0.6): you can leave faster
+than you arrive without it feeling abrupt.
+
+Per-segment override: Smooth (default), Linear, Instant. Instant is for cuts.
+
+**A zoom that starts at t = 0 opens already zoomed** rather than animating in from 1×. Nobody wants
+their video to begin by moving; if the first thing you want shown is a close-up, it should simply be
+there on frame one.
+
+### 3.5 Manual editing
+
+The zoom track in the timeline is directly manipulable, which is the whole reason it is a separate
+track rather than a property:
+
+- Drag a segment's body to move it; drag its edges to retime it.
+- Double-click to open a small inspector: level slider (1×–4×, live preview), anchor picker, ease.
+- Drag on the *preview canvas* while a segment is selected to reposition a `.fixed` anchor, with the
+  frame showing the result live.
+- `+` adds a segment at the playhead; `⌫` deletes the selected one.
+- **Number keys `1`–`9` set the selected segment's level** directly (1 = 1×, 2 = 1.25×, … up to 4×),
+  because adjusting zoom is the single most repeated action in this editor and a slider is the
+  slowest way to do it.
+- **⌘C / ⌘V on a segment** copies its level, anchor and easing onto another — the settings you tuned
+  once are the settings you want on the next twelve.
+- **"Apply to all"** pushes the selected segment's settings onto every automatic segment.
+- "Re-detect" regenerates the automatic ones.
+
+### 3.6 Advanced easing controls
+
+The default spring is tuned and most people should never see its parameters. Behind a disclosure,
+for the people who will: **mass**, **stiffness** and **damping**, with a live preview curve. Exposing
+the actual model rather than three vague sliders labelled "smoothness" is both more honest and more
+useful, and it costs nothing — the spring is already parameterised.
+
+### Phase 3 tests
+
+`ZoomPlannerTests` is the big one, and it is pure: fixture event logs (a slow demo, a click-storm, a
+long drag, a single click, an empty log) asserted against expected segment counts, levels and
+bounds. This is exactly the `RuleEngineTests`/`SnapZoneTests` shape the repo already uses.
+
+`ZoomEaseTests` asserts monotonicity, endpoint exactness (`ease(0) == from`, `ease(1) == to` — an
+ease that does not land precisely leaves a visible jolt), and clamp behaviour at the frame edges.
+
+---
+
+## The editor window
+
+*This section is cross-cutting: it appears here because Phases 4–7 all describe controls that live
+in it. The window itself is built in Phase 1, initially with only the canvas tab and a trim-only
+timeline, and gains tabs and tracks as each phase lands.*
+
+Modelled on `ScreenshotEditorWindowController` — a real `NSWindow`, not a `FloatingPanel`; through
+`ActivationPolicyLease`; keys via a local `NSEvent` monitor because there is no main menu.
+`contentMinSize` is 1100 × 700 (the timeline and the inspector both have a floor below which they
+start hiding controls silently, which is the one thing this window must not do).
+
+Layout, matching the reference:
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ ○○○  📁 🗑   Meeting demo.sarvstudio   ↶ ↷   ✨ Presets ▾  ▥  ⏱   [Export]│  titlebar
+├──────────────────────────────────────────────────────────────┬───────────┤
+│                                                          ▣ │ Background  │
+│                                                          ↖ │ ┌─────────┐ │
+│                    PREVIEW CANVAS                        ▣ │ │Wallpaper│ │  inspector
+│               (background + screen + cursor              💬│ │Gradient │ │
+│                + camera + captions)                      🔊│ │Color    │ │
+│                                                          ⌘ │ │Image    │ │
+│                                                          ⤳ │ └─────────┘ │
+│                                                     rail   │  swatches…  │
+├──────────────────────────────────────────────────────────────┴───────────┤
+│ ▥ Wide 16:9 ▾   ⧉ Crop      ⏮  ⏸  ⏭        ✂   ↔ ────●────              │  transport
+├──────────────────────────────────────────────────────────────────────────┤
+│ ✂5s │      1s      2s      3s      4s      5s      6s          │ 2s✂     │  ruler
+│ ┌────────────────────────────────────────────────────────────────────┐   │
+│ │ ▤ Clip                      7s ⏱1x        ∿∿∿ waveform ∿∿∿        │   │  clip track
+│ └────────────────────────────────────────────────────────────────────┘   │
+│ ┌────────────────────────────────────────────────────────────────────┐   │
+│ │ ⊡ Zoom                      🔍2x  🖱Auto                            │   │  zoom track
+│ └────────────────────────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+### The rail
+
+Seven icons, each selecting what the inspector shows. Selection is a single source of truth
+(`@Published var inspector: InspectorTab`), and a small dot marks a tab whose settings differ from
+the default — the reference has one beside the canvas icon, and it is a genuinely good idea: it
+tells you where your changes live before you go looking.
+
+`canvas` · `cursor` · `camera` · `captions` · `audio` · `keystrokes` · `effects`
+
+Tabs whose source is absent (no camera recorded, no audio track) are shown **disabled with a
+reason on hover**, not hidden. A control that vanishes teaches nothing.
+
+### The transport bar
+
+- **Aspect** — `AspectRatio`, reused. It already has `original`, `square`, `fourThree`, `threeTwo`,
+  `sixteenNine` and `nineSixteen`; add `fourFive` (the Instagram portrait crop) and `threeFour`, and
+  give each a friendly name beside the numbers the way the reference does — **Auto · Wide 16:9 ·
+  Vertical 9:16 · Square 1:1 · Classic 4:3 · Tall 3:4 · Portrait 4:5** — plus a genuinely custom
+  entry, which the reference lacks. Raw values are persisted, so the new cases append; nothing is
+  renamed.
+  Changing it re-runs `BackgroundLayout` and the preview reflows immediately.
+- **Always keep zoomed in** — a toggle that holds the frame at the current zoom rather than
+  returning to 1× between segments. For a vertical export of a wide screen this is not an
+  embellishment, it is the only way the content is legible.
+- **Crop** — a drag-handle overlay on the canvas, writing `cropRect` the way `AnnotationDocument`
+  already models it, with an aspect lock, typed numeric fields, and rule-of-thirds guides.
+  Non-destructive, like everything else here; cancelling restores the previous crop rather than
+  clearing it.
+  **Suggested crops** for common browser chrome: when the recorded window's owning bundle is Safari,
+  Chrome, Arc or Firefox, offer a one-click crop that removes the toolbar and URL bar. The
+  `owningBundleID` is already on `CapturableWindow`, and the inset per browser is a small table.
+  This is a tiny feature that saves a fiddly manual crop on a large fraction of all demos.
+- **Transport** — prev/play/next. Space plays; `←`/`→` step one frame; `⇧←`/`⇧→` one second;
+  `,`/`.` step frames the way editors expect.
+- **Split (✂)** — cuts the clip at the playhead.
+- **Timeline zoom** — fit button plus a slider. Fit is `↔`.
+
+### The timeline
+
+An `NSView`, not SwiftUI, for the same reason `SelectionView` is: it redraws on every mouse-moved
+over a waveform that may be tens of thousands of samples, and SwiftUI's diffing is the wrong tool.
+It draws:
+
+- A **ruler** with adaptive tick density (1 s / 5 s / 10 s / 30 s depending on zoom), labelled.
+- **Trim handles** at both ends, each with a scissors badge showing how much is trimmed
+  (`5s` / `2s` in the reference). Trimming is non-destructive — the source is untouched and the
+  badge is what tells you so.
+- The **clip track**: amber, rounded, with the audio waveform drawn inside it, the source
+  timecodes at its corners (`0:05` … `0:12`) and its duration and speed in the middle (`7s ⏱1x`).
+- The **zoom track**: indigo segments, each labelled with its level and anchor mode (`🔍2x 🖱Auto`).
+- A **playhead** the full height, draggable, snapping to clip edges and zoom boundaries when within
+  4 px (hold ⌥ to suspend snapping).
+
+Waveform data is computed once on open by an `AVAssetReader` pass into a min/max envelope at
+several resolutions (a mip-chain), cached in the project bundle and computed lazily per visible
+span for a long recording. Recomputing it on every zoom change is the obvious wrong answer and the
+one that makes a timeline feel heavy.
+
+**Audio scrubbing.** Dragging the playhead plays the audio under it at a rate proportional to the
+drag speed, in both directions. Finding the exact frame between two words is the single most common
+precise edit anyone makes, and doing it by eye on a waveform is guesswork — this is how every real
+editor solves it and it costs one `AVAudioUnitVarispeed`.
+
+**Trim bubbles.** A trimmed end shows a rounded badge with a scissors glyph and the trimmed
+duration — exactly as in the reference — and clicking one *undoes that trim*. It is both the
+indicator that something is hidden and the control that brings it back, which is why trimming never
+needs to feel committal.
+
+`⌘⌥⌫` resets every trim and cut on the timeline at once, for when an edit has gone wrong enough
+that undo is the slower route.
+
+### The inspector
+
+Reuses `BackgroundInspector`'s idiom directly — `SettingsModule` cards, `SectionHeader`, stock
+sliders, and swatches drawn through the **same** `BackgroundCompositor` code path as the export, so
+a swatch cannot lie about what it produces. `BackgroundInspector` is 709 lines and already solves
+wallpaper import, mesh editing, preset save/load and the padding/inset/corner/shadow sliders with
+sensible maxima derived from the short side. Read it before writing the canvas tab; most of it
+transfers with the image size swapped for the canvas size.
+
+Three additions, all of which improve the screenshot editor too and should be built there so both
+get them:
+
+- **Favourites** — star a background; starred ones sort first. With a catalogue of any size this is
+  the difference between a picker and a haystack.
+- **Randomise** — one button. Useful more often than it sounds, because "any of these is fine" is
+  the honest state most of the time.
+- **A larger catalogue.** Twenty built-in meshes is thin next to the reference's hundred-plus. They
+  are data — a `MeshSpec` is nine colours — so this is taste and an afternoon, not engineering.
+  Group them into named collections rather than one long grid.
+
+Note the reference credits its gradients to raycast.com. Anything adopted from elsewhere carries
+its attribution in the UI, as theirs does.
+
+### Project file
+
+`Meeting demo.sarvstudio` is a **package directory** (`NSFileWrapper`, `UTType` declared as a
+package), containing the `.sarvrec` bundle plus `project.json`. A package rather than a flat file
+because the recording is hundreds of megabytes and re-serialising it on every autosave would be
+absurd; and a directory the user can open shows them exactly what the app is keeping.
+
+`project.json` is `Codable` with a `formatVersion`, hand-written `init(from:)` that defaults
+missing keys rather than throwing, and an `unknown` passthrough for forward compatibility — the
+exact contract `AnnotationDocument` and `CaptureBackground.Fill` already implement. A project
+written by a newer build must open, not error.
+
+Autosave through `CoalescingSaver`. Undo through `UndoStack<StudioProject>` — snapshot undo over a
+value type, depth 200, transactions around drags, exactly as the screenshot editor does it. The
+project is geometry and numbers, never bitmaps, so snapshots stay cheap.
+
+### Project management
+
+- **Recent projects**, in the tray panel and on `⌘O`.
+- **Duplicate project** — cheap, because the recording bundle is hard-linked rather than copied.
+- **Open an existing video** (`.mp4`, `.mov`) as a project. Everything that depends on the event log
+  — cursor rendering, auto-zoom, keystrokes — is unavailable and *says so*, greyed with a reason,
+  rather than appearing and doing nothing. Everything else (background, crop, trim, speed, captions
+  from the audio, camera overlay, masks) works. This is a genuinely useful mode: it makes the
+  compositor available to footage recorded anywhere.
+- **Drag a video onto the app** does the same.
+- **Presets** — `.sarvpreset` files holding canvas + cursor + camera + caption settings, saved,
+  named, applied in one click, and set as the default for new recordings.
+  `BackgroundPresetStore` is the model, including its "an unreadable file is logged and left in
+  place, never overwritten" rule.
+- **⌘K command menu** — a searchable list of every editor action with its shortcut. This is the
+  cheapest possible discoverability for a window that has a hundred of them, and it is the thing
+  that stops the keyboard map being knowledge only the author has.
+- **Export several projects at once**, queued, with one progress list.
+- **Extract the raw files** — write the untouched screen, camera and audio tracks out of the bundle.
+  The recording is the user's; the app should never be the only thing that can open it.
+
+---
+
+## Phase 4 — Timeline editing
+
+### The clip model
+
+```swift
+struct Clip: Codable, Equatable, Identifiable {
+    var id: UUID
+    var sourceStart: TimeInterval        // into the recording
+    var sourceEnd: TimeInterval
+    var speed: Double = 1.0              // 0.25 … 4.0
+    var volume: Double = 1.0             // microphone
+    var systemAudioVolume: Double = 1.0  // separate — see below
+    var isMuted: Bool = false
+    /// Per-clip cursor overrides. Both exist because both have a real use.
+    var hidesCursor: Bool = false
+    var disablesCursorSmoothing: Bool = false
+}
+```
+
+The two cursor overrides earn their place: **hide** is for a stretch where the pointer is parked
+over the thing being discussed, and **disable smoothing** is for a stretch where precision matters
+more than grace — walking down a menu, dragging a handle — and interpolation makes the cursor
+appear to hover between items it never touched.
+
+The two volumes are separate because "mute the video I was demoing but keep my narration" is the
+common case, and a single volume cannot express it.
+
+The timeline is `[Clip]`. Trimming moves `sourceStart`/`sourceEnd`; splitting replaces one clip with
+two; deleting removes one and everything after slides left. **Nothing is ever removed from the
+recording** — trim is a view onto it, which is what makes "un-trim" free and is why the trim badge
+can honestly say "5s".
+
+`Timeline` is a pure struct with the whole edit vocabulary, and it is where the tests live:
+
+```swift
+func split(at t: TimeInterval) -> Timeline
+func delete(id: Clip.ID) -> Timeline
+func trim(id: Clip.ID, start: TimeInterval?, end: TimeInterval?) -> Timeline
+func setSpeed(id: Clip.ID, _ speed: Double) -> Timeline
+func sourceTime(forOutput t: TimeInterval) -> (clip: Clip, sourceTime: TimeInterval)?
+var duration: TimeInterval
+```
+
+`sourceTime(forOutput:)` is the function the renderer and the exporter both call, and it is where
+speed changes become correct or subtly wrong. A clip at 2× consumes source twice as fast; the
+cursor events, the zoom segments and the captions must all be looked up through *the same*
+mapping, or a sped-up section desynchronises everything but the video. One function, one test
+suite, no second implementation.
+
+### Which clock every track is on
+
+Stated once, because getting it wrong is invisible until an edit is made:
+
+> **Every track — zoom, camera, masks, keystrokes, captions — is stored in *source* time**, and is
+> resolved for rendering through `Timeline.sourceTime(forOutput:)`.
+
+That is what makes trimming the start of a recording leave the zooms attached to the moments they
+were built for, rather than sliding them all two seconds early. It is also what makes deleting a
+clip in the middle simply skip the zooms inside it.
+
+Two consequences that must be handled explicitly, and both belong in `ZoomEaseTests`:
+
+**Ease durations are in *output* time.** A zoom-in specified as 0.6 s inside a clip sped up to 4×
+would occupy 0.15 s of the finished video and read as a jump cut. So the ease is evaluated against
+output time and the source lookup follows, not the reverse.
+
+**A cut inside a zoom segment must blend, not pop.** Splitting mid-zoom leaves the transform at one
+value on the outgoing frame and a different value on the incoming one. The rule: at a clip
+boundary the renderer re-eases **from the transform it was actually showing** to the incoming
+segment's target over 0.3 s of output time. Cutting the middle out of a zoomed passage is a normal
+edit and it must not flash.
+
+### Speed
+
+Per-clip, 0.25× – 4×. Audio is time-stretched with `AVAudioUnitTimePitch` (pitch preserved) rather
+than resampled, because a sped-up voice that also goes up a fifth is unusable.
+
+**Speed ramps are Phase 7.** A constant-speed clip is a lookup; a ramp is an integral, and getting
+the integral wrong desynchronises audio in a way that is very hard to see coming. Not worth
+carrying into the phase that has to be right first.
+
+### Silence trimming
+
+`SilenceDetector` — pure over an amplitude envelope, no AV types:
+
+```swift
+static func silences(in envelope: [Float], sampleRate: Double,
+                     threshold: Float, minimumDuration: TimeInterval) -> [Range<TimeInterval>]
+```
+
+Defaults: −45 dBFS, 0.6 s minimum. The UI offers "Remove silences" as a one-shot that inserts cuts
+you can then undo or adjust individually — **not** a live filter. A live filter means the timeline
+does not show what will be exported, which breaks the promise the whole editor rests on.
+
+Each removed silence leaves a **0.15 s pad** at each edge, because cutting exactly at the threshold
+clips the attack of the next word and makes speech sound gasped.
+
+### Speed up the typing
+
+The other half of the same idea, and the one the reference actually ships: **watching someone type
+is boring at 1× and fine at 4×.** `TypingDetector` finds runs of keystrokes (5+ within 2 s, gaps
+under 800 ms) and proposes a speed change over each.
+
+Presented as **suggestions**, not applied: each proposed run is highlighted on the timeline with an
+accept/adjust/dismiss control, plus "apply to all". A speed change silently inserted into someone's
+timeline is exactly the kind of helpfulness that makes a tool untrustworthy.
+
+Default 4×, adjustable per run. Available only when keystrokes were recorded.
+
+### Minimums
+
+A clip cannot be shorter than **100 ms** and a zoom segment cannot be shorter than **100 ms** —
+below that they are unselectable with a mouse and produce nothing visible. Enforced in `Timeline`
+and `ZoomSegment`, so a drag clamps rather than creating something the user cannot get rid of.
+
+### Keyboard
+
+The shortcuts an editor's muscle memory expects, routed through a `StudioKeyRouting` enum in the
+`EditorKeyRouting` mould (pure, exhaustively tested):
+
+`Space` play/pause · `←`/`→` frame · `⇧←`/`⇧→` second · `,`/`.` frame · `⌘B` split ·
+`⌫` delete selected · `I`/`O` set in/out · `⌘Z`/`⌘⇧Z` undo/redo · `⌘E` export · `⌘S` save ·
+`⌘0` fit timeline · `⌘+`/`⌘-` timeline zoom · `Z` add zoom at playhead · `⌘W` close.
+
+**J / K / L shuttle**, because anyone who has used an editor reaches for it without thinking: `L`
+plays forward and each further press doubles the rate (1×, 2×, 4×, 8×), `J` does the same
+backwards, `K` stops. Holding `K` with `J` or `L` scrubs slowly. Preview playback rate is also
+settable directly (0.25× – 2×) for reviewing fast passages.
+
+`X` is **ripple delete** — remove the selected clip and close the gap — distinct from `⌫`, which
+lifts it and leaves the gap. Both are wanted and conflating them is a daily annoyance.
+
+`⌘L` toggles **loop playback**, which is how you judge whether a zoom's easing is right: you watch
+the same two seconds twenty times.
+
+### The tracks
+
+Five, top to bottom, each independently collapsible:
+
+1. **Clip** — video with its waveform, trim handles, speed.
+2. **Zoom** — the segments.
+3. **Camera** — layout segments (Phase 5).
+4. **Keystrokes** — one tick per recorded key, so a keystroke overlay can be trimmed or deleted
+   individually. Present only when keystrokes were recorded.
+5. **Audio** — mic and system as separate lanes when both exist.
+
+Collapsing is remembered per project. A five-track timeline in a 700 px window is unusable
+otherwise, and hiding tracks the project does not use is the difference between "capable" and
+"cluttered".
+
+### Copy and paste clip settings
+
+`⌥⌘C` / `⌥⌘V` copies speed, volume and mute from one clip to another — the same argument as for
+zoom segments.
+
+### Preview quality — three named modes
+
+A preview that silently degrades is ruled out; one the user *chose* is fine, and none of them
+affect the export.
+
+| Mode | What it does |
+|---|---|
+| **Quality** | Preview matches the export exactly, motion blur included. The default. |
+| **Performance** | Half resolution and motion blur off, for a higher frame rate. Says so in the UI while active, so nobody judges the blur from it. |
+| **Power saving** | Quarter resolution, 30 fps, playback idles after 30 s of no interaction. For editing on battery. |
+
+Naming them beats a "reduced quality" checkbox: the modes have different reasons, and a user with a
+2019 Intel Mac and a user on a train want different ones.
+
+### Multi-select and batch edits
+
+⌘-click selects several clips, zooms or masks; the inspector then edits what they have in common,
+and ⌫ removes all of them. Setting the same zoom level on twelve segments one at a time is the
+fastest way to make an editor feel hostile.
+
+### Copy the current frame
+
+`⌘C` with nothing selected copies the **composited** frame at the playhead as a PNG — background,
+cursor, camera and all. Reuses `CaptureWriter.copyToPasteboard`. A screen recording is very often
+where a screenshot was actually wanted, and this makes that a keystroke instead of a re-shoot.
+
+### `⌘/`
+
+Opens a sheet listing every editor shortcut, generated from `StudioKeyRouting` rather than
+hand-written, so it cannot drift from what the keys actually do.
+
+---
+
+## Phase 5 — Audio, camera and masks
+
+### Audio capture
+
+Two independent tracks, recorded separately and kept separate:
+
+- **System audio** — `SCStreamConfiguration.capturesAudio` (macOS 13+, verified available), with
+  `excludesCurrentProcessAudio = true`. Arrives as `CMSampleBuffer` on the SCK output queue.
+- **System audio from one app only** — Sarvkrit already has this machinery.
+  `Features/Sound/AudioProcessTap.swift` is a Core Audio process tap built for the volume mixer, and
+  a per-process tap is exactly what "record only Safari's audio" needs. This is a genuine advantage
+  over doing it from scratch: the hard part is written, tested and shipping.
+- **Microphone** — `AVCaptureSession` with an `AVCaptureAudioDataOutput`, *not*
+  `SCStreamConfiguration.captureMicrophone`, which is macOS 15. Device is user-selectable and the
+  list reuses `AudioDevice`/`AudioDeviceMonitor` from the Sound feature, so the picker matches the
+  one the app already has. Recorded in **stereo** where the device offers it.
+
+  **Automatic gain control is switched off by default**, with a toggle. macOS's AGC rides the input
+  level during a take, so a narration that starts quiet gets pushed up mid-sentence and the result
+  cannot be normalised cleanly afterwards. A constant input level and one correction in the editor
+  is the better order of operations, and it is the reference's default too.
+
+Keeping them separate is not incidental: it is what lets the editor mute system audio and keep the
+voice-over, duck one under the other, and export a mix the user chose rather than the one that
+happened.
+
+Note that the app already holds an `NSAudioCaptureUsageDescription` and the `.audioCapture`
+`Requirement`, complete with its documented "macOS refuses this one silently" behaviour. The
+recorder inherits that: if the system-audio track is all zeroes when it should not be, say so
+afterwards rather than shipping a silent file.
+
+### Audio editing
+
+Per-track: volume (0–200%, reusing `SoftClip` from the mixer for anything above 100% — the same
+limiter, the same "quiet material at 200% is bit-for-bit untouched" property), mute, and a
+waveform.
+
+**Ducking** — when both tracks exist, optionally attenuate system audio while the mic is above a
+threshold. Attack 80 ms, release 400 ms, depth adjustable, default −12 dB. `Ducker` is pure over
+two envelopes.
+
+**Noise removal** — `AVAudioUnitEQ` high-pass at 80 Hz plus a spectral gate. Modest and honest; we
+do not claim to do what a dedicated tool does.
+
+**Background music** — an optional third audio lane holding a file the user supplies, with its own
+volume, fade in/out and loop-to-length. Sarvkrit ships **no music library**: bundling licensed audio
+is a licensing and download-size question this app has no reason to take on, and every user already
+has music they are allowed to use.
+
+**Voice normalisation** — measure integrated loudness over the mic track and apply one constant
+gain to reach a target (default −16 LUFS, the streaming convention), then hand anything that would
+clip to `SoftClip`. One gain for the whole track, not a compressor: a demo recorded slightly too
+quiet is the actual problem, and dynamic-range compression on speech is a taste decision this app
+should not make silently. `LoudnessMeter` is pure over an envelope and exhaustively testable.
+
+### Camera
+
+`AVCaptureSession` with `AVCaptureVideoDataOutput`, written to its own file. Resolution follows the
+device, capped at 1080p — a 4K webcam feed for a 300 px circle is pure waste.
+
+Editor controls, all per-project:
+
+| Control | Range / options | Default |
+|---|---|---|
+| Shape | Circle · Squircle · Rectangle · Full-frame | Squircle |
+| Corner radius | 0 – 50% (squircle/rect) | 26% |
+| Size | 10 – 40% of canvas height | 22% |
+| Position | 9-way grid + free drag | bottom-leading |
+| Margin | 0 – 8% of canvas | 3% |
+| Shadow | reuses `CaptureBackground.Shadow` | on |
+| Border | width + colour | off |
+| Mirror | on/off | on (front cameras look wrong un-mirrored) |
+| Zoom / crop | 1× – 2.5×, draggable framing | 1× |
+| Size during zoom | shrink · hold · grow | **shrink**, `pow(zoom, −0.2)` |
+| Aspect | 1:1 · 4:3 · 16:9 · free | 1:1 |
+| Fade in / out | 0 – 2 s | 0.35 s |
+| Capture resolution | 720p · 1080p · device max | 1080p |
+
+The reference's PiP is a squircle with a continuous corner curve, and the difference between a
+`RoundedRectangle(style: .continuous)` and the circular default is visible at this size — use the
+continuous curve.
+
+**The camera shrinks when the frame zooms in, it does not grow.** This is the opposite of the
+instinct and the reference states the reason plainly: a zoom exists to show something, and the
+camera covering it defeats the zoom. Hold and grow are offered because a talking-head intro wants
+them, but shrink is the default.
+
+Two more things the shape controls should get right: the camera keeps a **constant margin from the
+canvas edge regardless of the project's padding** (otherwise raising padding appears to move the
+camera), and the corner radius is computed from the *shorter* side so a non-square camera does not
+end up with lozenge ends.
+
+**Background removal** is Phase 6: `VNGeneratePersonSegmentationRequest` (macOS 12+, verified) at
+`.balanced`, matted with a 2 px feather. It is a per-frame cost and it is not always good, so it is
+off by default and labelled for what it is.
+
+### The camera track
+
+Camera *layout* changes over time, so it belongs on the timeline rather than in a single settings
+panel. A third track holds `CameraSegment`s:
+
+```swift
+struct CameraSegment: Codable, Equatable, Identifiable {
+    var id: UUID
+    var start: TimeInterval
+    var end: TimeInterval
+    var layout: Layout          // .pip | .fullFrame | .hidden
+    var transition: TimeInterval  // default 0.45, eased
+}
+```
+
+This is what makes the standard shape of a good demo possible: **full-frame camera for a five-second
+intro, PiP for the walkthrough, hidden while a dense diagram is on screen.** Doing it with a single
+"camera position" setting cannot express any of that.
+
+Transitions between layouts animate position, size and corner radius together on one curve, so a
+full-frame camera *becomes* the PiP rather than cutting to it.
+
+### Masks — hiding what should not be in the recording
+
+Regions that obscure part of the frame for a time range: an API key, a customer name, a Slack
+sidebar.
+
+**One mask holds a list of rectangles**, not a single one, so "hide every price in this table" is
+one object with one time range rather than nine to keep in sync. Ellipses too, reusing
+`PixelFilterElement.isEllipse`.
+
+**This is where Sarvkrit is already better than what it is copying, and it should stay that way.**
+The README argues at length that an ordinary blur is reversible and pixelation is recoverable when
+the alphabet is small — which is exactly the password case — and `PixelFilterElement` already
+implements a `.secureBlur` mode that keeps nothing but the region's mean colour, with texture
+generated from a seed rather than from the pixels. That model, that renderer and that argument
+transfer to video unchanged; a mask gains a start and an end and nothing else.
+
+Modes: `secureBlur` (default), `smoothBlur`, `pixellate`, `solid`, and **`highlight`** — the
+inverse, dimming everything *outside* the region to draw the eye to it, which is `SpotlightElement`
+from the screenshot editor with a time range added. Each is named for what it actually does. The video case adds one thing stills do not need — **follow a window**, driven by the
+`windowMoved` events, so a sidebar stays covered through a whole demo without keyframing it by hand.
+
+A mask that is set to follow a window and whose window disappears **stays put and stays opaque**
+rather than uncovering what it was hiding. That is the only safe failure direction and it should be
+a test.
+
+---
+
+## Phase 6 — Captions and keystrokes
+
+### Transcription
+
+`SFSpeechRecognizer` with `requiresOnDeviceRecognition = true`, run over the mic track (or the
+system track when there is no mic). `supportsOnDeviceRecognition` is checked first, and when it is
+false the feature says plainly that on-device recognition is unavailable for the chosen language
+and offers nothing — it does not fall back to the network. That is the whole reason this is the
+implementation and not a nicer-sounding API.
+
+`SFTranscriptionSegment` gives per-word `timestamp` and `duration`, which is exactly what the
+karaoke rendering needs. `addsPunctuation = true`.
+
+Output model:
+
+```swift
+struct Caption: Codable, Equatable, Identifiable {
+    var id: UUID
+    var words: [Word]                     // each with start, duration, text
+    var start: TimeInterval               // derived, cached
+    var end: TimeInterval
+}
+```
+
+### Grouping words into caption lines
+
+`CaptionGrouper` — pure, and this is where the quality is:
+
+1. Break at a pause longer than 0.45 s.
+2. Break at sentence-ending punctuation.
+3. Otherwise accumulate up to `maxCharacters` (default 42) and at most `maxWords` (default 9).
+4. Never leave an orphan of one word — merge it backwards.
+5. Prefer breaking at a clause boundary (`, ; : and but so because`) when a break is needed
+   mid-sentence.
+
+The reference's lines — "you press command and just drag it", "down here and now we format it to",
+"show US dollars." — are exactly this: short, breath-length, broken where a person would pause.
+
+### Rendering
+
+Karaoke highlighting, confirmed in every frame of the reference: spoken words in white, upcoming
+words in grey (~#9A9A9A), switching at each word's `start`. `CaptionStyle`:
+
+| Control | Options | Default |
+|---|---|---|
+| Font | System / Rounded / Mono / any installed | Rounded |
+| Weight | regular … heavy | semibold |
+| Size | 2 – 8% of canvas height | 4.2% |
+| Spoken colour | picker | white |
+| Upcoming colour | picker | 60% white |
+| Background | none / solid / blur | solid #000 @ 78% |
+| Corner radius | 0 – 24 | 14 |
+| Padding | 0 – 32 | 16 × 12 |
+| Position | top / centre / bottom + offset | bottom, 8% up |
+| Max width | 40 – 100% of canvas | 72% |
+| Highlight mode | word / line / none | word |
+
+Text is laid out with Core Text into a cached `CGImage` per caption line, re-tinted per frame
+rather than re-laid-out — laying out text 60 times a second for a line that changes once a second
+is the obvious waste.
+
+### The transcript editor
+
+A panel listing every caption line with its timecode, editable inline. Fixing "shows" to "show"
+must not re-run recognition, and re-timing must be possible by dragging a line's edges in the
+timeline. Also: delete a line, merge two, split one at the cursor.
+
+**A vocabulary field.** `SFSpeechRecognitionRequest.contextualStrings` takes words to bias
+recognition towards — product names, library names, people's names, jargon. One text field labelled
+for what it is ("Words to expect"), pre-filled with the project name. This is the difference between
+a transcript that says "Sarvkrit" and one that says "sav credit", and it is three lines of code.
+
+**Language** is chosen explicitly rather than guessed, from
+`SFSpeechRecognizer.supportedLocales()` filtered to those that support on-device recognition —
+showing a language we cannot actually run offline would be a promise we break at the last moment.
+The default is the system language when it qualifies.
+
+**Export SRT and VTT** alongside the video. Cheap, and it is what makes a recording accessible
+somewhere other than the file we produced.
+
+### Speaker notes
+
+A per-project text panel, shown in the editor and **never rendered into the video**. Two uses, and
+the second is the one that matters: notes about what still needs re-recording, and a script to read
+from. When notes exist, an option shows them full-screen on a chosen display during recording — a
+teleprompter — excluded from capture by `excludedBundleIDs` like everything else of ours.
+
+### Keystroke display
+
+Off by default; requests Accessibility on first enable (see the requirements note above).
+
+Renders recent keys as pills — `⌘` `⇧` `K` — in a configurable corner, each appearing on keydown
+and fading after 1.6 s, with repeated keys collapsing into a counter rather than stacking.
+
+Keys are captured with `NSEvent.addGlobalMonitorForEvents(matching: .keyDown)` under Accessibility
+trust — **not** through the shared `EventTapService`. That is the whole point of keeping this
+feature off the `EventTapFeature` path: a global monitor observes without consuming, so nothing this
+feature does can ever swallow a keystroke from the app the user is demonstrating.
+
+**What is never recorded**: anything typed while the focused element is a secure text field (the
+`FocusedRoleCache` check described under Files), and, when "modifiers only" is chosen, plain
+characters.
+The default is **modifier combinations only** — ⌘C, ⌃⇧R — because that is what a demo needs to
+show, and recording every letter someone types is a different and much larger promise.
+
+---
+
+## Phase 7 — The long tail
+
+- **Presets** — a named bundle of canvas + cursor + camera + caption settings, applied in one
+  click. `BackgroundPresetStore` is the model to copy, including its "an unreadable file is logged
+  and left in place, never overwritten" rule.
+- **Annotations over video** — reuse `AnnotationElement` wholesale, with each element gaining a
+  time range. Arrows, text, shapes, counters, spotlight, blur — all of it already exists and all of
+  it is already tested; it needs a start and an end.
+- **GIF export** — needs its own palette quantiser and dithering to not look terrible; treat it as
+  a real piece of work, not a format flag.
+- **Vertical / square templates** — 9:16 and 1:1 with the screen scaled and the camera enlarged, as
+  a preset rather than a separate mode. Note that zoom levels tuned for 16:9 are wrong at 9:16 —
+  `ZoomPlanner` targets a *fraction of the frame*, so it re-solves correctly when the aspect
+  changes, and the vertical export must re-run it rather than reuse the landscape segments.
+- **Device frames** — draw the recording inside a MacBook, iPhone or iPad bezel. A vector frame
+  (paths and a screen rect, in the `BackgroundCatalogue` mould — data, not PNG assets, for the same
+  reasons its comment gives), with colour variants. For a Mac recording the model can be detected
+  from the hardware identifier and the display's aspect; for iPhone capture the device reports
+  itself. Detection is a *default*, never a lock — the picker always wins.
+- **Chapter markers** from `appActivated` events.
+- **iPhone/iPad recording** — the device appears as an `AVCaptureDevice` over USB. A separate
+  capture path, sharing the editor unchanged. **State the limits up front**: macOS cannot report
+  finger taps the way it reports mouse clicks, so there is no cursor and no automatic zoom on an
+  iOS recording. Manual zooms, background, masks, captions and trimming all work. Saying this in
+  the UI when the source is a device is better than letting someone discover that the auto-zoom
+  toggle does nothing.
+- **`sarvkrit://` commands** — `record`, `stop`, `openRecording`, extending `CaptureURLCommand`.
+
+---
+
+## Coverage against the reference
+
+Every feature found on screen.studio's site and changelog, and where it lands here. The point of
+this table is that omissions are visible.
+
+| Reference feature | Here |
+|---|---|
+| Screen / window / area recording | Phase 1.5 |
+| Multi-display | Phase 1.5, cursor `isInside` in 1.2 |
+| Fullscreen-app recording | Phase 1.5 (window mode, `includeChildWindows`) |
+| Camera recording, 720p–4K | Phase 5 |
+| Microphone recording | Phase 5 |
+| System audio, all apps | Phase 5 (`capturesAudio`) |
+| System audio, selected apps | Phase 5 (`AudioProcessTap`, already in the app) |
+| Pause / resume | Phase 1.4 |
+| Countdown | Phase 1.5 (`CountdownView`, exists) |
+| Recording widget / HUD | Phase 1.6 |
+| Recording recovery (fragmented MP4) | Phase 1.1a |
+| Low disk space warnings | Phase 1.1a |
+| Recording flags / markers | Phase 1.6 |
+| Camera preview while recording | Phase 1.6 |
+| Precise window sizing before recording | Reuses `WindowManipulator` (exists) |
+| Area picker with grid guides, typed dimensions | Phase 1.5 |
+| Hide desktop icons | Phase 1.1 (`CaptureOptions`, exists) |
+| Auto gain control off | Phase 5 |
+| Stereo microphone | Phase 5 |
+| Automatic zoom on clicks | Phase 3.2 |
+| Automatic zoom on typing | Phase 3.2 |
+| Manual zoom ranges, duration | Phase 3.5 |
+| Zoom speed / animation / instant | Phase 3.4 |
+| Zoom level by number key | Phase 3.5 |
+| Copy/paste zoom, apply to all | Phase 3.5 |
+| Spring mass/tension controls | Phase 3.6 |
+| Smooth cursor movement | Phase 2.2 |
+| Cursor size, auto and manual | Phase 2.4 |
+| Motion blur | Phase 2.3 |
+| Click effects: ripple / shockwave / circle | Phase 2.5 |
+| Click sounds | Phase 2.5 |
+| Hide cursor when idle | Phase 2.6 |
+| Cursor loop to start | Phase 2.7 |
+| Cursor rotation when moving fast | Phase 2.5a |
+| Shake-to-locate removal | Phase 2.5a |
+| Enlarged-system-cursor detection | Phase 2.5a |
+| Custom cursor sets | Phase 2.1 |
+| Captured cursor bitmaps for non-system cursors | Phase 1.2 |
+| Zoom starting at t=0 opens already zoomed | Phase 3.4 |
+| Blended zoom across a cut | Phase 4 § clocks |
+| Restart / discard a take | Phase 1.6 |
+| Backgrounds: wallpaper / gradient / colour / image | Reuses `CaptureBackground` |
+| Favourites, random, larger catalogue | Editor § inspector |
+| Padding, inset, corner radius, shadow | Reuses `CaptureBackground` |
+| Background blur | Reuses `CaptureBackground.Fill.blurred` |
+| Aspect ratios incl. 9:16, 4:5, 1:1, custom | Reuses `AspectRatio`, extended |
+| Crop, aspect-locked, numeric | Editor § transport |
+| Device mockups, colours, models, auto-detect | Phase 7 |
+| Camera shape, size, position, radius, shadow | Phase 5 |
+| Camera fullscreen / hidden segments | Phase 5 § camera track |
+| Camera fade in/out | Phase 5 |
+| Camera background removal | Phase 6 |
+| Volume normalisation | Phase 5 |
+| Noise reduction | Phase 5 |
+| Per-clip volume, mute | Phase 5 |
+| Waveforms | Editor § timeline |
+| Ducking | Phase 5 |
+| Silence removal | Phase 4 |
+| Background music | Phase 5 |
+| Transcription, on-device | Phase 6 |
+| Language selection | Phase 6 |
+| Transcript editing | Phase 6 |
+| Captions styling and position | Phase 6 |
+| Word-level highlighting | Phase 6 |
+| SRT / VTT export | Phase 6 |
+| Speaker notes / teleprompter | Phase 6 |
+| Keystroke display | Phase 6 |
+| Keystroke timeline track | Editor § tracks |
+| Trim, split, delete, ripple delete | Phase 4 |
+| Speed per clip | Phase 4 |
+| Copy/paste clip settings | Editor § timeline |
+| Multi-track timeline | Editor § tracks |
+| J/K/L, frame stepping, loop | Phase 4 |
+| Timeline zoom, ⌘-scroll, pinch | Editor § transport |
+| Masks, blur/obscure, custom shapes | Phase 5 § masks |
+| Highlight mask | Phase 5 § masks |
+| Presets, save / share / default | Editor § project management |
+| Recent projects, duplicate, drag-drop | Editor § project management |
+| Create project from an existing video | Editor § project management |
+| Command menu ⌘K | Editor § project management |
+| Auto-save, project recovery | Editor § project file, Phase 1.1a |
+| MP4 up to 4K60, quality presets | Phase 1.9 |
+| GIF with palette | Phase 7 |
+| Copy to clipboard | Phase 1.9 |
+| Export presets: web / social / editor | Phase 1.9 |
+| Batch export | Editor § project management |
+| Quick export after recording | Phase 1.7 |
+| Files over 4 GB | Phase 1.1 |
+| Raw file extraction | Editor § project management |
+| Preview quality reduction | Editor § timeline |
+| Motion blur on cursor / zoom / pan | Phase 2.3 |
+| Antialiasing, texture caching | The renderer |
+| Lazy waveforms | Editor § timeline |
+| Audio scrubbing | Editor § timeline |
+| Trim bubbles, click to undo a trim | Editor § timeline |
+| Reset all trims and cuts | Editor § timeline |
+| Multi-select, batch edits | Editor § timeline |
+| Copy current frame as an image | Editor § timeline |
+| `⌘/` shortcut sheet | Editor § timeline |
+| Preview quality / performance / power saving | Editor § timeline |
+| Per-clip hide cursor, disable smoothing | Phase 4 § clip model |
+| Separate mic and system volume per clip | Phase 4 § clip model |
+| Speed up typing segments | Phase 4 |
+| Minimum clip / zoom duration | Phase 4 |
+| Transcription vocabulary hints | Phase 6 |
+| Browser chrome crop suggestions | Editor § transport |
+| "Always keep zoomed in" | Editor § transport |
+| Masks holding several rectangles | Phase 5 § masks |
+| iPhone / iPad recording | Phase 7 |
+| Device frames for iPhone/iPad | Phase 7 |
+| Menu bar access | Feature § tray panel |
+| Customisable shortcuts | Feature § shortcuts |
+| **Shareable links, cloud hosting, comments, view counts** | **Excluded — see Non-goals** |
+| **Licence keys, subscriptions, activation** | **Excluded — Sarvkrit has no tiers** |
+| **Dock icon toggle** | N/A — `LSUIElement` with `ActivationPolicyLease` |
+| **VPN / proxy handling** | N/A — no network code |
+
+### Where this plan goes further
+
+Parity is the floor, not the ceiling. Nine places where Sarvkrit should end up ahead, mostly because
+the screenshot editor already solved the problem:
+
+1. **Secure blur.** The reference's mask is a numeric blur amount. An ordinary blur is a linear
+   convolution and is routinely inverted; `PixelFilterElement.secureBlur` already keeps nothing but
+   a region's mean colour. For hiding an API key on video that is not a refinement, it is the
+   difference between working and not.
+2. **Masks that follow a window.** The reference states its masks are stationary and do not follow
+   scrolling. We have `windowMoved` events; a mask pinned to a window stays put when the window
+   does not.
+3. **Real caption styling.** The reference offers size and visibility. We have font, weight, colour,
+   background, radius, padding, position, width and highlight mode — because `TextElement` and
+   `TextPreset` already exist.
+4. **Silence removal.** The reference has none.
+5. **Zoom on typing, not only on clicks.** The reference is explicit that a zoom with no click under
+   it does nothing. Filling in a form is a demo too.
+6. **Annotations.** Arrows, text, shapes, counters and highlights are Paused on the reference's own
+   roadmap. `AnnotationElement` is shipped and tested here; it needs a time range.
+7. **Auto Balance.** Choosing a background from the recording's own colours already exists.
+8. **ProRes export and separate audio tracks**, for handing a recording to a real editor. The
+   reference exports MP4 and GIF only.
+9. **No account, no network, no export paywall.** The reference gates export behind a subscription
+   and hosts shared links in its cloud. Sarvkrit contains no network code at all, and this feature
+   must not be the thing that changes that.
+
+---
+
+## Verification
+
+### Automated — `make test`
+
+Pure logic, exhaustively, in the house style (no AV, no CG, no filesystem):
+
+`ZoomPlannerTests` · `ZoomEaseTests` · `TimelineTests` · `CursorPathTests` (smoothing, click-snap,
+shake removal, loop-back) · `CursorGlyphTests` · `ClickEffectTests` · `SilenceDetectorTests` ·
+`TypingDetectorTests` · `CaptionGrouperTests` · `DuckerTests` · `LoudnessMeterTests` ·
+`MaskGeometryTests` (including: a follow-a-window mask whose window vanishes stays opaque) ·
+`CameraLayoutTests` · `StudioKeyRoutingTests` · `StudioProjectCodingTests` (round-trip +
+forward-compat `unknown` passthrough) · `RecordingClockTests` · `RecordingRecoveryTests` (a
+truncated fragmented file recovers, and the sidecars truncate to match) · `ExportPresetTests` ·
+`StudioLibraryStoreTests` (age *and* size eviction)
+
+Rendering, through the existing snapshot harnesses:
+
+- `StudioRenderSnapshotTests` — a fixture project rendered at fixed times, written to
+  `PreviewDirectory` under `make preview`, asserted differentially (zoomed ≠ un-zoomed, captions on
+  ≠ off, cursor styles differ from each other).
+- `StudioChromeSnapshotTests` — the editor window in both appearances. **Use the real off-screen
+  `NSWindow` at (−30000, −30000)**, not the windowless `NSHostingView`: this UI is built on
+  semantic colours and stock controls, and the windowless helper renders those transparent and
+  renders AppKit controls as placeholder blocks. `TrayPanelRenderTests` documents both traps.
+- `StudioRendererParityTests` — the software and GPU backends agree within a per-channel tolerance,
+  and the geometry assertions (cursor centroid, screen-rect bounds, caption baseline) are exact.
+  Geometry is where the bugs are.
+- `StudioRenderGeometryTests` — the same `render(project:at:)` call used by preview and export
+  produces the same transform for the same time. This is what keeps "preview matches export" true;
+  it is one function, so this is cheap to assert and catches any future fork immediately.
+
+Hardware-touching code goes behind `ScreenRecording` and is stubbed by `StubScreenRecordingService`,
+which replays a fixture bundle. No test may open a real `SCStream` or `AVCaptureSession` — the test
+host lives inside `Sarvkrit.app` and would prompt for TCC or hang. A `CIContext` *is* fine
+(`PixelFiltersTests` already uses one) provided it is the `.software` backend, so the result does
+not depend on which GPU ran it.
+
+Remember `AppIdentity.isRunningTests`: nothing here may write the pasteboard, post events or open a
+window during a test run.
+
+### Manual
+
+0. In `sarvkrit_wt/studio` (or the phase's own worktree): `xcodegen generate`, and confirm with
+   `pgrep -lf "Sarvkrit.app/Contents/MacOS/Sarvkrit"` that no other worktree's build is running.
+1. `make test` — the whole suite, with a running Sarvkrit quit first.
+2. `make preview` — open `build/preview/` and look at the rendered frames. Several classes of bug
+   in this feature (a cursor one pixel off, a caption clipped, a shadow tracing square corners) are
+   invisible to assertions and obvious in a picture. This is why the harness exists.
+3. `make install && open /Applications/Sarvkrit.app` — permissions are keyed to location, and
+   Screen Recording will need the relaunch dance on first grant.
+4. Record a 30-second demo of a real app with clicks, typing, scrolling and a window drag.
+5. Confirm, in order: the recording opens; auto-zoom found the click clusters and not the idle
+   stretches; the cursor is sharp at 2.5× and lands exactly on what it clicked; captions match the
+   speech and highlight word by word; trimming the ends does not move the zooms; exporting 1080p
+   H.264 produces a file that matches the preview frame for frame.
+6. ⌃⇧⎋ during recording clears everything.
+7. Revoke Screen Recording in System Settings and confirm the feature says so rather than
+   producing black frames.
+
+---
+
+## Sequencing note
+
+Phase 1 is the risky one and it is the one to build first, in full, including the clock test. The
+zoom planner and the cursor renderer are pure functions over data — they can be written and tested
+before there is a single frame of real video, and they should be, because they are where the taste
+lives and taste needs iteration.
+
+Everything after Phase 3 is additive: a project with no captions, no camera and no audio renders
+correctly through the same pipeline, so each later phase adds a layer rather than changing one.
+
+

--- a/docs/superpowers/specs/2026-09-05-screen-studio-feature-inventory.md
+++ b/docs/superpowers/specs/2026-09-05-screen-studio-feature-inventory.md
@@ -1,0 +1,828 @@
+# Screen Studio — Exhaustive Feature Inventory (research for clone-implementation spec)
+
+Research date: 2026-09-05. Current shipping version at time of research: **3.7.5-4595** (released 2026-08-05).
+
+Confidence markers used throughout: **[P]** = primary source (screen.studio / its docs / changelog / privacy policy), **[R]** = reverse-engineered from a third-party tool that drives the real app, **[3]** = third-party review (lower trust), **[BETA]** = on the vendor's own beta/roadmap, not shipped.
+
+---
+
+## 0. Source URLs
+
+Primary:
+- https://screen.studio/ (homepage; pricing lives at the `#pricing` anchor — there is **no** `/pricing` page, it 404s)
+- https://screen.studio/guide (docs index, ~60 articles)
+- https://screen.studio/changelog (full history back to 2.5.7, May 2023)
+- https://screen.studio/roadmap
+- https://screen.studio/download
+- https://screen.studio/legal/privacy-and-cookie-policy
+- https://screen.studio/dashboard (account/licence/shareable-link management)
+- https://hub.screen.studio/ (public feedback board), https://hub.screen.studio/changelog (empty)
+- https://preview.screen.studio/guide/... (a preview docs mirror; content matched production)
+
+Guide articles cited individually in the sections below (all under `https://screen.studio/guide/<slug>`).
+
+Reverse-engineering sources (high value, they drive the actual shipping binary):
+- https://github.com/HyperfocuSam/screenstudio-agent — CLI driving Screen Studio over Chrome DevTools Protocol; verified against 3.7.3-4475. README + `src/cli/commands/*.ts` + `skills/screenstudio-cli/SKILL.md`
+- https://github.com/ShawnPana/screenstudio-cli — upstream of the above
+- https://codeforcreatives.com/blog/reverse-engineering-file-formats-with-claude/ — `.screenstudio` bundle layout
+- https://github.com/crafter-station/open-screenstudio — an open clone attempt (README only, no internals)
+- https://www.raycast.com/screen-studio/screen-studio — official Raycast extension
+
+Third-party reviews consulted (treat pricing claims in these as **stale/wrong** — see §21):
+dockshare.io, denshub.com, saastreats.net, datastudios.org, creatoreconomytools.com, alternativeto.net news posts for 3.0 / 3.1 / 3.2.
+
+---
+
+## 1. Product identity and platform
+
+- macOS-only screen recorder + opinionated post-production editor. No Windows/Linux. "Is the Windows version ready?" is a standing FAQ item on the homepage. [P]
+- Author: Adam Pietrasiak (indie/small team). Payments via **Lemon Squeezy**. Support: team@screen.studio.
+- **System requirements** [P] (`/guide/system-requirements`):
+  - macOS **Ventura 13.1 or later**
+  - Apple **M1 or later preferred**; Intel supported on MacBook Pro 2018+, MacBook Air 2020+
+  - **8 GB RAM minimum**
+  - Separate Apple Silicon and Intel builds are distributed (from `screenstudioassets.com`). A crash affecting Intel machines was fixed in 2.22.9; 3.4.2 added "ensure correct app version architecture for device".
+- Per-feature OS floors:
+  - System audio recording requires macOS 13.0+ (2.16.7 fixed a UI state that let you try on older macOS).
+  - Recording-control widget is excluded from the capture only on **macOS 12.3+** (`/guide/managing-recording-in-progress`).
+  - **iPhone Mirroring** capture requires **macOS Sequoia 15+** (`/guide/iphone-mirroring`).
+  - **Apple Speech Recognition** transcription engine requires **macOS 26.0+** (`/guide/captions`).
+- A **beta channel** exists as a separate download (`/download`).
+
+---
+
+## 2. Architecture (reverse-engineered — important for a clone)
+
+Evidence: screenstudio-agent drives the shipping app through `--remote-debugging-port`. [R]
+
+- **Screen Studio is an Electron app.** It accepts `--remote-debugging-port=9222`, exposes `/json` page listing, and its renderer is inspectable over CDP.
+- Renderer is **React** — the CLI walks `document.getElementById("root")[__reactContainer…]`'s fiber tree looking for components with `memoizedProps.label` of `"Record display"`, `"Record window"`, `"Record area"` and calls their `onClick`.
+- State is **MobX**: `$projects` is an "MobX ObservableMap of all open projects"; `window.$project` is the active one. The SKILL warns "Screen Studio can crash if MobX state becomes inconsistent."
+- Main↔renderer IPC is **electronTRPC** — `bridge.client.query/mutation/subscription`. Known procedures include `capture.finish`. Notably **no** state query exists: `capture.state`, `capture.status`, `capture.getState`, `capture.isRecording`, `capture.info`, `capture.current`, `capture.get`, `recording.state` all return *"No query-procedure on path"*.
+- Renderer has **Node integration disabled** (`require`/`process`/`module`/`__dirname` undefined); the privileged preload bridge is still reachable over the port.
+- `electronEnv` global exposes app version and flags.
+- Undo/redo is an explicit snapshot API: `project.history.update()` is called *before* each mutation; `project.canUndo` / `project.canRedo`.
+- `project.serialize()` returns project JSON. `project.updateConfig({...})` applies config live.
+- The **preview canvas is a DOM canvas element** rendered at 2x — the CLI screenshots "just the canvas element from Screen Studio's preview renderer at 2x resolution". So preview compositing is done in the renderer (WebGL/Canvas), not by a native player.
+- The recorder core is separate and native-ish: logs land in `polyrecorder.log`, and changelog entries repeatedly say things like "updated the version of the core of Screen Studio recorder", "reworked recorder core library", "beta experimental: used a different version of core of our recorder".
+- **There are two capture engines, and the user can switch.** 2.25.2 [P]: *"Speaker notes feature is disabled when Screen Capture Kit is turned off (cannot be used in this case)."* A user-facing toggle to disable **ScreenCaptureKit** therefore exists, implying a legacy fallback capture path (almost certainly CGDisplayStream/AVFoundation) for older macOS or problem hardware. A clone should plan for the same split — and note that window-exclusion features (speaker notes, the recording widget) only work on the SCK path.
+- **App UI is English-only.** No evidence anywhere of UI localization; "multi-language" in Screen Studio refers exclusively to caption/transcript languages (§12).
+
+---
+
+## 3. Project file format — `.screenstudio` bundle [R] + [P]
+
+`.screenstudio` is a **macOS bundle (a directory Finder shows as one file)**, not a single file. `/guide/sharing-your-project` [P] confirms: *"Some applications or cloud services that don't recognize this extension might treat it as a folder containing separate files"* and recommends right-click → Compress before sharing.
+
+Root level:
+- `meta.json` — version number, required version, creation date
+- `project.json` — the edit document; Screen Studio writes it when the bundle is opened
+- `recording-markers.json` — recording flags (see §5)
+- `recording/` — the raw capture
+
+Inside `recording/`:
+- **Hundreds of `.m4s` fragmented-MP4 segments plus `.m3u8` playlists** — i.e. the recorder writes HLS-style fragmented segments live, which is how it survives crashes and supports pause/resume and recovery.
+- `channel-<N>-display-<M>.mp4` — a flattened per-channel screen video. The CLI globs `channel-*-display-*.mp4` because the channel number varies per recording. This implies **multiple video channels** (screen, camera, external device) each tagged by display.
+
+> **Caveat on the two media layouts.** The `.m4s`/`.m3u8` segment list comes from the codeforcreatives teardown; the `channel-N-display-M.mp4` flat file comes from screenstudio-agent verified against **3.7.3-4475**. These are different sources and possibly different app versions. They may coexist (segments written live, then muxed into a flat per-channel MP4 on finish — which would explain both the recovery behaviour and the CLI being able to hand a single file to ffmpeg), or one layout may predate the other. Do not treat this as one verified layout.
+- `.m4a` audio files (microphone / system audio as separate assets)
+- `cursors/` — **cursor images captured during recording** (every distinct system cursor bitmap seen)
+- `metadata.json`
+- `keystrokes-0.json`
+- `mouseclicks-0.json`
+- `polyrecorder.log`
+
+Event schemas (read directly by the CLI's `analyze` command) [R]:
+```
+keystrokes-0.json : [{ processTimeMs: number, character: string, type: string }, …]
+mouseclicks-0.json: [{ processTimeMs: number, button: string, x: number, y: number }, …]
+```
+Mouse *positions* are a separate stream from clicks (the app exposes `recording.mouseEvents` and `recording.hasCursor`).
+
+`project.json` is hand-editable: *"If you corrupt state, it persists to disk. You may need to manually edit `project.json` inside the `.screenstudio` bundle to fix it."*
+
+Projects **auto-save** (added 2.25.10). Default projects folder is `~/…Screen Studio Projects…` (observed as `~/Screen Studio Projects/`); the location is configurable in Settings (added 2.22.0). Save = `⌘S`, Save As = `⌘⇧S`.
+
+**There is no project library / browser UI.** Projects are plain bundles in a folder. Discovery routes are: **File → Open Recent** (the list is existence-checked and self-updating, 2.22.0; large project icons in it were fixed in 3.5.1), the recording modal, the **system tray menu** ("open projects from the system tray menu", 2.26.0), **drag & drop** onto the editor or menu-bar icon (2.26.0), and Finder. The web **dashboard** manages licences, devices and shareable links only — **not** projects.
+
+---
+
+## 4. In-memory project object model [R]
+
+This is the closest thing to a schema for a clone. All from screenstudio-agent's `state.ts`, `zoom.ts`, `slice.ts`, `mask.ts`.
+
+```
+project
+  .name .id .path
+  .playbackDurationMs        // duration of the EDIT
+  .isDirty .canUndo .canRedo .hasAudio
+  .config                    // 68 keys, flat, primitives/arrays/objects
+  .scenes[]                  // in practice one scene, scenes[0]
+  .recording
+  .history.update()
+  .updateConfig({...}) .serialize()
+
+recording
+  .recordingPath             // path to recording/ inside the bundle
+  .durationMs
+  .mode                      // display | window | area | device
+  .hasCamera .hasAudio .hasCursor .hasKeystrokes .hasMicrophone .hasSystemAudio
+  .keystrokes[] .mouseEvents[]
+
+scene
+  .id .name
+  .slices[]
+  .zoomRanges[]
+  .masks[]
+  .update({ zoomRanges, masks, … })
+  .findSliceAtTime(ms)
+  .addMaskAt(ms) .updateMask(id, {...}) .removeMask(id)
+  .addZoomRangeAt(ms)        // creates a ~3s default range; known to overwrite adjacent ranges
+
+slice                        // a timeline clip
+  .id .index
+  .sourceStartMs .sourceEndMs        // position in the ORIGINAL recording
+  .playbackStartMs .playbackEndMs    // position in the EDITED output
+  .speed                             // derived
+  .timeScale                         // STORED value; timeScale = 1 / speed  (4x → 0.25, 0.5x → 2)
+  .volume
+  .systemAudioVolume                 // separate from .volume — mic and system audio are independent per slice
+  .hideCursor                        // per-slice cursor hiding
+  .splitAt(ms) .remove() .mergeWithNext()
+  .canSplitAt(ms)
+  .update({ sourceStartMs, sourceEndMs, timeScale, volume, hideCursor, … })
+
+zoomRange
+  .id                        // 10-char alphanumeric
+  .type                      // "auto" | "manual"
+  .isAuto .isManual
+  .zoom                      // magnification multiplier, e.g. 2, 2.5, 3
+  .startTime .endTime        // source ms  (read back as sourceStartTime/sourceEndTime)
+  .duration
+  .manualTargetPoint         // { x: 0-1, y: 0-1 } normalised to the FULL recording frame
+  .snapToEdgesRatio          // CLI writes 0.25 on creation
+  .glideDirection            // null | direction — CLI writes null
+  .glideSpeed                // CLI writes 0.3 on creation
+  .isDisabled                // disable without deleting
+  .isSystem                  // app-generated vs user — CLI writes false
+  .hasInstantAnimation       // true = cut to the zoom with no animation ("Instant Zoom") — CLI writes false
+```
+> **Caveat on those numbers.** `snapToEdgesRatio: 0.25`, `glideSpeed: 0.3`, `glideDirection: null`, `isSystem: false`, `hasInstantAnimation: false` are the values screenstudio-agent's zoom-construction template writes when creating a new zoom. They very likely mirror the app's own defaults (the template was built by observing real zooms), but they were **not** read out of the app's default config — treat them as strong hints, not verified defaults. Same for mask `blur: 20`.
+```
+
+mask
+  .id
+  .type                      // "sensitive-data" (blur mask); highlight is the other type
+  .startTime .endTime        // source ms (read back as sourceStartTime/sourceEndTime)
+  .bounds                    // ARRAY of { x, y, width, height } — multiple rects per mask
+  .blur                      // numeric blur amount, CLI default 20
+```
+
+**Coordinate spaces** (documented explicitly in the agent SKILL) [R]:
+- *Recording coordinate space* — what the metadata reports, e.g. `2560 × 1353`. **Mask `bounds` are in this space.**
+- *Video file pixel space* — the actual raw `.mp4` dimensions, e.g. `4096 × 2164`.
+- They differ by a `recordingScale` factor (observed **0.625**): `video_px = recording_px × (1 / 0.625) = × 1.6`.
+- Zoom `manualTargetPoint` is normalised 0–1 so it is space-independent.
+- Zoom crop maths: at zoom level Z the viewport is `(videoWidth/Z, videoHeight/Z)` centred at `(targetX × videoWidth, targetY × videoHeight)`, and **the crop is clamped to the video bounds** — so `x`/`y` of 0 or 1 pin the viewport flush to an edge rather than running off it. At 2× on a 4096×2304 source the visible area is exactly 2048×1152, i.e. one quadrant-pair. [R]
+
+`config` is **68 flat keys** [R]. Confirmed key names seen in the wild: `backgroundColor`, `cursorSize`, `hideCursor`. The rest map to the sidebar controls enumerated in §8–§13.
+
+---
+
+## 5. Recording
+
+### 5.1 Capture targets [P]
+Opened via a **recording picker modal** (auto-shown at launch; reopen with **`⌥⌘↩`**, or via the menu-bar icon, or the system tray menu). Modes:
+
+| Mode | Behaviour |
+|---|---|
+| **Display** | Move the mouse to the target display and click to confirm. Multi-display supported. If only one display, it is auto-selected (2.8.1). Ultra-wide/ultrawide handled specially — video is scaled down to avoid crashing the encoder (2.26.0), and 4K export from ultrawide with auto aspect was a fixed bug (2.25.10). |
+| **Window** | Click a window to pick it, or **right-click the `Window` button for a list**. Full-screen apps are selectable (2.6.3) but the docs advise using `Display` for a full-screen app. Windows can be **resized precisely before recording** (2.6.2) with size presets including smaller sizes and a 16:10 preset (2.6.4). The chosen window is focused before recording starts (2.10.8) — this needs Accessibility permission. |
+| **Area** | Drag the area, or **type exact dimensions**. Guide lines appear while picking (2.26.0); a **25% / 50% / 75% grid** is shown (2.25.18); the input form dodges the centre of the area so you can align on centre. Area dimensions can be **saved and reused as an aspect ratio** (2.25.10). Max dimensions are surfaced (2.25.2). |
+| **iPhone / iPad** | See §5.6. |
+
+Other picker affordances: "Start recording" button sits next to the picked target (2.10.8). Unrecorded area is dimmed; the dim can be disabled (2.20.0). Recording can be started, and projects opened, from the **system tray menu** (2.26.0).
+
+### 5.2 Camera & microphone at capture time [P] (`/guide/webcam-microphone`)
+- **Camera**: click the camera icon → pick device. A live preview window appears. *"The preview remains visible during recording but doesn't appear in the final output. Screen areas covered by the preview are still captured."* Right-click → **"Hide camera preview"**. 3.4.7 added a **full-frame camera preview before recording**.
+- **Camera capture quality**: **720p / 1080p / 4K** selectable ("High quality camera format", 3.4.5; 1080p and 4K support landed 3.2.2). Ideal webcam FPS set to **30** (3.4.10).
+- **Microphone**: click the mic icon → pick device. *"The white bar under the microphone icon shows if your microphone is working and collecting sound."*
+- **Stereo microphone support** added 3.4.7; a "stereo mode option for microphones" was fixed in 3.7.1. Historically the exported mic stream was converted to **mono** (2.25.2) and stereo mix was corrected in 2.22.0.
+- **Auto gain control is disabled** by default (2.25.10) with an option to toggle it — important, macOS AGC otherwise changes input volume mid-take.
+- Camera without a microphone is allowed; a warning appears if you select a camera and no mic (2.22.14).
+- Warning shown if the mic is muted because the laptop lid is closed (2.22.0).
+- **macOS Video Effects** pass through and are controlled from the system menu-bar camera icon, not from Screen Studio: **Background (wallpapers), Portrait (background blur), Studio Light** (`/guide/camera-settings`), and **Reactions** (`/guide/reactions-`) which must be turned **off** there to keep emoji/hand-gesture effects out of a recording. Screen Studio has **no built-in background blur** of its own in the shipping version.
+
+### 5.3 System audio [P] (`/guide/recording-system-audio`)
+- Click the **`system audio`** button, then choose **all apps** or **a selected group of apps** — "the rest of them will be ignored". Per-app system-audio capture is a real feature, not just a global tap.
+
+### 5.4 Recording controls in progress [P] (`/guide/managing-recording-in-progress`, `/guide/starting-finishing-the-recording`)
+- A floating **recording control widget** with: **finish**, **pause**, **resume**, **restart**, **delete/cancel**, plus an **elapsed-time counter**.
+- Right-click the widget → **"Hide current recording control"**. On macOS 12.3+ the widget is excluded from the captured video. (3.0.1 explicitly "removed recording controls from recording output".)
+- **Pause/resume shipped in 3.2.0** (April 2025) along with a **keyboard shortcut for pausing**.
+- Four ways to stop: the widget's `Stop Recording` icon; the **menu-bar icon** (noted as possibly hidden behind a MacBook notch); **right-click the Dock icon → `Finish Recording`**; or the **global Start/Stop shortcut** set during onboarding and editable in Settings.
+- A **`Magnetic multifunction button`** was added in 3.5.0.
+- **Countdown**: a countdown runs between the record click and the first frame — the docs don't state the duration, but measurement by screenstudio-agent puts the gap at a consistent **~4.2 s** from click to first frame, of which ~1.6 s is after the picker closes. [R] Countdown bugs appear in the changelog (2.8.1 "avoid incorrect timeout error stopping recording countdown"; 2.6.3 freeze on full-screen apps).
+- Low-disk-space checks before and during recording; friendly error codes; project **recovery** if a recording stops unexpectedly (2.26.0, 3.2.0 "improved recording recovery system").
+- Only one recording session at a time is enforced (3.0.0-3181).
+- **Hide Dock icon**: Settings → General → **"Hide Dock Icon"** — hidden when no project is open and no recording is running (`/guide/hiding-dock-icon`).
+- **Notifications**: suppressed by default. To let them through, enable macOS System Settings → Notifications → **"Allow notifications when mirroring or sharing display"** (`/guide/capturing-notifications`).
+
+### 5.5 Recording flags [P] (`/guide/recording-flag`)
+- Press **`⌃⌥⌘F`** (customisable, Settings → Shortcuts → "Create recording flag") during a take to drop a marker. Flags appear on the editor timeline. Persisted as `recording-markers.json`.
+
+### 5.6 iPhone / iPad [P]
+Two distinct paths:
+
+**A. Direct device capture** (`/guide/recording-iphone-ipad`) — since 2.15.3 (July 2023):
+- Over **USB cable**; *"USB-C to Lightning cable is strongly recommended instead of USB-A to Lightning"*; docking stations discouraged; connect directly.
+- Unlock the device first, trust the Mac when prompted, and **don't lock the device during recording**.
+- **Audio from the iPhone itself** is recordable since **3.2.0**. Mac mic and webcam can be recorded simultaneously.
+- **Device mockups/frames**: auto-detected model, changeable in the editor ("Device frame" tab), with **colour variants** per model; mockups can be **disabled entirely** (2.25.2). Mockup library seen in the changelog: iPhone 11, 12, 13, 14, 15 (all models' bezels), 16, 16 Plus, 16 Pro, 17 Pro, 17 Pro Max, iPhone Air; iPad Pro 11", iPad Pro 12, horizontal iPad mockups. Device list is ordered chronologically (3.5.1). Corner radius is matched to the real device (2.26.0). Rotating the device mid-recording is handled (2.25.2).
+- **Hard limits**: *"Screen Studio cannot record your finger taps the same way it can record your mouse clicks and movement."* Therefore **automatic zooms are not supported** and **no cursor is drawn**. Workaround suggested: pair a Bluetooth mouse — but *"Screen Studio will not be able to make its movement smooth like on desktop recordings."*
+
+**B. iPhone Mirroring capture** (`/guide/iphone-mirroring`) — added 3.5.0:
+- Requires **macOS Sequoia 15+** and Apple's iPhone Mirroring app.
+- You record the **iPhone Mirroring app's window** using normal *Window* mode; Screen Studio then still offers the **"Device frame"** tab to skin it as an iPhone.
+- Mic and webcam can be layered on.
+
+### 5.7 Importing existing video [P] (`/guide/creating-project-from-existing-video`)
+- **File → "Create project from video…"**. Accepts **.mp4** (2.25.18) and **.MOV** (3.2.0). Audio is carried across if present.
+- Everything visual works (zooms, background, etc.). **Unavailable**: mouse-cursor animations and the selfie camera — because those come from capture-time metadata that an imported file doesn't have. (2.26.0 explicitly hardened against crashing "if there are no cursors, e.g. when importing external video".)
+
+### 5.8 Speaker notes / teleprompter [P] (`/guide/speaker-notes-`) — since 2.18.1
+- Recording modal → settings icon → **"Show Speaker Notes"**.
+- Start with **"Start Prompter"** or **`⌘⌥.`**.
+- Settings (top-right of the notes window): **scrolling speed** (a faster option added 3.4.4), **opacity**, **font size**.
+- Notes are invisible in the recording *even though they cover what you're recording* — this is a real compositing exclusion, not just a window level. Consequently the feature is **disabled when ScreenCaptureKit is turned off** (2.25.2), which strongly implies it relies on SCK's window-exclusion list.
+- Visible in fullscreen presentations (3.1.0); visible when using DisplayLink (3.4.6).
+
+### 5.9 Resolution / frame rate / HDR
+- **Export** is stated at up to **4K 60 fps** [P, homepage]. Frame-rate choices at export are **60** vs **24–30** [P, `/guide/explanation-of-export-settings`].
+- Capture side: recorded display FPS is detected and displayed (rounded up, 2.22.0). Retina is handled via a `recordingScale` factor (0.625 observed) between recording coordinate space and the raw file's pixel space [R] — i.e. the raw file is captured at higher-than-logical resolution and the edit model works in logical points.
+- **No HDR.** Nothing in any primary source mentions HDR capture or export; the app targets SDR H.264-class MP4. Treat HDR as unsupported.
+- **No 120 Hz / ProMotion capture** — 60 fps is the ceiling. [3, but consistent with all primary material]
+
+### 5.10 macOS permissions required [P] (`/guide/setting-up-permissions`)
+On first launch it requests **Accessibility**, **Camera**, **Microphone**, and **Screen Recording**. Accessibility is specifically for **focusing and resizing recorded windows** (2.16.6 added an explicit toggle for that in recorder settings, and 2.10.8 added clearer prompts). Keystroke capture also implies an input-monitoring/event-tap path, though the docs don't name it separately.
+
+---
+
+## 6. Captured metadata (the thing that makes Screen Studio Screen Studio)
+
+**Confirmed: the cursor is NOT baked into the recorded video.** Primary-source quote, changelog 2.18.1 [P]:
+
+> "raw screen recording file will not include your mouse cursor as it is not directly recorded by Screen Studio — it is re-added later basing on your mouse position data."
+
+What is captured alongside the video, per the bundle contents and the runtime object model:
+
+| Data | Where | Notes |
+|---|---|---|
+| **Mouse positions** (continuous) | a JSON file in `recording/`; surfaced at runtime as `recording.mouseEvents` | Filename **not confirmed** — only `keystrokes-0.json` and `mouseclicks-0.json` are named by any source. The `-0` suffix implies a per-channel/per-display index, so expect something like `mousemoves-0.json`. Used for smoothing, auto-zoom panning, cursor re-rendering |
+| **Mouse clicks** | `mouseclicks-0.json` → `{processTimeMs, button, x, y}` | Button identity is captured, so left/right clicks are distinguishable. Drives auto-zoom and click effects |
+| **Keystrokes** | `keystrokes-0.json` → `{processTimeMs, character, type}` | Drives the on-screen shortcut overlay AND typing-segment detection |
+| **Cursor bitmaps** | `recording/cursors/` | The actual system cursor images encountered, so the correct arrow/I-beam/pointer/resize cursor is re-drawn. Texture caching added 2.22.16; "support for system cursor variants" 3.4.7; missing-cursor fallback 3.2.3 |
+| **Cursor type changes** | implied | There's an "Optimize original cursor types" toggle that smooths rapid type transitions, and a fixed bug where the cursor stayed a pointer after clicking a link |
+| **Recording flags** | `recording-markers.json` | User-dropped markers |
+| **Device/frame metadata** | `metadata.json` | Frame size, `recordingScale`, mode, device model for iOS |
+| **Channel/display mapping** | filenames `channel-N-display-M.mp4` | Multi-channel, multi-display aware |
+| Capability flags | `recording.has{Camera,Audio,Cursor,Keystrokes,Microphone,SystemAudio}` | |
+
+Not captured: **window bounds / app-switch events**. No evidence anywhere for these; auto-zoom is purely click-driven (see §7).
+
+---
+
+## 7. Automatic zoom
+
+### 7.1 How it decides [P] (`/guide/auto-zoom`)
+> "The Auto zoom option focuses on the areas where clicks occurred during your recording. It automatically detects the click positions and zooms in on those areas."
+
+And the crucial constraint:
+> "if you add auto-zoom where no mouse click occurs, it will not zoom to any area."
+
+So: **the trigger is a mouse click, full stop.** Not window focus, not text entry, not app switching. Zoom ranges are created automatically at capture/import time and each is typed `auto` or `manual`. (An `isSystem` boolean exists on the model; that app-generated zooms set it `true` is my inference from the field's existence, not something observed.) An `auto` range resolves its target from the clicks inside its own time range; a `manual` range uses a fixed `manualTargetPoint`.
+
+Once zoomed, the viewport **follows the cursor** — panning is driven by the mouse-position stream, with `glideSpeed` (default **0.3**) and `glideDirection` controlling the follow, and `snapToEdgesRatio` (default **0.25**) pulling the frame to screen edges so you don't get a sliver of desktop. There is an "Always keep zoomed in" toggle (see §9) and a fixed bug for "following cursor when zooming" (3.5.0).
+
+### 7.2 Zoom parameters [R]/[P]
+- **`zoom`** — magnification multiplier. Manual creation defaults to **2**; values like 2, 2.5, 3 are normal. The UI exposes a zoom-level control at the top of the zoom editor (moved there in 2.25.18).
+- **`manualTargetPoint` {x, y}** — normalised 0–1 over the full recording frame; UI shows it as a draggable **purple dot** in the preview. The picker **displays the % values being picked and snaps to 50% within ±1%** (2.25.18).
+- **Duration** — drag either edge of the zoom on the timeline. **Minimum zoom duration was reduced from 1 s to 0.1 s** (2.25.30); an earlier change had *increased* the minimum to 1 s (2.25.10).
+- **`hasInstantAnimation`** — **Instant Zoom** (`/guide/instant-zoom`): cut straight to the zoom with no animation. Exposed as a toggle in the zoom settings panel and also as an option in Animations (3.4.4).
+- **`isDisabled`** — right-click a zoom → **`Disable`** or **`Remove`** (disable-without-delete added 2.11.1).
+- **`glideSpeed`** — exposed to automation; the UI-visible "glide options" were **removed from the UI layer in 2.22.0** but the property survives in the model.
+
+### 7.3 Zoom editing UX [P]
+- Zooms live on their own **zoom track** in the timeline. The track stays active even when empty (2.25.18).
+- **Set zoom level with number keys `0–9` while hovering a zoom** (2.12.5).
+- **"Apply zoom level of one zoom to all other zooms"** (2.12.5), with a toast confirming the apply-to-all (2.25.18).
+- **Duplicate** a zoom (2.10.6); duplication is blocked if there isn't room before the next zoom (2.25.10).
+- **Copy/paste zoom ranges and slice settings** (2.25.18 / 2.26.0).
+- **Multi-select with ⌘-click, then batch actions on multiple zoom ranges** (2.25.18).
+- If the first zoom starts on frame 0, the video **starts already zoomed** rather than animating in (2.11.2).
+- Cutting the video mid-zoom **blends** the zoom/cursor animation correctly rather than popping (2.25.2).
+- Disabling automatic zoom creation: **Settings → Recording → "Create zooms automatically"** (`/guide/disable-automatic-zooms-`). A second, related label appears on the feedback board as Settings → Editing → *"Create initial zooms automatically"*. Also, vertical mode has an "always on" zoom that can be separately disabled (2.17.12).
+- `scene.addZoomRangeAt(ms)` creates a **~3-second** default range and is known to overwrite adjacent ranges; the robust path is replacing the whole `zoomRanges` array. [R]
+- **No shortcut to drop a zoom during recording** — that's an open feature request ("Manual zoom by shortcut", In Review, 6 upvotes) at hub.screen.studio.
+
+### 7.4 Easing / animation engine
+- **Spring physics**, not bezier easing. The changelog references "object mass" ("fixed infinite animation simulation if 'object mass' is set to 0"), "auto number spring simulation", and "properly simulates springs that are 'slow' to move without stopping the simulation too quickly". The animations engine core was **rewritten in 2.25.2** for performance and export speed.
+- **Screen animation style** (`/guide/animations`), advanced: **`Focused`** — "stabilizes quickly for readable content" — vs **`Smooth`** — "fluid motion suited for creative presentations".
+- **Motion blur** — see §8.
+
+---
+
+## 8. Cursor
+
+### 8.1 Core model
+Cursor is **re-rendered at composite time from captured positions plus captured cursor bitmaps** (§6). This is why cursor size, style, smoothing and hiding are all post-recording decisions, and why they're unavailable on imported video.
+
+### 8.2 Controls [P] (`/guide/cursor`, `/guide/animations`, `/guide/mouse-click-sound`)
+
+Standard:
+| Control | Type | Notes |
+|---|---|---|
+| **`Hide cursor`** | toggle | Removes the cursor entirely |
+| **`Cursor size`** | slider/number | `cursorSize` config key; e.g. `2.0` |
+| **`Cursor type`** | picker | **macOS** or **Touch** styles, plus **custom cursor sets** (3.0.0) — "a large collection of cursor sets", incl. a **macOS Tahoe cursor set** (3.4.8) auto-selected on matching OS, **Halloween cursor set** (3.5.0), high-resolution **Figma cursors** (2.18.1). Missing cursors for older macOS added (3.4.8); fallback for a missing custom cursor (3.2.3). Hover-preview of cursors in the sidebar (2.25.2) |
+| **`Always use default system cursor`** | toggle | Ignore all other cursor types (2.7.7) |
+| **`Hide cursor if it's not moving`** | toggle | Auto-hide when idle (2.14.0) |
+| **`Loop cursor position`** | toggle | Near the end of the video, the cursor returns to its position at the start — makes a clip loop seamlessly (2.14.0) |
+
+Advanced (behind an `Advanced` disclosure):
+| Control | Notes |
+|---|---|
+| **`Rotate cursor while moving`** | Slight rotation at speed (2.7.3) |
+| **`Stop cursor movement at the end of the video`** | |
+| **`Remove cursor shakes`** | Detects and removes shakes caused by external accessibility apps controlling the mouse (2.17.12) |
+| **`Optimize original cursor types`** | Smooths rapid cursor-type transitions; can be disabled (2.20.0) |
+
+Per-slice:
+- **`Hide mouse cursor`** — right-click a timeline fragment (`/guide/hiding-the-cursor-in-specific-sections`); model field `slice.hideCursor`. Shipped 3.1.0.
+- **`Disable smooth mouse movement`** — per-fragment toggle in cursor settings; removes interpolation so dropdown-menu interactions read accurately (`/guide/disable-smooth-mouse-movement`).
+
+### 8.3 Smoothing & motion blur [P]
+- **`Cursor animation style`**: **`Smooth`**, **`Medium`**, **`Rapid`**, **`None`** — four discrete presets, not a slider.
+- **Motion blur**: an intensity **slider**, with three independent advanced channels:
+  - **`Cursor movement`** — blur on the cursor itself
+  - **`Screen zooming in`** — blur during zoom in/out
+  - **`Screen moving`** — blur while panning under a zoom
+  - The motion-blur engine was **rewritten in 2.25.2** "for more accurate results and better performance".
+  - Preview quality setting can **disable motion blur in the preview** for smoother scrubbing (§16).
+
+### 8.4 Click effects [P]
+Three named effects, added over time:
+- **Ripple** (2.25.2, with an explicit enable/disable UI; weakened in 2.25.25)
+- **Circle** (2.25.25)
+- **Shockwave** (2.26.0)
+- 3.0.0 grouped these as "custom cursors and click effects". Ripple is being **reworked** in the current beta.
+- **Mouse click sound effects** (3.3.0): editor → **`Cursor`** tab → **`Click sound`** section → choose from a set of click sounds (previewable) and set a **volume**.
+
+### 8.5 Spotlight / highlight
+There is **no cursor spotlight/vignette that follows the mouse**. The closest shipping feature is the static **Highlight** mask (§14) which dims everything outside a fixed rectangle for a fixed time range.
+
+---
+
+## 9. Background / canvas [P] (`/guide/background`, `/guide/aspect-ratio`, `/guide/cropping-the-recording`)
+
+### 9.1 Background type
+- **Wallpaper** — a large curated library: macOS native wallpapers (Sonoma 2.10.1, Sequoia 2.25.2, **Tahoe** 3.4.0), **iPadOS 17** wallpapers, **100+ wallpapers by Blue Pixel Studio** (2.17.0), wallpapers from **Raycast** (2.22.19), and **Glassmorphism wallpapers** (3.4.11). Library has **categories** and **favourites** (2.17.0), plus a **"pick random wallpaper"** button (2.17.3). Default wallpaper changed to **Tahoe Light** in 3.5.0.
+- **Gradient** — generated from a chosen colour.
+- **Color** — single solid; hex or palette. Colour pickers accept **paste from clipboard** (2.6.0) and **hex codes without the `#`** (3.4.0).
+- **Image** — upload your own. Custom-image proportions and duplicate-filename handling were both bug-fixed; if the app loses access to a custom image it falls back to the default wallpaper (2.25.5).
+
+### 9.2 Frame geometry
+| Control | Type | Notes |
+|---|---|---|
+| **Padding** | slider | Space around the recording. **At 0 the background is entirely hidden.** Initial padding is set automatically based on recording type (2.10.4) |
+| **Rounded corners** | slider | Smoother rounded-corner rendering (2.25.2); aliasing on light backgrounds fixed 3.1.0; for iPad/iPhone the radius is matched to the real device |
+| **Inset** | slider + colour | A border/inset around the recorded screen (2.8.0). **Real-time inset colour changes** (3.4.10) |
+| **Shadow** | toggle/slider | Screen shadow. Fixed for large displays (2.25.2), for crop with radius 0 (2.25.10), for external devices without a mockup (2.25.30), and for the webcam with border radius (3.4.2) |
+| **Background move on zoom** | removed | The background used to shift during a zoom; that was **removed** in 2.25.30 (background is now static under zoom) |
+
+**No background blur control exists** — background blur is only obtainable via the macOS camera Portrait effect, and only for the camera. Confirmed absent.
+
+**No "auto-balance" feature exists.** Searched specifically; nothing in the docs, changelog or roadmap. Treat as not a Screen Studio feature.
+
+### 9.3 Aspect ratio [P]
+Six presets, with these exact labels:
+| Label | Ratio |
+|---|---|
+| **`Auto`** | original aspect ratio of the recording |
+| **`Wide`** | 16:9 |
+| **`Vertical`** | 9:16 |
+| **`Square`** | 1:1 |
+| **`Classic`** | 4:3 |
+| **`Tall`** | 3:4 |
+
+Plus **4:5** support added in 3.0.0-3301 (so 4:5 exists even though the guide page lists six). **No 3:2 and no free-form custom project aspect ratio** in the guide. There *is* a **custom aspect ratio for the webcam** (2.25.18) and a **saved recording-area aspect ratio** (2.25.10).
+
+Additional toggle: **`Always keep zoomed in`** — affects how the chosen aspect ratio crops the visible area (fixed for window/area sources in 3.5.0).
+
+Vertical mode has an "always on" zoom that can be disabled (2.17.12).
+
+### 9.4 Crop [P]
+- Open with the **`Crop`** button. Two current guide pages conflict over `C`: the crop page says `C` opens crop, the trimming page says `C` cuts at the playhead. The changelog settles it — 2.25.18: *"`C` is now used to cut clip at current time instead of opening crop tools."* **Treat the crop page as stale: `C` = cut at playhead**, and crop has no documented shortcut (2.22.9 also fixed "a crop shortcut that was triggered while renaming a file", so one existed historically).
+- Drag edges **or type exact numeric values**; **fixed crop aspect ratio** selectable (2.18.1 "Precise Crop Tools").
+- **25% / 50% / 75% grid lines** while cropping (2.25.18) and guide lines (2.26.0).
+- **Crop suggestions for Google Chrome and Safari** (2.10.6) — e.g. to cut off the browser chrome/URL bar automatically.
+- Crop changes the **final frame only**, not the project aspect ratio.
+- Closing the crop editor without confirming **restores** the previous crop (2.10.8). Playback stops when the crop tool opens.
+
+---
+
+## 10. Camera / webcam in the editor [P] (`/guide/camera`, `/guide/dynamic-camera-layouts-`)
+
+### 10.1 Floating camera controls
+| Control | Notes |
+|---|---|
+| **Hide camera** | |
+| **Position** | Where the camera sits in the frame. The small webcam **keeps a constant distance from the edge regardless of project padding** (2.25.18) |
+| **Size** | |
+| **Roundness** | Corner radius. Radius for **non-square** webcam shapes is computed correctly (2.25.23) |
+| **Mirror camera** | Horizontal flip |
+| **Custom aspect ratio for the webcam** | 2.25.18 |
+| **Shadow** | Present (a shadow-with-border-radius bug was fixed in 3.4.2) |
+| Antialiasing | Improved 2.25.10 |
+
+**Shapes**: there is **no explicit shape picker** (circle / square / rounded-rect). Shape is emergent from **size + custom aspect ratio + roundness** — a 1:1 aspect at full roundness gives a circle, other aspects give rounded rectangles. 2.25.23's fix ("properly calculate rounded corners radius for webcam in non square shape") confirms non-square is a supported, first-class state.
+
+### 10.2 Camera behaviour under zoom [P]
+> "when there is a zoom in the recording, we decrease the size of your camera frame to avoid covering the content of your recording."
+
+You can **set the camera size during zooms** independently, or **disable the automatic resize** to keep a constant size. (This is the "webcam overlay with auto zoom-out" advertised on the homepage.)
+
+### 10.3 Dynamic camera layouts [P] — shipped 3.0.0
+- A **separate "Layouts" timeline track**, edited the same way as zooms — add layout segments over time.
+- Layout states: **fullscreen camera**, **`Default`** (camera + screen together, i.e. the floating overlay, where you can also reposition per moment), and **hidden** ("hide the camera view altogether for parts of the recording").
+- Intended use: full-screen camera intro → cut to screen. 3.0.0's announcement: *"You can create video intros with fullscreen camera or hide the camera entirely for portions of the video."*
+- Conflicting `1/2/3` shortcuts between the zoom and layout editors were fixed (2.25.25), which implies **`1`/`2`/`3` select tracks or layout modes**; **`4`** activates the **mask timeline** (`/guide/adding-a-mask-and-highlight`).
+
+### 10.4 Not shipped (beta only)
+**Background removal, smooth face tracking, camera cropping, LUTs, and split-screen camera layout with smooth transitions are all on the beta/roadmap, not in 3.7.5.** [BETA, https://screen.studio/roadmap]
+
+---
+
+## 11. Audio
+
+### 11.1 Tracks
+Independent audio streams, kept separate through to export:
+- **Microphone** — separate `.m4a`, `slice.volume`
+- **System audio** — separate, `slice.systemAudioVolume` (a genuinely separate per-slice property)
+- **Background music** — a third, project-level track
+- **Click sound effects** — synthesised at composite time from click events
+- **Camera** audio is not separate; the raw webcam file has no audio (see §17.4).
+
+### 11.2 Controls [P]
+- **Waveform** on the timeline for mic and system audio (2.10.6). Rewritten waveform engine (2.26.0), lazy-loaded for huge projects (2.25.18), **waveform height reflects the volume setting** (2.20.4 / 2.25.18).
+- **`Set volume`** — right-click a timeline part → `Set volume` → pick a level. Applies to the whole recording or a single slice. Checkmark shown in the context menu for the current volume/speed (2.25.18).
+- **Mute** microphone audio (2.13.0); **mute external audio from the sidebar** (3.2.2); audio-channel muting fixes in 3.7.1.
+- **Automatic microphone improvements** — **volume normalization** and **noise reduction**, on by default, toggleable in the editor's **Audio tab** (2.10.6, made toggleable 2.18.1). Homepage calls these "voice normalization" and "background noise removal".
+- **Auto gain control** disable option (2.25.10).
+- **Audio scrubber** (`/guide/scrubber`) — a strip above the timeline; drag the playhead and audio plays at a speed proportional to drag speed, forward or backward, for finding an exact edit point. Toggleable; it has its own export interaction bugs historically.
+- Speed changes preserve audio pitch reasonably — "fixed robotic audio at 1.2x speed" (3.4.4), "enhanced audio quality when using preview playback speeds above x1" (3.7.1).
+
+### 11.3 Background music [P] (`/guide/background-music`) — shipped 3.4.0/3.4.6/3.4.9
+- **Built-in royalty-free library** ("Background audio library" 3.4.6; "Built-in background audio tracks library" 3.4.9) — *"can be used for any purpose without concerns about copyright issues"*.
+- **`Add background audio`** to upload your own — **MP3 and MP4** accepted.
+- Audio **preview** in the picker (3.4.11). Background audio is **synchronised to the timeline** (3.4.10).
+- **No documented ducking, looping or fade controls.** Only track choice and (implicitly) volume.
+
+### 11.4 Silence removal
+**Not a feature.** There is no "remove silence" / silence trimming in Screen Studio. The nearest equivalent is **Speed Up Typing Segments** (§13.4). "Audio Improvements Requests" is an open thread on the feedback board.
+
+### 11.5 Beta
+**AI voice cleanup** — "On-device voice enhancement and AI noise removal" [BETA]. **Voice audio enhancement** ("studio-like sound") and **AI Voiceover** are Planned/In Progress. [https://screen.studio/roadmap]
+
+---
+
+## 12. Captions / transcription [P] (`/guide/captions`)
+
+### 12.1 Engines — two, both on-device
+1. **Whisper** — runs locally. Model size is user-selectable:
+   - **`Base`** — "prioritizes speed"
+   - **`Small`** — "balances accuracy and speed"
+   - **`Medium`** — "provides the highest accuracy" at the cost of processing time
+2. **Apple Speech Recognition** (added 3.5.0) — requires **macOS 26.0+**.
+
+Privacy claim [P, homepage + privacy policy]: transcripts are generated **entirely on device**, "no data uploaded to external servers". The privacy policy states *"All screen recordings are processed locally on your device. The recordings are never uploaded to our servers unless you explicitly choose to create a shareable link."*
+
+### 12.2 Generation parameters
+- **AI Model** — Base / Small / Medium (Whisper only)
+- **Language** — **auto-detected, manually overridable** (manual selection added 2.10.2). Multilingual.
+- **Prompt** — a free-text field to "help generate an accurate transcript", for product names and jargon. (This is Whisper's `initial_prompt`.)
+
+### 12.3 Styling and editing
+- **Caption size** — adjustable directly in the video preview.
+- **Show/hide** the caption overlay.
+- **Transcript editor** to fix typos; the editor UI was substantially reworked in 2.7.2.
+- **Export the transcript as a separate file.** The format isn't named in the docs — do not assume SRT.
+- Captions work even with the built-in microphone (2.22.0).
+- Transcript segments that fall inside cuts are **skipped** (2.25.10), and 3.5.0 fixed "transcript processing avoiding lost or extra words when project has cuts" — so the transcript is time-mapped through the edit.
+- **No documented font, colour, background-box, position or word-level-highlight controls.** Size and visibility are the only styling knobs in the shipping version. **Improved caption style and animation is on the beta.** [BETA]
+
+---
+
+## 13. Timeline editing [P]
+
+### 13.1 Structure
+- Tracks: **video slices** (the yellow clip bar), **zooms**, **camera layouts**, **masks/highlights**, **keyboard shortcuts**, plus the **audio scrubber** strip and waveforms.
+- Tracks can be hidden; "always keep at least one track active"; the zoom track stays visible when empty (2.25.18).
+- **Timeline zoom**: `⌘ + scroll`, **pinch on the trackpad**, `+`/`-`, animated, staying centred on the playhead or the visible centre (2.22.0, 2.25.10, 2.25.30, 2.26.0). Max timeline zoom was raised (2.25.18).
+- Scroll the timeline **during playback** (2.25.18).
+- **Preview size** is adjustable (2.25.18); sidebar and timeline can be hidden (2.11.1).
+
+### 13.2 Cutting
+| Action | Shortcut / gesture |
+|---|---|
+| **Split tool (razor)** | **Hold `⌥`** (changed from a toggled `S` in 2.25.18). Scissors icon in the UI |
+| **Cut at playhead** | **`C`** (2.25.18 repurposed `C` for this) |
+| **Ripple delete** | **`X`** — "deletes clip before the playhead till previous cut" (2.25.18) |
+| **Remove a section** | Cut on both sides, right-click the middle → **`Remove`** |
+| **Trim** | Drag a clip's left/right edge. Trims render as **yellow bubbles with a scissors icon**; click a bubble to undo that specific trim |
+| **Reset all** | "Reset all trims and cuts on timeline" (3.4.11) |
+| **Minimum clip length** | **100 ms** (2.25.10) |
+
+Behavioural details worth cloning: while the split tool is active, clicking the timeline does **not** move the playhead; dragging/resizing an item does not drag the playhead; undo/redo of a slice removal **restores the playhead to the same moment of the source video**; split makes items "wiggle independently to show a wave-like effect".
+
+### 13.3 Speed [P] (`/guide/speeding-up-the-video`)
+- **Right-click a part → `Set speed` → pick a value from a list** (discrete list, not a free slider, in the main menu; the typing-segment UI uses a slider).
+- Slow-down is supported as well as speed-up (2.10.6).
+- **`Apply to all`** option for slice speed changes (3.6.0).
+- Stored as **`timeScale = 1 / speed`** [R].
+- Export of slices above 2x had a bug (fixed 3.2.2); audio quality with speed adjustments fixed in the same release.
+- **No speed ramps.** Speed is per-slice and constant within a slice. There is no acceleration curve.
+
+### 13.4 Speed Up Typing Segments — the "magic auto-edit" [P] (`/guide/speed-up-typing-segments`) — shipped 3.0.0
+- The app **detects typing from the captured keystroke stream** and **suggests** speeding those fragments up.
+- Select a suggested segment → adjust pace with a **speed slider** → choose **"Apply to all typing parts"** or apply only to the selected segment. There is an **"Apply all suggestions"** action for consistency across the recording.
+- Default multiplier is not documented.
+
+### 13.5 Other editing
+- **Copy/paste** of zoom ranges and slice settings (2.25.18/2.26.0); **⌘-click multi-select** and batch actions.
+- **Copy current frame as an image** — right-click the preview → copy, or **`⌘C`**; paste anywhere (`/guide/copy-current-frame-as-an-image`; added 2.25.18, context-menu route 3.5.0). Includes the composited frame (background, effects).
+- **Loop playback** mode.
+- Arrow keys move by **0.5 s**, or **1 s with `Shift`** (2.25.2).
+- **JKL playback controls** and playback-speed settings (announced June 2024 on @screenstudio).
+- **Undo/redo** via `project.history` snapshots.
+- **Command Menu — `⌘K`** (`/guide/command-menu`, shipped 3.0.0): "quick keyboard access to all Screen Studio features" — switch tools, access editing features, change settings, execute actions. Enabled outside the main editor as of 3.4.10. The command list isn't published.
+- **`⌘/`** opens a window listing **all** keyboard shortcuts (`/guide/screen-studio-shortcuts`). **Every action's shortcut is rebindable** in Settings → Shortcuts. The full default map is not published anywhere — it must be read from the in-app `⌘/` sheet.
+
+Known shortcut inventory (assembled from the docs + changelog; not exhaustive):
+
+| Shortcut | Action |
+|---|---|
+| `⌥⌘↩` | Open the New Recording modal |
+| `⌃⌥⌘F` | Drop a recording flag (default, rebindable) |
+| `⌘⌥.` | Start/stop the speaker-notes prompter |
+| `⌘K` | Command menu |
+| `⌘/` | Show all shortcuts |
+| `⌘S` / `⌘⇧S` | Save / Save As |
+| `⌘C` / `⌘V` | Copy current frame / paste |
+| `⌘⇧E` | Export dialog [R] |
+| `⌘⌥C` | Quick export to clipboard [R] |
+| `⌥` (hold) | Split/razor tool |
+| `C` | Cut at playhead |
+| `X` | Ripple delete to previous cut |
+| `0`–`9` | Set zoom level of the hovered zoom |
+| `1` / `2` / `3` | Track/layout selection (inferred from a fixed conflict) |
+| `4` | Mask timeline |
+| `←` / `→` | ±0.5 s (`⇧` → ±1 s) |
+| `Esc` | Close sidebar panel; again → back to background settings |
+| `⌘`+scroll / pinch | Zoom the timeline |
+| `⌘`+click | Multi-select timeline items |
+| Global start/stop | Set during onboarding, rebindable |
+| Pause recording | Added 3.2.0, rebindable |
+
+---
+
+## 14. Masks and highlights [P] (`/guide/adding-a-mask-and-highlight`) — shipped 3.1.0
+
+- Press **`4`** to open the mask timeline, then click at the position in the video to place one.
+- **Mask** — `type: "sensitive-data"` — **blurs** a rectangle to hide passwords, API keys, PII. `blur` is a **numeric amount** (CLI default **20**). `bounds` is an **array of `{x, y, width, height}`** in *recording coordinate space*, so **one mask can cover multiple rectangles**.
+- **Highlight** — dims/de-emphasises everything outside a region to draw the eye. **Opacity is adjustable.**
+- Both are **time-ranged** on their own timeline track (`startTime`/`endTime` in source ms).
+- **Masks do not track content** — *"masks remain stationary and won't follow screen movement during scrolling."* No object tracking.
+- **A mask and a highlight cannot both be applied to the same frame.**
+- 3.2.0 improved "handling of content under masks" (i.e. the blur samples correctly under zoom/pan).
+
+---
+
+## 15. Keystroke / shortcut display [P] (`/guide/shortcuts`) — shipped 2.7.0 / 2.22.0
+
+- Screen Studio detects keys pressed **during recording** (from `keystrokes-0.json`) and can render them as an on-screen overlay.
+- **`Show shortcuts`** toggle in the Keyboard Shortcuts menu. Disabled if no keys were pressed.
+- **Shortcut labels size** — a slider. That is the only styling control. (**Real keycap overlays** are a beta feature. [BETA])
+- **`Show single key shortcuts`** — include lone keypresses, not just combos. The app **filters out rapid adjacent presses** so ordinary typing doesn't clutter the video.
+- **A dedicated shortcuts timeline track** (2.22.0) with per-instance control: **click a shortcut to disable/remove it**, or **right-click → `disable all "x" shortcuts`** to suppress every instance of that combination.
+- **"Hide all shortcuts from timeline"** option (3.4.5).
+- Rendering details: `Space` is spelled out as the word "Space"; the Ctrl key is ordered correctly; **F1–F12 and arrow combos are displayed without the `FN` key** (2.22.14). Non-Latin keyboards' unknown keys are ignored (2.16.6).
+
+---
+
+## 16. Annotations, text, shapes
+
+**None.** Screen Studio has **no text tool, no shape tool, no arrows, no freehand drawing, no callouts.** "Annotations" is explicitly listed as **Paused** on the roadmap: *"Enable users to incorporate visual or textual descriptions of clicks within recordings."* "Full text slides" and "Enter/Exit animations" are **Planned**, not shipped. [https://screen.studio/roadmap]
+
+The only overlay primitives are: cursor + click effects, keystroke labels, masks/highlights, captions, camera, device mockups.
+
+---
+
+## 17. Presets, settings, export
+
+### 17.1 Presets [P] (`/guide/creating-preset`, `/applying-preset`, `/sharing-preset`)
+- A preset captures the **look-and-feel settings** — background, aspect ratio, camera positioning, and by extension the rest of the 68 config keys.
+- Create: finish styling a project → **`Presets`** button → name it → **`Create new preset`**.
+- Apply: `Presets` button → click a preset.
+- **Share**: `Presets` → preset settings → **`Open in finder`** → send the file. Format is **`.screenstudiopreset`** (introduced 2.12.0), which **bundles images** so custom backgrounds travel with it.
+- **Preset storage location is configurable** (3.2.0). A **default preset** is applied to new recordings (2.20.0), with special handling for external-device recordings (3.0.0-3301).
+- Separately: **Settings → Editing → "Use last project settings as default for new recordings"** (`/guide/managing-project-settings-for-new-recordings`) — a toggle that makes each new recording inherit the previous project's settings (default ON since 2.25.10).
+
+### 17.2 App settings tabs [P]
+Confirmed tabs: **General** (Hide Dock Icon, window position reset), **Recording** ("Create zooms automatically", accessibility/focus options, quick-export-widget toggle, dim toggle), **Editing** ("Use last project settings…", "Create initial zooms automatically"), **Shortcuts** (rebind everything), **Advanced** (proxy/VPN network toggle for licence activation, "Share diagnostics info", reduce export memory usage, cursor-type optimisation toggle), plus performance/preview options.
+
+**Diagnostics** (`/guide/diagnostic-info`): Settings → Advanced → **"Share diagnostics info"** returns Screen Studio version, macOS version, Mac specs, connected camera and microphone — *"This only includes device names and models - no content or personal data is accessed."*
+
+### 17.3 Export [P] (`/guide/exporting-the-video`, `/guide/explanation-of-export-settings`)
+
+**Formats: MP4 and GIF. That is the complete list.**
+- **No HEVC, no ProRes, no WebM, no MOV export, no transparent/alpha export.** (MOV and MP4 are *import* formats only.) Searched specifically; nothing in any primary source. Codec is not named but is H.264-class in an MP4 container.
+- **GIF**: dedicated pipeline (2.5.10) producing smaller files; a **high-quality colour-palette GIF mode** (2.11.0); **GIF loop count setting** (3.4.0). Guide advises *"We do not recommend creating GIFs that are longer than 1 minute."* MP4 and GIF settings are remembered **separately** (2.16.6).
+
+**Settings exposed:**
+| Setting | Options / notes |
+|---|---|
+| **Format** | MP4 / GIF |
+| **Output size (resolution)** | Up to **4K**; HD offered as the lighter option. *"a 4K resolution export will take four times longer than exporting the same project in HD"* |
+| **Frame rate** | **60 fps** (smoother, slower export) or **24–30 fps** (standard, faster, smaller) |
+| **Quality** | A **compression level**. Explicitly: *"The compression level in Screen Studio does not affect the time it takes to export your content."* — i.e. quality and speed are decoupled; only resolution and fps drive export time |
+| **Export presets** | "for web, social media, video editing" (homepage) |
+
+**Destinations:**
+- **Export to file** (a save dialog; the file-save modal is docked to the export window since 3.5.2)
+- **Copy to clipboard** (2.6.0)
+- **Shareable link** (§18)
+- **Quick export** — reuses the last-used settings (2.26.0); a toggle list of export settings sits under the record button so a recording can be exported instantly (2.26.0)
+- **Export multiple projects at once** (3.0.0) — the save location is requested up front
+
+**Export UX:** a progress window; clicking the info symbol reveals the full output path (3.4.7 "export file details in export window"). Export can run while you keep editing another project (2.25.2). Playback stops automatically when export starts (3.0.0-3301). The project can be deleted right after export (2.10.6).
+
+**Export engine claims:** "new exporting engine and significantly faster export speeds" (2.26.0); "fundamental changes to the exporting engine" (2.25.2); "+~25% export speed" (2.25.18); "faster export for projects with multiple cuts" (3.4.4); an **experimental multi-threaded export mode** that "might increase export speed by 20-40%, but might result in broken video file in some rare cases and hardware setups" (2.22.14); an advanced **"reduce export memory usage"** option (2.25.30). **Up to 3× faster exports** via a reworked render engine is on the beta. [BETA]
+
+**Performance settings** [P] (`/guide/performance-settings`) — three preview modes:
+- **Quality** — preview matches the export exactly, motion blur on
+- **Performance** — disables motion blur and similar in the preview for a higher preview frame rate
+- **Power Saving Mode** — lowers compute and preview frame rate
+Plus "options to reduce preview quality" (2.16.1) and playback entering idle mode after 30 s of inactivity (2.25.18).
+
+### 17.4 Extract raw recording files [P] (`/guide/extracting-raw-recording-files`) — since 2.18.1
+**Export → "Extract raw recording files…"** → choose a destination folder. Extracts the individual source assets for use in an external NLE. Caveats stated verbatim in the 2.18.1 changelog:
+> "you can extract raw webcam file as a separate file. Notes: webcam file does not include audio from the microphone - you'll need to extract microphone audio file as well. Another note - raw screen recording file will not include your mouse cursor as it is not directly recorded by Screen Studio - it is re-added later basing on your mouse position data."
+
+So the extractable components are at least: **raw screen video (cursor-free)**, **raw webcam video (audio-free)**, **microphone audio**, and by extension **system audio**.
+
+---
+
+## 18. Shareable links / cloud [P] (`/guide/shareable-links`, `/guide/shareable-links-comments`) — shipped 3.0.0
+
+- One click produces a hosted link. Managed via **Screen Studio menu → "Manage Shareable Links"** → the web **dashboard**.
+- **Hard limit: 30 minutes per shared recording.** *"Please note that currently shareable recordings have a 30 min limit. For longer projects, you'll need to export them as a file."* (Raised from a lower limit to 30 min in 3.3.1; made consistent in 3.4.5.)
+- **Private shareable links** (3.4.4) with an improved private link page and **invitation emails** (3.4.5).
+- **View counter** (3.5.1); the owner's own views don't increment it (3.7.1).
+- **Custom title** — editable from the quick-export widget at share time (3.5.1); a customised title becomes the main overlay text (3.3.0).
+- **Comments** (3.4.10): open the link → **"Show Comments"** → **"Write a comment"**; set a display name via a pencil icon; **`⌘↩`** submits and **binds the comment to the current video timestamp**.
+- Ultra-wide monitor recordings had a share-creation bug (fixed 3.0.0-3301).
+- **Requires an active licence** — access control for existing links when a licence expires was explicitly fixed (3.0.0-3301), and the homepage lists "Shareable links" as a plan feature.
+- **Storage**: uploaded to the vendor's cloud, served via **Cloudflare** ("Shared recordings (only when you create shareable links), shareable links thumbnails"). Retention is not stated. [P, privacy policy]
+
+**Quick share widget** [P] (`/guide/quick-share-widget-`) — shipped 3.0.0: appears after a recording with **Share** (link), **Save** (file), **Copy** (clipboard) and **Edit** (double-click opens the editor). Auto-saves the project (3.0.0-3337). Export settings for it are configured via the **"Edit quick export settings"** icon in the recording modal, and the whole widget can be turned off with **"Show quick export widget after recording"** — reached from the **settings gear at the far right of the recording picker**, which may or may not be the same surface as the Settings window's Recording tab.
+
+---
+
+## 19. Integrations, automation, AI
+
+- **Raycast extension** — official, at https://www.raycast.com/screen-studio/screen-studio, ~4,776 installs. Backed by a **custom URL scheme exposed in 2.5.10** "that allows controlling main features of Screen Studio from the outside of it".
+- **No AppleScript, no official CLI, no public API.** The screenstudio-agent author states plainly: *"Screen Studio has no automation surface of its own — no AppleScript, no URL scheme, no CLI"* (i.e. the 2.5.10 URL scheme is undocumented/limited), which is why third-party automation goes through the Electron debug port.
+- **No Notion, Slack, YouTube or Loom integrations.** Sharing is: file, clipboard, or a Screen Studio-hosted link (which can be pasted anywhere).
+- **Drag & drop** project files onto the editor or the menu-bar icon to open (2.26.0).
+- **AI features shipping today**: Whisper/Apple on-device transcription; click-driven auto-zoom; typing-segment detection; audio normalisation + noise reduction. **AI Voiceover** and **AI noise removal / voice cleanup** are In Progress / Beta. [BETA]
+- **Telemetry** [P, privacy policy]: **PostHog** receives "Feature usage events, recording metadata, device information, IP address" and specifically "Usage analytics (feature usage patterns for blur, highlight, export formats - when permitted)". **Sentry** receives "Device specifications, crash logs, error reports, IP addresses, user email (if user is logged in)".
+
+---
+
+## 20. Version history highlights (for feature-dating a clone roadmap)
+
+| Version | Date | Landmark |
+|---|---|---|
+| 2.5.10 | May 2023 | Raycast URL scheme; new GIF pipeline |
+| 2.7.0 | May 2023 | Show pressed shortcuts in the video |
+| 2.8.0 | Jun 2023 | Inset around the recorded screen |
+| 2.10.6 | Jun 2023 | Waveform, auto mic normalisation + noise reduction, slow-down, Chrome/Safari crop suggestions |
+| 2.12.0 | Jun 2023 | `.screenstudiopreset` format |
+| 2.14.0 | Jun 2023 | Hide idle cursor; loop cursor position |
+| 2.15.1 / 2.15.3 | Jul 2023 | System audio recording; iPhone & iPad recording |
+| 2.17.0 | Aug 2023 | 100+ wallpapers, categories, favourites |
+| 2.18.1 | Nov 2023 | Speaker Notes; precise crop; **extract raw recording files** (the cursor-not-baked-in disclosure) |
+| 2.22.0 | Mar 2024 | Dedicated keyboard-shortcut timeline; single-key display; project location setting |
+| 2.25.2 | Aug 2024 | Ripple click effect; rewritten animations engine; **new motion blur engine**; device rotation |
+| 2.25.18 | Sep 2024 | Timeline overhaul: `⌥` razor, `C` cut, `X` ripple delete, multi-select, copy/paste zooms, project-from-mp4, copy frame |
+| 2.26.0 | Dec 2024 | Click ripple + shockwave; new export engine; drag & drop; pinch-zoom timeline |
+| **3.0.0** | **17 Dec 2024** | **Shareable links, dynamic camera layouts, quick share widget, custom cursors, speed-up-typing, `⌘K` command menu, multi-project export** |
+| 3.0.0-3301 | Feb 2025 | 4:5 aspect ratio |
+| **3.1.0** | Mar 2025 | **Masks + highlights**; per-slice cursor hiding |
+| **3.2.0** | Apr 2025 | **Pause/resume recording**; iPhone device audio; .MOV import; preset storage location |
+| 3.3.0 | Jun 2025 | **Mouse click sound effects** |
+| 3.4.0–3.4.11 | Jun–Oct 2025 | Background audio + library; Tahoe wallpapers & cursors; private shareable links; 720p/1080p/4K camera; link comments; glassmorphism wallpapers |
+| 3.5.0 | Oct 2025 | **Apple Speech Recognition transcripts**; **iPhone Mirroring support**; Halloween cursors; magnetic multifunction button |
+| 3.6.0 | Feb 2026 | "Apply to all" for slice speed |
+| 3.7.x | May–Aug 2026 | Audio fixes, billing/account polish, reliability |
+
+---
+
+## 21. Pricing and gating [P]
+
+**Authoritative (screen.studio homepage `#pricing`, Sept 2026):**
+| Plan | Price | Includes |
+|---|---|---|
+| **Monthly** | **$20 / month** | "All Screen Studio features included" + "Shareable links" |
+| **Yearly** | **$9 / month, billed yearly** (= $108/yr) | Same |
+
+- Billing/subscription management runs through **Lemon Squeezy** ("Manage subscription").
+- **Education discount available** — via a "request-educational-discount" link on the site.
+- **Legacy one-time licences exist but are no longer sold.** The homepage FAQ has a standing entry *"What happens if I purchased a one-time license in the past?"*, and `/guide/activating-screen-studio` says the licence-key field is *"only applicable for legacy one-time purchase licenses."* Changelog references "expired lifetime license validation" (3.4.2). **Do not quote a one-time price** — every third-party figure ($89 / $149 / $189 / $229) is stale or fabricated and they mutually contradict.
+- **Teams**: **not shipped.** "Teams subscriptions architecture" is *In Progress* on the roadmap — *"Owner can invite team members who will need to sign in and will automatically be able to activate their Studio installs."*
+
+**What the free/unactivated app does** — this is the single most important gating fact, and it comes from `/download` [P]:
+> Users without an active paid plan can access **all features except video export**.
+
+So: **recording and full editing are free; export is the paywall.** There is **no watermark tier** — third-party claims that "the free version adds a watermark to all videos" and "free users only get MP4 and MOV" (saastreats.net) are **wrong**; MOV isn't even an export format. datastudios.org corroborates the primary source: *"No free trial: Recording works, but exports require payment."*
+
+**Activation** [P] (`/guide/activating-screen-studio`, `/guide/managing-license`):
+- Two paths: **email address + emailed activation code** (current subscriptions), or **licence key** (legacy one-time).
+- **Per-device activation with a deactivation limit.** Manage at **screen.studio/dashboard** → Device tab → **"Disconnect device"** to free a seat. *"You do not need access to your old device to reset your license key; you can perform this action from any device with internet access."* (A "device deactivation limit" bug was fixed in 3.4.0; "visibility of active devices in dashboard" in 3.0.0-3301.) The exact device count is not published.
+- On expiry: a licence-expiration screen with status and expiration time; app-update logic is restricted for expired licences; existing shareable links lose access. Refunded subscriptions are deactivated (3.4.2).
+
+---
+
+## 22. Beta / roadmap — NOT in 3.7.5 [P, https://screen.studio/roadmap]
+
+**On Beta** (this is effectively "Screen Studio 4"):
+1. **Up to 3× faster exports** — "Reworked Screen Studio's render engine. Exports are faster and editing is snappier."
+2. **New camera features** — "Background removal, smooth face tracking, cropping, LUTs, and a new split-screen layout with smooth transitions."
+3. **New zoom effects** — "Glass Loupe effect, sharper zoomed-in text, and lots of tiny improvements."
+4. **Better captions & shortcuts** — "Improved style and animation. Real keycap overlays for shortcuts."
+5. **AI voice cleanup** — "On-device voice enhancement and AI noise removal."
+6. **Unsplash backgrounds** — "Search for background images on Unsplash within Screen Studio."
+7. **Improved click effects** — "Reworked the Ripple click effect."
+
+**In Progress**: Teams subscriptions architecture; AI Voiceover.
+
+**Planned**: Voice audio enhancement (studio-like sound); Multi-clip recordings (merge multiple recordings into one project); Full text slides; Enter/Exit animations; Create videos from screenshots.
+
+**Paused**: Annotations.
+
+**Completed**: 26 items listed.
+
+---
+
+## 23. Explicit absences — things a clone spec should NOT assume exist
+
+| Assumed feature | Reality |
+|---|---|
+| Transparent / alpha export | **No** |
+| HEVC / ProRes / WebM / MOV export | **No** — MP4 and GIF only |
+| HDR capture or export | **No** |
+| >60 fps / ProMotion capture | **No** |
+| Text, shapes, arrows, freehand annotation | **No** — Paused on roadmap |
+| Silence removal / auto-trim of dead air | **No** — only typing-segment speed-up |
+| Audio ducking, looping, fades for background music | **Not documented** |
+| Caption font / colour / position / word-level highlight | **No** — size and visibility only |
+| SRT export specifically | Unconfirmed — "export the transcript as a separate file", format unnamed |
+| Cursor spotlight / follow-me vignette | **No** — only static Highlight masks |
+| Camera background removal, face tracking, LUTs, split-screen | **Beta only** |
+| Object/scroll tracking for masks | **No** — masks are stationary |
+| Multi-clip / multi-take projects | **No** — one recording per project; Planned |
+| Speed ramps / acceleration curves | **No** — constant speed per slice |
+| Teams / shared workspaces | **Not shipped** — In Progress |
+| Notion / Slack / YouTube integrations | **No** |
+| Custom (free-form) project aspect ratio | **No** — six presets + 4:5; custom exists only for the webcam |
+| 3:2 aspect ratio | **Not listed** |
+| Windows / Linux | **No** |
+| Zoom-drop shortcut during recording | **No** — open feature request |
+| Auto-zoom on non-click events (typing, hover, app switch) | **No** — clicks only |
+| Background blur (canvas) | **No** — only macOS Portrait mode on the camera |
+| "Auto-balance" | **Not a Screen Studio feature** |
+| Camera shape picker (circle/square) | **No** — shape emerges from size + custom aspect ratio + roundness |
+| Project library / browser UI | **No** — bundles in a folder; Open Recent, tray menu, drag & drop, Finder |
+| Localized app UI | **No** — English only; "multi-language" means caption languages |
+| Watermark on a free tier | **No such tier** — export is simply blocked |
+
+---
+
+## 24. Minimum viable clone — the five load-bearing mechanisms
+
+1. **Capture video without the cursor**, and capture, as separate timestamped streams: mouse positions, mouse clicks (`{processTimeMs, button, x, y}`), keystrokes (`{processTimeMs, character, type}`), and the cursor bitmaps themselves. Everything distinctive downstream is a function of this metadata.
+2. **Composite at render time, not at capture time** — cursor, click effects, keystroke labels, zoom crop, background, camera, masks and captions are all applied to a raw, unmodified screen video during preview and export. This is why every one of them stays editable afterwards.
+3. **Spring-simulated zoom/pan** driven by click positions, with `glideSpeed`, `snapToEdgesRatio` and cursor-following, plus motion blur on three independent channels (cursor / zooming / panning).
+4. **A segmented, crash-resilient recorder** — fragmented `.m4s` + `.m3u8` written live, enabling pause/resume, low-disk warnings and project recovery.
+5. **A slice model with `timeScale = 1/speed`, dual source/playback time axes, and per-slice `volume` / `systemAudioVolume` / `hideCursor`,** so cuts and speed changes re-map the cursor, zoom, caption and keystroke streams coherently.


### PR DESCRIPTION
Adds the screen recording feature and its editor, then fixes the six
symptoms reported against it. The last five commits are the fixes; this
summary is about those, because they are what the diagnosis turned on.

## What was actually wrong

Six reported symptoms turned out to be four faults, and the primary
sources — the on-disk crash report, the unified log at `--info`, and the
interrupted bundle — contradicted three theories I had formed by reading
the code. Those are noted in the commits.

**The camera was blocking the main thread.** `AVCaptureSession.startRunning()`
blocks until the graph is up, and `AVCaptureMovieFileOutput.startRecording(to:)`
blocks until the session is running. `CameraRecorder` handed the first to
a detached task and made the second call on the main actor. AVFoundation
pumps the run loop while it waits, so AppKit kept delivering events with
a main-actor frame on the stack; a click reached a global event monitor,
`MainActor.assumeIsolated` asked which executor was current, and got the
address `0x1e`. The log shows the cost: filter built, camera up, then
eight seconds of nothing — `SCStream` sat three statements further on and
was never reached, so the recording never began. That single fault is
"nothing on screen", "I do not see the area", and the crash.

**The shortcut was never registered at launch.** `rebindHotkeys()` runs
from `AppState.sync()` inside `AppState.shared`'s initialiser, four lines
before `wireRecording()` assigns any handler, and it read the closures by
value — so all four were nil and nothing was registered. `sync()` skips
features already active, so the only escape was toggling the feature off
and on, which is exactly the reported workaround.

**A failed start left everything behind** — camera running, event
monitors installed for the life of the process, and a bundle still saying
`state: "recording"` that the next launch offered to recover. Neither
`finish()` nor `discard()` could clean up: both are gated on a flag set
only on success.

**The webcam circle was never built.**

## Verified live, not just green

The suite is at 1,903 tests, but all six symptoms got past it, so it is
not the evidence. On the identical configuration that failed — window
source, camera on, keystrokes on, the same 3024x1796 — before and after:

| | Before | After |
| --- | --- | --- |
| time to `recording started` | never (8 s, then a crash) | 122 ms |
| `SCStream` lifecycle lines | 0 | 4 |
| `state` | `"recording"` | `"complete"` |
| `screen.mov` | 0 bytes | 3.3 MB |
| `hasCamera` | `false` | `true`, 2.6 MB `camera.mov` |
| crash reports | 2 | 0 |

`sarvkrit://record` and `sarvkrit://stop-recording` are what made that
possible: every previous round depended on reproducing the failure by
hand. The window selector is the point — the failing case was a *window*
recording, and a script had no way to name one.

The live test also caught a regression in the new preview window, which
is in the commit: building the preview layer after the session was
already recording reconfigured it and killed the take 1.2 s in.

## Not done

Recording shortcuts are still hardcoded to `action.defaultShortcut` with
no store behind them. The settings pane only displays them, so nothing
lies to the user, but they cannot be rebound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7SzrctuRiWyegmsivFfKg