### PR TITLE
Put system sleep back when Keep Awake is switched off (1.1.1)

### DIFF
--- a/Sources/Sarvkrit/Core/AppState.swift
+++ b/Sources/Sarvkrit/Core/AppState.swift
@@ -283,6 +283,10 @@ final class AppState: ObservableObject {
         objectWillChange.send()
         store.setEnabled(feature.id, enabled)
         sync()
+        // After `sync()`, so the feature is already stood down by the time it is told the user is
+        // the one who did it. This is the only caller, which is what makes it a reliable signal of
+        // an actual click — `deactivate()` alone cannot say that, since `deinit` calls it too.
+        if !enabled { feature.userDidDisable() }
     }
 
     /// Rebuild the event tap because a feature's *mask* changed, rather than its enabled state.

--- a/Sources/Sarvkrit/Core/Feature.swift
+++ b/Sources/Sarvkrit/Core/Feature.swift
@@ -168,6 +168,15 @@ protocol Feature: AnyObject {
     func activate()
     func deactivate()
 
+    /// The user switched this feature off, as opposed to it being stood down.
+    ///
+    /// `deactivate()` cannot carry this: `AppState` also calls it from `deinit`, so a feature with
+    /// undoing to do that needs the user present — a password prompt, a confirmation — cannot tell
+    /// the click apart from the teardown. Keep Awake is the one that needs it, to put system sleep
+    /// back. Declared here rather than only defaulted in the extension so an implementation is
+    /// actually reached through a `Feature` existential.
+    func userDidDisable()
+
     /// A feature's own detail pane, when the generic one can't express it.
     ///
     /// `FeatureDetailView` renders title / toggle / prose / permission status for any feature, which
@@ -208,6 +217,7 @@ extension Feature {
     var requirements: Set<Requirement> { [.accessibility] }
     func activate() {}
     func deactivate() {}
+    func userDidDisable() {}
     @MainActor func makeDetailView() -> AnyView? { nil }
     @MainActor func trayPanels() -> [TrayPanel] { [] }
     var panelIsItsOwnSwitch: Bool { false }

--- a/Sources/Sarvkrit/Features/System/KeepAwakeFeature.swift
+++ b/Sources/Sarvkrit/Features/System/KeepAwakeFeature.swift
@@ -39,13 +39,24 @@ final class KeepAwakeFeature: Feature, ObservableObject {
     private var timer: Timer?
 
     private static let keepDisplayKey = "keepAwake.keepDisplayOn"
-    private static let lidClosedKey = "keepAwake.lidClosed"
+    /// Internal, not private, so the turn-off tests can arrange state through the same keys the
+    /// app stores rather than keeping their own copies of the strings.
+    static let lidClosedKey = "keepAwake.lidClosed"
     private static let durationKey = "keepAwake.duration"
     /// Our record that *we* were the ones who set the system flag.
-    private static let weSetFlagKey = "keepAwake.weSetSleepDisabled"
+    static let weSetFlagKey = "keepAwake.weSetSleepDisabled"
 
-    init(defaults: UserDefaults = .standard) {
+    /// Injected for the same reason `defaults` is: every path that changes the system flag goes
+    /// through here, and a test that reached the real one would raise a root password dialog in
+    /// the middle of `make test`.
+    private let runPrivileged: (String) -> Bool
+
+    init(
+        defaults: UserDefaults = .standard,
+        runPrivileged: @escaping (String) -> Bool = SleepDisableFlag.runPrivileged
+    ) {
         self.defaults = defaults
+        self.runPrivileged = runPrivileged
     }
 
     // MARK: - Settings
@@ -66,7 +77,10 @@ final class KeepAwakeFeature: Feature, ObservableObject {
             guard newValue != lidClosed else { return }
             objectWillChange.send()
             defaults.set(newValue, forKey: Self.lidClosedKey)
-            applyLidClosed()
+            // Split, because on and off are not symmetrical. `applyLidClosed()` sets the flag and
+            // is also called from `activate()`; clearing must happen only here, where the user has
+            // just asked for normal sleep back.
+            if newValue { applyLidClosed() } else { clearFlagIfOurs() }
         }
     }
 
@@ -102,9 +116,22 @@ final class KeepAwakeFeature: Feature, ObservableObject {
         timer?.invalidate()
         timer = nil
         expiresAt = nil
-        // The flag is deliberately NOT cleared here: it needs root, and a dying app can't put up a
-        // password dialog. The watchdog started when it was enabled clears it within seconds.
+        // The flag is deliberately NOT cleared here, and the reason is narrower than it looks.
+        // Clearing needs root, and `AppState` calls this from `deinit` as well as from a toggle —
+        // in the test host that is a `KeepAwakeFeature` on the real `UserDefaults.standard`, so a
+        // password dialog here would interrupt `make test` on a machine where the flag happens to
+        // be on, and never on CI. The user's click arrives as `userDidDisable()` instead.
+        //
+        // On the way out of the app nothing calls this at all: the watchdog notices the pid is
+        // gone and clears the flag within seconds. What it cannot do is notice a *toggle*, which
+        // is the whole reason `userDidDisable()` exists.
         reconcile()
+    }
+
+    /// The user switched Keep Awake off. Distinct from `deactivate()` on purpose — see the comment
+    /// there for what that distinction is protecting.
+    func userDidDisable() {
+        clearFlagIfOurs()
     }
 
     @MainActor
@@ -134,7 +161,7 @@ final class KeepAwakeFeature: Feature, ObservableObject {
             pid: ProcessInfo.processInfo.processIdentifier,
             watchdogSeconds: Int(duration.watchdogSeconds)
         )
-        if SleepDisableFlag.runPrivileged(script) {
+        if runPrivileged(script) {
             weSetFlag = true
             log.notice("sleep disabled system-wide, with a watchdog to restore it")
         } else {
@@ -147,8 +174,24 @@ final class KeepAwakeFeature: Feature, ObservableObject {
 
     /// Asks the user to restore normal sleep. Only ever called from an explicit click.
     func restoreSleep() {
-        guard SleepDisableFlag.runPrivileged(SleepDisableFlag.disableScript()) else { return }
-        weSetFlag = false
+        clearFlagIfOurs()
+    }
+
+    /// Puts normal sleep back, if the flag is ours to put back.
+    ///
+    /// Gated on `weSetFlag` because of `KeepAwakeState.action`'s `(false, true, false)` row: a flag
+    /// somebody disabled sleep with by hand, in a terminal, for a reason we know nothing about, is
+    /// not ours to clear. The gate also means the common case — turning off a feature that never
+    /// touched the system flag — costs no password prompt at all.
+    ///
+    /// A refusal leaves `weSetFlag` alone deliberately. The flag is still set and still ours, so
+    /// the pane must keep offering to restore it rather than forgetting it exists.
+    private func clearFlagIfOurs() {
+        guard weSetFlag else { reconcile(); return }
+        if runPrivileged(SleepDisableFlag.disableScript()) {
+            weSetFlag = false
+            log.notice("normal sleep restored")
+        }
         reconcile()
     }
 

--- a/Sources/Sarvkrit/UI/System/KeepAwakeDetailView.swift
+++ b/Sources/Sarvkrit/UI/System/KeepAwakeDetailView.swift
@@ -81,10 +81,13 @@ struct KeepAwakeDetailView: View {
 
     private var strandedNotice: some View {
         VStack(alignment: .leading, spacing: Theme.Space.sm) {
-            Label("Sleep is still disabled from last session", systemImage: "exclamationmark.triangle.fill")
+            Label("Your Mac still can't sleep", systemImage: "exclamationmark.triangle.fill")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.orange)
-            Text("Your Mac restarted while the lid-closed option was on, which stopped the background task that would have restored normal sleep. It's safe to fix now.")
+            // Deliberately doesn't name a cause. It used to say the Mac had restarted, which was
+            // one of the two ways to get here and reads as nonsense in the other — declining the
+            // password prompt on the way out leaves the flag set in the same session.
+            Text("The lid-closed option left system sleep switched off, and putting it back needs your password. It's safe to do now.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Tests/SarvkritTests/KeepAwakeTurnOffTests.swift
+++ b/Tests/SarvkritTests/KeepAwakeTurnOffTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import Sarvkrit
+
+/// Turning Keep Awake off has to put system sleep back.
+///
+/// 1.1.0 shipped without this: the lid-closed option set `SleepDisabled` machine-wide and no
+/// user-initiated *off* path ever cleared it, so a Mac stayed unable to sleep until the user found
+/// a banner button — or for twelve hours. `KeepAwakeStateTests` covers the pure truth table and
+/// `SleepDisableFlagTests` covers the shape of the root scripts; neither touched the toggle path,
+/// which is exactly where the bug lived. These tests are that path.
+///
+/// `@MainActor` because they drive `AppState.setEnabled`, as `AppStateTests` does.
+@MainActor
+final class KeepAwakeTurnOffTests: XCTestCase {
+
+    /// Records the scripts it is handed instead of running them, so the whole suite stays off
+    /// `NSAppleScript` and never writes a real `pmset` setting.
+    private final class PrivilegedSpy {
+        private(set) var scripts: [String] = []
+        var succeeds = true
+
+        func run(_ script: String) -> Bool {
+            scripts.append(script)
+            return succeeds
+        }
+
+        /// Matched against the whole script, not a substring: the *enable* script also contains
+        /// "disablesleep 0" — that is its watchdog's cleanup line — so a substring test here
+        /// reports success the moment the option is switched on and can never fail.
+        var clearedSleep: Bool { scripts.contains(SleepDisableFlag.disableScript()) }
+        var disabledSleep: Bool { scripts.contains { $0.contains("pmset -a disablesleep 1") } }
+    }
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "keepAwake.turnOff.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    private func makeFeature(_ spy: PrivilegedSpy) -> KeepAwakeFeature {
+        KeepAwakeFeature(defaults: defaults, runPrivileged: spy.run)
+    }
+
+    /// Puts the feature in the state the bug report describes: running, lid-closed on, flag ours.
+    private func makeRunningWithLidClosed(_ spy: PrivilegedSpy) -> KeepAwakeFeature {
+        let feature = makeFeature(spy)
+        feature.activate()
+        feature.lidClosed = true
+        XCTAssertTrue(spy.disabledSleep, "precondition: turning it on should disable sleep")
+        XCTAssertTrue(defaults.bool(forKey: KeepAwakeFeature.weSetFlagKey),
+                      "precondition: the flag should be recorded as ours")
+        return feature
+    }
+
+    // MARK: - The bug
+
+    func testTurningLidClosedOffRestoresSleep() {
+        let spy = PrivilegedSpy()
+        let feature = makeRunningWithLidClosed(spy)
+
+        feature.lidClosed = false
+
+        XCTAssertTrue(spy.clearedSleep,
+                      "turning the lid-closed option off must clear SleepDisabled, not leave the Mac unable to sleep")
+        XCTAssertFalse(defaults.bool(forKey: KeepAwakeFeature.weSetFlagKey),
+                       "once cleared we no longer own the flag")
+    }
+
+    func testTurningKeepAwakeOffRestoresSleep() throws {
+        let spy = PrivilegedSpy()
+        let feature = makeRunningWithLidClosed(spy)
+
+        // Through AppState, because the master toggle is a generic feature binding — the wiring is
+        // as much the fix as the method it calls.
+        let state = AppState(
+            features: [feature],
+            store: FeatureStore(defaults: defaults),
+            permissions: PermissionsManager(),
+            defaults: defaults
+        )
+        state.setEnabled(feature, true)
+        state.setEnabled(feature, false)
+
+        XCTAssertTrue(spy.clearedSleep,
+                      "turning Keep Awake off must clear SleepDisabled; the watchdog only fires when the app exits")
+    }
+
+    // MARK: - Invariants the fix must not break
+
+    func testAFlagWeDidNotSetIsLeftAlone() {
+        let spy = PrivilegedSpy()
+        // Lid-closed on, but never recorded as ours — somebody disabled sleep by hand.
+        defaults.set(true, forKey: KeepAwakeFeature.lidClosedKey)
+        let feature = makeFeature(spy)
+
+        feature.lidClosed = false
+
+        XCTAssertTrue(spy.scripts.isEmpty,
+                      "a flag somebody else set is not ours to clear, and clearing costs a password")
+    }
+
+    func testActivatingWithLidClosedOffAsksForNothing() {
+        let spy = PrivilegedSpy()
+        let feature = makeFeature(spy)
+
+        feature.activate()
+
+        XCTAssertTrue(spy.scripts.isEmpty,
+                      "launch must not fire an unexplained password dialog — that is what the stranded banner is for")
+    }
+
+    func testADeclinedPromptKeepsOwnershipSoTheBannerStillCatchesIt() {
+        let spy = PrivilegedSpy()
+        let feature = makeRunningWithLidClosed(spy)
+        spy.succeeds = false
+
+        feature.lidClosed = false
+
+        XCTAssertTrue(spy.clearedSleep, "it should still have tried")
+        XCTAssertTrue(defaults.bool(forKey: KeepAwakeFeature.weSetFlagKey),
+                      "the flag is still set and still ours, so the pane must keep offering to restore it")
+    }
+}

--- a/docs/releases/1.1.1.md
+++ b/docs/releases/1.1.1.md
@@ -1,0 +1,55 @@
+**Keep Awake now puts system sleep back when you switch it off.**
+
+In 1.1.0, turning off "keep awake with the lid closed" didn't restore normal sleep. The system-wide setting stayed on, so your Mac couldn't sleep and **Apple menu → Sleep** stayed greyed out — until you found the "Restore Normal Sleep" button, quit Sarvkrit, or twelve hours passed.
+
+Turning off either that option or Keep Awake itself now restores sleep straight away. It is the only change in 1.1.1.
+
+## If you're on 1.1.0 and your Mac still won't sleep
+
+Updating fixes it going forward, but 1.1.0 may have left the setting on right now. Either turn the lid-closed option on and off again once on 1.1.1, or check and clear it yourself:
+
+```
+pmset -g | grep SleepDisabled
+sudo pmset -a disablesleep 0
+```
+
+If the first command prints nothing, there's nothing to clear.
+
+## Install
+
+1. Download `Sarvkrit.dmg` below and drag **Sarvkrit** to your Applications folder. Put it there rather than leaving it in Downloads — macOS keys permissions to where the app lives.
+2. **First launch: System Settings → Privacy & Security → Open Anyway.** Only the first time.
+
+   Double-click Sarvkrit, click **Done** on the warning, then open **System Settings → Privacy & Security**, scroll down to **Security**, and click **Open Anyway** next to Sarvkrit. Authenticate, open Sarvkrit again and choose **Open**. From then on it opens normally.
+
+   That second step is not optional, and it is not a warning you can ignore: this build is signed but **not notarized**, because notarization needs a paid Apple Developer account. Double-clicking alone will get you "Apple could not verify Sarvkrit is free of malware" and nothing else.
+
+   Not *right-click → Open*: macOS 15 Sequoia removed that override, so on 15 and later it shows the same refusal with no Open button. Open Anyway works on 14 too, so it is the only route given here. If you would rather use a terminal, `xattr -dr com.apple.quarantine /Applications/Sarvkrit.app` does the same thing.
+
+Or skip the whole detour with one command:
+
+```
+curl -fsSL https://sarvkrit.com/install | sh
+```
+
+## Upgrading from 1.1.0
+
+Drag the new copy over the old one, or run the install command above. Your settings, clipboard history, snippets and shelf are all kept. Nothing switches itself on.
+
+## Requirements
+
+- **macOS 14.4 or later.**
+- **Universal** — Apple Silicon and Intel (`x86_64 arm64`).
+
+## Verifying the download
+
+```
+shasum -a 256 Sarvkrit.dmg
+@SHA@
+```
+
+The app inside is signed and passes `codesign --verify --strict`.
+
+## Licence
+
+[PolyForm Shield 1.0.0](https://polyformproject.org/licenses/shield/1.0.0) — free to use for anything including at work, source public to read and change. You may not use the code to build a competing product. Source-available, not open source.

--- a/project.yml
+++ b/project.yml
@@ -11,10 +11,10 @@ options:
 settings:
   base:
     SWIFT_VERSION: "5.0"
-    MARKETING_VERSION: "1.1.0"
+    MARKETING_VERSION: "1.1.1"
     # Monotonic, and deliberately not a copy of MARKETING_VERSION: as a CFBundleVersion, "1.1.0"
     # sorts *below* the "2" that 1.1 development carried. It only ever counts up.
-    CURRENT_PROJECT_VERSION: "3"
+    CURRENT_PROJECT_VERSION: "4"
     DEVELOPMENT_TEAM: 77A36893HP
     CODE_SIGN_STYLE: Manual
     ALWAYS_SEARCH_USER_PATHS: NO


### PR DESCRIPTION
Released as [v1.1.1](https://github.com/sadana-psylief/Sarvkrit/releases/tag/v1.1.1), cut from the
`v1.1.0` tag so the patch carried nothing but this fix. This lands the same two commits on `main`,
which otherwise regresses the moment 1.2 ships.

## The bug

The lid-closed option sets `SleepDisabled` machine-wide, and 1.1.0 had no user-initiated path that
ever cleared it again.

- Turning the option off ran `applyLidClosed()`, whose `guard isRunning, lidClosed` now failed, so
  it reconciled and returned.
- Turning Keep Awake off ran `deactivate()`, which skipped the flag on the stated grounds that
  "the watchdog clears it within seconds". The watchdog exits when `kill -0 <pid>` fails or its
  deadline elapses, so with the app still running the flag survived for up to twelve hours.

Either way the Mac could not sleep and Apple menu → Sleep stayed greyed out, while the pane's own
footer promised normal behaviour returned straight away. The only way out was a banner button whose
text blamed a restart that had not happened.

## Why the clear is not in `deactivate()`

`AppState` calls that from `deinit` as well as from a toggle, and five test files build an
`AppState` over `FeatureRegistry.makeAll()` — whose `KeepAwakeFeature` takes
`UserDefaults.standard`, the real app's preferences inside the test host. A password dialog there
would interrupt `make test` on a machine where the flag happened to be on and pass everywhere else,
which is the shape f437833 was written to remove.

So the click arrives as a new `Feature.userDidDisable()`, sent only from `AppState.setEnabled` —
its one caller is the toggle binding, so it cannot fire from `deinit`, from `sync()`, or from a
permission change. It is declared in the protocol body rather than only defaulted in the extension,
or the override would never be reached through a `Feature` existential.

Both paths stay gated on `weSetFlag`, so a flag somebody set by hand in a terminal is still left
alone, and a declined prompt keeps ownership so the banner can still offer to fix it.

## Tests

New `KeepAwakeTurnOffTests` covers the toggle path that nothing exercised before —
`KeepAwakeStateTests` had the truth table and `SleepDisableFlagTests` had the script shapes, and
between them they missed this. `runPrivileged` is injected the way `defaults` already was, so the
suite never reaches `NSAppleScript` or writes a real `pmset` setting. 1587 tests pass, 0 failures.

Verified on a real machine as well: `pmset -g | grep SleepDisabled` reports `1` after turning the
option on and nothing after turning it off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)